### PR TITLE
[13.x] Fix flaky circuit breaker release delay assertions

### DIFF
--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -80,7 +80,9 @@ class ThrottlesExceptionsTest extends TestCase
 
         $job->shouldReceive('hasFailed')->once()->andReturn(false);
         $job->shouldReceive('release')->withArgs(function ($delay) {
-            return $delay >= 600;
+            // The delay is the remainder of the decay window, less wall clock
+            // seconds elapsed since the first exception opened the circuit.
+            return $delay >= 590 && $delay <= 610;
         })->once();
         $job->shouldReceive('isReleased')->andReturn(true);
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -87,7 +87,9 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
 
         $job->shouldReceive('hasFailed')->once()->andReturn(false);
         $job->shouldReceive('release')->withArgs(function ($delay) {
-            return $delay >= 600;
+            // The delay is the remainder of the decay window, less wall clock
+            // seconds elapsed since the first exception opened the circuit.
+            return $delay >= 590 && $delay <= 610;
         })->once();
         $job->shouldReceive('isReleased')->andReturn(true);
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);


### PR DESCRIPTION
The Redis Cluster queue job intermittently fails `ThrottlesExceptionsWithRedisTest` with `release(599)`. The released delay is the remainder of the decay window anchored when the first exception opened the circuit, so it drops below 600 whenever the dispatches cross a wall clock second, a race the assertion was protected from by the `setUp()` clock pin removed in #60793 and one the cache-based `ThrottlesExceptionsTest` shares behind only a three second grace period. Both assertions now accept a small tolerance around the 600 second decay window instead of depending on sub-second scheduling.