### PR TITLE
[13.x] Add the timeout in JobTimedOut

### DIFF
--- a/src/Illuminate/Queue/Events/JobTimedOut.php
+++ b/src/Illuminate/Queue/Events/JobTimedOut.php
@@ -9,10 +9,12 @@ class JobTimedOut
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
+     * @param  int|null  $timeout  The timeout exceeded in seconds.
      */
     public function __construct(
         public $connectionName,
         public $job,
+        public $timeout = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -309,7 +309,7 @@ class Worker
                 );
 
                 $this->events->dispatch(new JobTimedOut(
-                    $job->getConnectionName(), $job
+                    $job->getConnectionName(), $job, $this->timeoutForJob($job, $options)
                 ));
             }
 


### PR DESCRIPTION
  We can listen to this event and access the job, but the timeout may also come from the worker.

  Ie in cases such as `queue:work --queue=notifications,emails,logs --timeout=120`

This means we may see loads of `JobTimedOut` events and assume it's the job, when it's actually the worker.

This PR adds the timeout in seconds to the event so we can see easier if it was the worker, the job etc.

 I haven't added a test as it's within a signal, rest assured I'll check the dev branch tho if this is accepted 🤓 
 
 Thanks man
