### PR TITLE
Simplify remaining exception expectations

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
@@ -62,7 +62,7 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
             static fn () => throw new Exception('Default global scope.')
         );
 
-        $this->expectExceptionMessage('Default global scope.');
+        $this->expectExceptionObject(new Exception('Default global scope.'));
         $post->tags()->get();
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -863,8 +863,7 @@ class FilesystemAdapterTest extends TestCase
         $this->filesystem->write('foo/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Disk is not empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('Disk is not empty.'));
 
         $filesystemAdapter->assertEmpty();
     }

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -203,8 +203,7 @@ class QueueTest extends TestCase
 
         Cloud::bootManagedQueues($this->app);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [cloud] queue connection has not been configured.');
+        $this->expectExceptionObject(new InvalidArgumentException('The [cloud] queue connection has not been configured.'));
         $this->app['queue']->connection('cloud');
     }
 
@@ -1476,8 +1475,7 @@ class QueueTest extends TestCase
 
         $queue = $this->app['queue']->connection('cloud');
 
-        $this->expectException(ManagedQueueNotFoundException::class);
-        $this->expectExceptionMessage('Managed queue [missing-queue] does not exist.');
+        $this->expectExceptionObject(new ManagedQueueNotFoundException('Managed queue [missing-queue] does not exist.'));
 
         $queue->push(new FakeJob, queue: 'missing-queue');
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -590,8 +590,7 @@ class FoundationApplicationTest extends TestCase
 
     public function testAbortThrowsHttpException()
     {
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Request is bad');
+        $this->expectExceptionObject(new HttpException(400, 'Request is bad'));
 
         $app = new Application();
         $app->abort(400, 'Request is bad');

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -89,9 +89,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testSeeInDatabaseFindsNotMatchingResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-
-        $this->expectExceptionMessage('Found similar results: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
+        $this->expectExceptionObject(new ExpectationFailedException('Found similar results: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT)));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -103,9 +101,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testSeeInDatabaseFindsManyNotMatchingResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-
-        $this->expectExceptionMessage('Found similar results: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
+        $this->expectExceptionObject(new ExpectationFailedException('Found similar results: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.'));
 
         $builder = $this->mockCountBuilder(false, countResult: [5, 5]);
 

--- a/tests/Foundation/FoundationViteFontsTest.php
+++ b/tests/Foundation/FoundationViteFontsTest.php
@@ -349,8 +349,7 @@ class FoundationViteFontsTest extends TestCase
 
         file_put_contents(public_path('build/fonts-manifest.json'), 'not-valid-json{');
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('not valid JSON');
+        $this->expectExceptionObject(new ViteException('not valid JSON'));
 
         app(Vite::class)->fonts();
     }
@@ -359,8 +358,7 @@ class FoundationViteFontsTest extends TestCase
     {
         $this->makeFontsManifest(['version' => 99, 'families' => []]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unsupported font manifest version [99]. Supported versions: 1.');
+        $this->expectExceptionObject(new ViteException('Unsupported font manifest version [99]. Supported versions: 1.'));
 
         app(Vite::class)->fonts();
     }
@@ -369,8 +367,7 @@ class FoundationViteFontsTest extends TestCase
     {
         $this->makeFontsManifest(['style' => ['inline' => ''], 'families' => []]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('missing the [version] key');
+        $this->expectExceptionObject(new ViteException('missing the [version] key'));
 
         app(Vite::class)->fonts();
     }
@@ -379,8 +376,7 @@ class FoundationViteFontsTest extends TestCase
     {
         $this->makeFontsManifest(['version' => 1]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('missing the [families] key');
+        $this->expectExceptionObject(new ViteException('missing the [families] key'));
 
         app(Vite::class)->fonts();
     }
@@ -389,8 +385,7 @@ class FoundationViteFontsTest extends TestCase
     {
         $this->makeFontsManifest();
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate font CSS file');
+        $this->expectExceptionObject(new ViteException('Unable to locate font CSS file'));
 
         app(Vite::class)->fonts();
     }
@@ -406,8 +401,7 @@ class FoundationViteFontsTest extends TestCase
             ],
         ]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Font alias [display] is not defined in the font manifest. Available aliases: sans.');
+        $this->expectExceptionObject(new ViteException('Font alias [display] is not defined in the font manifest. Available aliases: sans.'));
 
         app(Vite::class)->fonts(['display']);
     }
@@ -425,8 +419,7 @@ class FoundationViteFontsTest extends TestCase
             ],
         ]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] is missing the [alias] key');
+        $this->expectExceptionObject(new ViteException('preload entry [0] is missing the [alias] key'));
 
         app(Vite::class)->fonts();
     }
@@ -444,8 +437,7 @@ class FoundationViteFontsTest extends TestCase
             ],
         ]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] for alias [sans] is missing the [file] key');
+        $this->expectExceptionObject(new ViteException('preload entry [0] for alias [sans] is missing the [file] key'));
 
         app(Vite::class)->fonts();
     }
@@ -464,8 +456,7 @@ class FoundationViteFontsTest extends TestCase
             ],
         ]);
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] for alias [sans] is missing the [url] key');
+        $this->expectExceptionObject(new ViteException('preload entry [0] for alias [sans] is missing the [url] key'));
 
         app(Vite::class)->fonts();
     }
@@ -585,8 +576,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
         $this->makeFontsCssFile('build', 'assets/fonts-abc123.css', "@font-face { font-family: 'Inter'; }");
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('keyed by alias');
+        $this->expectExceptionObject(new ViteException('keyed by alias'));
 
         app(Vite::class)->fonts(['sans']);
     }
@@ -607,8 +597,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
         $this->makeFontsCssFile('build', 'assets/fonts-abc123.css', "@font-face { font-family: 'Inter'; }");
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('keyed by alias');
+        $this->expectExceptionObject(new ViteException('keyed by alias'));
 
         app(Vite::class)->fonts(['sans']);
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -135,8 +135,7 @@ class HttpClientTest extends TestCase
     #[DataProvider('invalidFakeResponseHeaderValuesProvider')]
     public function testInvalidFakeResponseHeaderValuesAreRejected($value)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
+        $this->expectExceptionObject(new InvalidArgumentException('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'));
 
         $this->factory::response('OK', 200, ['X-Test' => $value]);
     }
@@ -195,16 +194,14 @@ class HttpClientTest extends TestCase
 
     public function testFakeResponseRejectsUnsupportedBody()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.');
+        $this->expectExceptionObject(new InvalidArgumentException('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.'));
 
         $this->factory::response(new stdClass);
     }
 
     public function testFakeResponseRejectsNonStreamResourceBody()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.');
+        $this->expectExceptionObject(new InvalidArgumentException('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.'));
 
         $this->factory::response(stream_context_create());
     }
@@ -843,8 +840,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
+        $this->expectExceptionObject(new InvalidArgumentException('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'));
 
         $this->factory->withHeaders(['X-Test' => $value])->post('http://foo.com/json');
     }
@@ -1094,8 +1090,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Multipart header values must be scalar, null, or Laravel Stringable.');
+        $this->expectExceptionObject(new InvalidArgumentException('Multipart header values must be scalar, null, or Laravel Stringable.'));
 
         $this->factory->asMultipart()->post('http://foo.com/multipart', [
             [
@@ -4071,8 +4066,7 @@ class HttpClientTest extends TestCase
         $responses[] = $this->factory->get('https://forge.laravel.com')->body();
         $this->assertSame(['ok', 'ok'], $responses);
 
-        $this->expectException(StrayRequestException::class);
-        $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
+        $this->expectExceptionObject(new StrayRequestException('https://laravel.com'));
 
         $this->factory->get('https://laravel.com');
     }

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -435,8 +435,7 @@ class GdDriverTest extends TestCase
     {
         $driver = new GdDriver;
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The image format [text/plain] is not supported.');
+        $this->expectExceptionObject(new ImageException('The image format [text/plain] is not supported.'));
 
         $driver->process('not-an-image', new ImagePipeline);
     }

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -75,8 +75,7 @@ class ImageManagerTest extends TestCase
 
         $manager = new ImageManager($app);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Image driver [nonexistent] is not supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('Image driver [nonexistent] is not supported.'));
 
         $manager->driver('nonexistent');
     }
@@ -273,8 +272,7 @@ class ImageManagerTest extends TestCase
         $app = $this->makeApp([]);
         $manager = new ImageManager($app);
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Invalid base64 image data.');
+        $this->expectExceptionObject(new ImageException('Invalid base64 image data.'));
 
         $manager->fromBase64('!!!not-base64!!!')->toBytes();
     }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -289,8 +289,7 @@ class ImageTest extends TestCase
     {
         $image = new Image('not-an-image');
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Unable to determine the dimensions of the image.');
+        $this->expectExceptionObject(new ImageException('Unable to determine the dimensions of the image.'));
 
         $image->dimensions();
     }
@@ -374,8 +373,7 @@ class ImageTest extends TestCase
         try {
             $image = (new Image($this->fakeImageContents()))->using('fake')->cover(1, 1);
 
-            $this->expectException(ImageException::class);
-            $this->expectExceptionMessage('Unable to determine the dimensions of the image.');
+            $this->expectExceptionObject(new ImageException('Unable to determine the dimensions of the image.'));
 
             $image->dimensions();
         } finally {
@@ -442,8 +440,7 @@ class ImageTest extends TestCase
     {
         $image = $this->makeImage();
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The [tiff] format is not supported.');
+        $this->expectExceptionObject(new ImageException('The [tiff] format is not supported.'));
 
         $image->optimize('tiff');
     }
@@ -623,8 +620,7 @@ class ImageTest extends TestCase
     {
         $image = new Image($this->fakeImageContents());
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Failed to process image:');
+        $this->expectExceptionObject(new ImageException('Failed to process image:'));
 
         // Trigger a driver error by using a non-existent driver
         $image->using('nonexistent')->cover(100, 100)->toBytes();
@@ -799,8 +795,7 @@ class ImageTest extends TestCase
     {
         $image = $this->makeImage();
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The [jpge] format is not supported.');
+        $this->expectExceptionObject(new ImageException('The [jpge] format is not supported.'));
 
         $image->optimize('jpge');
     }
@@ -816,8 +811,7 @@ class ImageTest extends TestCase
     {
         $image = new Image($this->fakeImageContents());
 
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Images cannot be serialized. Store the image first and serialize the path instead.');
+        $this->expectExceptionObject(new ImageException('Images cannot be serialized. Store the image first and serialize the path instead.'));
 
         serialize($image);
     }
@@ -952,8 +946,7 @@ class ImageTest extends TestCase
 
     public function test_resize_requires_at_least_one_dimension()
     {
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('At least one resize dimension must be specified.');
+        $this->expectExceptionObject(new ImageException('At least one resize dimension must be specified.'));
 
         $this->makeImage()->resize();
     }
@@ -1004,8 +997,7 @@ class ImageTest extends TestCase
 
     public function test_scale_requires_at_least_one_dimension()
     {
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('At least one scale dimension must be specified.');
+        $this->expectExceptionObject(new ImageException('At least one scale dimension must be specified.'));
 
         $this->makeImage()->scale();
     }

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -45,10 +45,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
 
     public function testPrunableMethodMustBeImplemented()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
-            'Please implement',
-        );
+        $this->expectExceptionObject(new LogicException('Please implement'));
 
         MassPrunableTestModelMissingPrunableMethod::create()->pruneAll();
     }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -275,10 +275,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel;
 
-        $this->expectException(ValueError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new ValueError(
             sprintf('Value [%s] is not of the expected enum type [%s].', var_export(ArrayableStatus::pending, true), StringStatus::class)
-        );
+        ));
 
         $model->string_status = ArrayableStatus::pending;
     }
@@ -287,10 +286,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel;
 
-        $this->expectException(ValueError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new ValueError(
             sprintf('"unexpected_value" is not a valid backing value for enum %s', StringStatus::class)
-        );
+        ));
 
         $model->string_status = 'unexpected_value';
     }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -275,9 +275,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel;
 
-        $this->expectExceptionObject(new ValueError(
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(
             sprintf('Value [%s] is not of the expected enum type [%s].', var_export(ArrayableStatus::pending, true), StringStatus::class)
-        ));
+        );
 
         $model->string_status = ArrayableStatus::pending;
     }
@@ -286,9 +287,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel;
 
-        $this->expectExceptionObject(new ValueError(
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(
             sprintf('"unexpected_value" is not a valid backing value for enum %s', StringStatus::class)
-        ));
+        );
 
         $model->string_status = 'unexpected_value';
     }

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -37,10 +37,7 @@ class EloquentPrunableTest extends DatabaseTestCase
 
     public function testPrunableMethodMustBeImplemented()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
-            'Please implement',
-        );
+        $this->expectExceptionObject(new LogicException('Please implement'));
 
         PrunableTestModelMissingPrunableMethod::create()->pruneAll();
     }

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -128,8 +128,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_zero_as_unexpected_output()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "0" was printed.');
+        $this->expectExceptionObject(new AssertionFailedError('Output "0" was printed.'));
 
         $this->artisan('zero')
             ->doesntExpectOutput('0')
@@ -138,8 +137,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_zero_as_unexpected_output_substring()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "0" was printed.');
+        $this->expectExceptionObject(new AssertionFailedError('Output "0" was printed.'));
 
         $this->artisan('zero')
             ->doesntExpectOutputToContain('0')

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -324,8 +324,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_an_unresolvable_ref(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to resolve JSON Schema $ref [#/$defs/Missing].');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to resolve JSON Schema $ref [#/$defs/Missing].'));
 
         JsonSchema::fromArray([
             '$ref' => '#/$defs/Missing',
@@ -335,8 +334,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_remote_ref(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].'));
 
         JsonSchema::fromArray([
             '$ref' => 'https://example.com/user.json',
@@ -420,8 +418,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_when_the_type_cannot_be_determined(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine the JSON Schema type for the given schema.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine the JSON Schema type for the given schema.'));
 
         JsonSchema::fromArray([
             'title' => 'Mystery',
@@ -430,8 +427,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_detects_a_circular_ref_instead_of_recursing(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Circular JSON Schema $ref [#/$defs/node] detected.');
+        $this->expectExceptionObject(new InvalidArgumentException('Circular JSON Schema $ref [#/$defs/node] detected.'));
 
         JsonSchema::fromArray([
             'type' => 'object',
@@ -617,8 +613,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_an_unsupported_union_member(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported JSON Schema type [wat] in a multi-type union.'));
 
         JsonSchema::fromArray([
             'type' => ['string', 'wat'],
@@ -627,8 +622,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_non_string_union_member(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported JSON Schema type [123] in a multi-type union.'));
 
         JsonSchema::fromArray([
             'type' => ['string', 123],
@@ -637,8 +631,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_when_a_union_carries_type_specific_keywords(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Type-specific keywords [items] are not supported on a multi-type JSON Schema union.');
+        $this->expectExceptionObject(new InvalidArgumentException('Type-specific keywords [items] are not supported on a multi-type JSON Schema union.'));
 
         JsonSchema::fromArray([
             'type' => ['array', 'string'],
@@ -648,8 +641,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_boolean_property_schema(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to represent the schema for property [meta]; boolean schemas are not supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to represent the schema for property [meta]; boolean schemas are not supported.'));
 
         JsonSchema::fromArray([
             'type' => 'object',
@@ -661,8 +653,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_non_numeric_numeric_constraint(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The JSON Schema [minimum] constraint must be a number.');
+        $this->expectExceptionObject(new InvalidArgumentException('The JSON Schema [minimum] constraint must be a number.'));
 
         JsonSchema::fromArray([
             'type' => 'number',
@@ -672,8 +663,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_non_integer_integer_constraint(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The JSON Schema integer constraint [1.9] must be an integer.');
+        $this->expectExceptionObject(new InvalidArgumentException('The JSON Schema integer constraint [1.9] must be an integer.'));
 
         JsonSchema::fromArray([
             'type' => 'integer',
@@ -683,8 +673,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_tuple_items(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Tuple and boolean JSON Schema "items" are not supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('Tuple and boolean JSON Schema "items" are not supported.'));
 
         JsonSchema::fromArray([
             'type' => 'array',
@@ -697,8 +686,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_when_a_union_branch_conflicts_with_sibling_keys(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Conflicting [type] between a "anyOf" branch and its sibling keys.');
+        $this->expectExceptionObject(new InvalidArgumentException('Conflicting [type] between a "anyOf" branch and its sibling keys.'));
 
         JsonSchema::fromArray([
             'type' => 'integer',
@@ -711,8 +699,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_an_unsupported_one_of_union(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only a nullable "oneOf" (a single schema plus a "null" branch) is supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('Only a nullable "oneOf" (a single schema plus a "null" branch) is supported.'));
 
         JsonSchema::fromArray([
             'oneOf' => [
@@ -724,8 +711,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_throws_for_a_null_default(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A null JSON Schema [default] is not supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('A null JSON Schema [default] is not supported.'));
 
         JsonSchema::fromArray([
             'type' => 'string',
@@ -736,8 +722,7 @@ class DeserializerTest extends TestCase
     public function test_it_resolves_the_root_ref_pointer(): void
     {
         // "#" resolves to the root, so a self-reference is detected as circular...
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Circular JSON Schema $ref [#] detected.');
+        $this->expectExceptionObject(new InvalidArgumentException('Circular JSON Schema $ref [#] detected.'));
 
         JsonSchema::fromArray(['$ref' => '#']);
     }

--- a/tests/JsonSchema/UnionTypeTest.php
+++ b/tests/JsonSchema/UnionTypeTest.php
@@ -70,16 +70,14 @@ class UnionTypeTest extends TestCase
 
     public function test_it_rejects_an_unsupported_member_name(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported JSON Schema type [wat] in a multi-type union.'));
 
         JsonSchema::union(['string', 'wat']);
     }
 
     public function test_it_rejects_a_non_string_member(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported JSON Schema type [123] in a multi-type union.'));
 
         JsonSchema::union(['string', 123]);
     }

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -24,40 +24,35 @@ class AttachmentTest extends TestCase
 
     public function testFromUrlThrowsForFtpScheme(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionObject(new InvalidArgumentException('Attachment URLs must use the http or https scheme.'));
 
         Attachment::fromUrl('ftp://example.com/file.pdf');
     }
 
     public function testFromUrlThrowsForFileScheme(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionObject(new InvalidArgumentException('Attachment URLs must use the http or https scheme.'));
 
         Attachment::fromUrl('file:///var/www/file.pdf');
     }
 
     public function testFromUrlThrowsForMailtoScheme(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionObject(new InvalidArgumentException('Attachment URLs must use the http or https scheme.'));
 
         Attachment::fromUrl('mailto:user@example.com');
     }
 
     public function testFromUrlThrowsForInvalidUrl(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionObject(new InvalidArgumentException('Attachment URLs must use the http or https scheme.'));
 
         Attachment::fromUrl('not-a-url');
     }
 
     public function testFromUrlThrowsForEmptyString(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionObject(new InvalidArgumentException('Attachment URLs must use the http or https scheme.'));
 
         Attachment::fromUrl('');
     }

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -222,8 +222,7 @@ class MailCloudflareTransportTest extends TestCase
         $message->sender('sender@example.com');
         $message->to('me@example.com');
 
-        $this->expectException(TransportException::class);
-        $this->expectExceptionMessage('invalid_request_schema');
+        $this->expectExceptionObject(new TransportException('invalid_request_schema', 400));
 
         $transport->send($message);
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -211,8 +211,7 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Email addresses may not contain line break characters.');
+        $this->expectExceptionObject(new InvalidArgumentException('Email addresses may not contain line break characters.'));
 
         $mailer->send('foo', ['data'], function (Message $message) {
             $message->to("\"foo\r\nBcc: victim@example.com\"@example.com")->from('hello@laravel.com');

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1217,8 +1217,7 @@ class QueueSqsQueueTest extends TestCase
         // Only the first chunk is attempted; its exception propagates untouched and later chunks are not sent.
         $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('SQS is down');
+        $this->expectExceptionObject(new RuntimeException('SQS is down'));
 
         $queue->bulk(range(1, 15), 'data', $this->fifoQueueName);
     }
@@ -1399,8 +1398,7 @@ class QueueSqsQueueTest extends TestCase
 
         $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('SQS is down');
+        $this->expectExceptionObject(new RuntimeException('SQS is down'));
 
         $queue->bulk(['a'], 'data', $this->queueName);
     }

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Redis\Connections;
 
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +53,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client->shouldReceive('_masters')->once()->andReturn([]);
         $client->shouldReceive('scan');
 
-        $this->expectExceptionMessage('Unable to determine default node. No master nodes found in the cluster.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.'));
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->scan(0);

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -249,8 +249,7 @@ class PhpRedisConnectorTest extends TestCase
     {
         $connector = new TestablePhpRedisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+        $this->expectExceptionObject(new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.'));
 
         $connector->testFormatHost([
             'host' => 'tcp://127.0.0.1',
@@ -272,8 +271,7 @@ class PhpRedisConnectorTest extends TestCase
     {
         $connector = new TestablePhpRedisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+        $this->expectExceptionObject(new InvalidArgumentException('Redis host must be a non-empty string.'));
 
         $connector->testFormatHost([
             'scheme' => 'tls',
@@ -284,8 +282,7 @@ class PhpRedisConnectorTest extends TestCase
     {
         $connector = new TestablePhpRedisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+        $this->expectExceptionObject(new InvalidArgumentException('Redis host must be a non-empty string.'));
 
         $connector->testFormatHost([
             'host' => null,

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connectors\PredisConnector;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Predis\Retry\Retry;
 use Predis\Retry\Strategy\EqualBackoff;
@@ -71,8 +72,7 @@ class PredisConnectorTest extends TestCase
     {
         $connector = new TestablePredisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+        $this->expectExceptionObject(new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.'));
 
         $connector->testFormatHost([
             'host' => 'tcp://127.0.0.1',
@@ -228,8 +228,7 @@ class PredisConnectorTest extends TestCase
 
         $connector = new TestablePredisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Strategy [bogus] is not a valid Predis backoff strategy.');
+        $this->expectExceptionObject(new InvalidArgumentException('Strategy [bogus] is not a valid Predis backoff strategy.'));
 
         $connector->testFormatRetry([
             'retry' => [

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -99,12 +99,7 @@ class ImplicitRouteBindingTest extends TestCase
 
         $container = Container::getInstance();
 
-        $this->expectException(BackedEnumCaseNotFoundException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Case [%s] not found on Backed Enum [%s].',
-            'cars',
-            CategoryBackedEnum::class,
-        ));
+        $this->expectExceptionObject(new BackedEnumCaseNotFoundException(CategoryBackedEnum::class, 'cars'));
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
     }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -319,8 +319,7 @@ class RouteCollectionTest extends TestCase
 
     public function testRouteCollectionRequestMethodNotAllowed()
     {
-        $this->expectException(MethodNotAllowedHttpException::class);
-        $this->expectExceptionMessage('The POST method is not supported for route users. Supported methods: GET, HEAD.');
+        $this->expectExceptionObject(new MethodNotAllowedHttpException(['GET', 'HEAD'], 'The POST method is not supported for route users. Supported methods: GET, HEAD.'));
 
         $this->routeCollection->add(
             new Route('GET', 'users', ['uses' => 'UsersController@index', 'as' => 'users'])

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -387,8 +387,7 @@ class RoutingRouteTest extends TestCase
 
     public function testMiddlewareGroupsCannotReferenceItself()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('[web] middleware group is referencing itself.');
+        $this->expectExceptionObject(new LogicException('[web] middleware group is referencing itself.'));
 
         $router = $this->getRouter();
         $router->get('foo/bar', ['middleware' => 'web', function () {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -931,7 +931,7 @@ class SupportStrTest extends TestCase
         Str::random();
 
         try {
-            $this->expectExceptionMessage('Out of random strings.');
+            $this->expectExceptionObject(new Exception('Out of random strings.'));
             Str::random();
             $this->fail();
         } finally {
@@ -1810,7 +1810,7 @@ class SupportStrTest extends TestCase
         Str::uuid();
 
         try {
-            $this->expectExceptionMessage('Out of Uuids.');
+            $this->expectExceptionObject(new Exception('Out of Uuids.'));
             Str::uuid();
             $this->fail();
         } finally {
@@ -1915,7 +1915,7 @@ class SupportStrTest extends TestCase
         Str::ulid();
 
         try {
-            $this->expectExceptionMessage('Out of Ulids');
+            $this->expectExceptionObject(new Exception('Out of Ulids'));
             Str::ulid();
             $this->fail();
         } finally {

--- a/tests/Support/SupportTimeboxTest.php
+++ b/tests/Support/SupportTimeboxTest.php
@@ -58,7 +58,7 @@ class SupportTimeboxTest extends TestCase
         $mock->shouldReceive('usleep')->once();
 
         try {
-            $this->expectExceptionMessage('Exception within Timebox callback.');
+            $this->expectExceptionObject(new Exception('Exception within Timebox callback.'));
 
             $mock->call(function () {
                 throw new Exception('Exception within Timebox callback.');
@@ -73,7 +73,7 @@ class SupportTimeboxTest extends TestCase
         $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
 
         try {
-            $this->expectExceptionMessage('Exception within Timebox callback.');
+            $this->expectExceptionObject(new Exception('Exception within Timebox callback.'));
 
             $mock->call(function ($timebox) {
                 $timebox->returnEarly();

--- a/tests/Testing/AssertTest.php
+++ b/tests/Testing/AssertTest.php
@@ -65,10 +65,9 @@ class AssertTest extends TestCase
 
     public function testArraySubsetMayFailIfArrayIsNotArray(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Argument #1 of Illuminate\Testing\Assert::assertArraySubset() must be an array or ArrayAccess'
-        );
+        ));
 
         Assert::assertArraySubset('string', [
             'int' => 1,
@@ -79,10 +78,9 @@ class AssertTest extends TestCase
 
     public function testArraySubsetMayFailIfSubsetIsNotArray(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Argument #2 of Illuminate\Testing\Assert::assertArraySubset() must be an array or ArrayAccess'
-        );
+        ));
 
         Assert::assertArraySubset([
             'string' => 'string',

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -1080,10 +1080,7 @@ class AssertTest extends TestCase
             'bar' => [],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage(
-            'Cannot scope directly onto the first element of property [bar] because it is empty.'
-        );
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto the first element of property [bar] because it is empty.'));
 
         $assert->has('bar', 0, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -1096,10 +1093,7 @@ class AssertTest extends TestCase
             'bar' => [],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage(
-            'Cannot scope directly onto the first element of property [bar] because it is empty.'
-        );
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto the first element of property [bar] because it is empty.'));
 
         $assert->has('bar', null, function (AssertableJson $item) {
             $item->where('key', 'first');

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -809,9 +809,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -825,9 +823,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -890,9 +886,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -906,9 +900,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1137,9 +1129,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1229,9 +1219,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1246,9 +1234,7 @@ EOT
         $statusCode = 500;
         $expectedStatusCode = 418;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1260,9 +1246,7 @@ EOT
 
     public function testAssertNoContentAssertsEmptyContent(): void
     {
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Response content is not empty');
+                $this->expectExceptionObject(new AssertionFailedError('Response content is not empty'));
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setStatusCode(204);
@@ -1278,9 +1262,7 @@ EOT
         $statusCode = 500;
         $expectedStatusCode = 401;
 
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Expected response status code');
+                $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1581,8 +1563,7 @@ EOT
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+                $this->expectExceptionObject(new AssertionFailedError('Failed asserting that two arrays are equal.'));
 
         $response->assertJsonPathsCanonicalizing([
             '*.foo' => ['foo 0', 'foo 2', 'foo 3'],

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -10,6 +10,7 @@ use Illuminate\Tests\Translation\Fixtures\Enums\Baz;
 use Illuminate\Tests\Translation\Fixtures\Enums\Foo;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -77,8 +78,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => ['breeze']]);
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be a string, array given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Translation value for key [foo::bar.baz] must be a string, array given.'));
 
         $t->string('foo::bar.baz', [], 'en');
     }
@@ -96,8 +96,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => 'breeze']);
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be an array, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Translation value for key [foo::bar.baz] must be an array, string given.'));
 
         $t->array('foo::bar.baz', [], 'en');
     }

--- a/tests/Validation/ValidationArrayKeysRuleTest.php
+++ b/tests/Validation/ValidationArrayKeysRuleTest.php
@@ -84,8 +84,7 @@ class ValidationArrayKeysRuleTest extends TestCase
 
         $v = new Validator($trans, ['foo' => ['key_1' => 'bar']], ['foo' => 'array_keys']);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule array_keys requires at least 1 parameters.');
+        $this->expectExceptionObject(new InvalidArgumentException('Validation rule array_keys requires at least 1 parameters.'));
 
         $v->passes();
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -56,8 +56,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/http-exception.php');
         $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
 
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('http exception message');
+        $this->expectExceptionObject(new HttpException(403, 'http exception message'));
 
         $engine->get(__DIR__.'/fixtures/foo.php');
     }


### PR DESCRIPTION
Converts the remaining `expectException` + `expectExceptionMessage` pairs to `expectExceptionObject`, following up on #61049.