### PR TITLE
[13.x] Add inline images to mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Markdown;
+use Illuminate\Notifications\Messages\InlineImageRenderer;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -111,9 +112,15 @@ class MailChannel
      */
     protected function buildMarkdownHtml($message)
     {
-        return fn ($data) => $this->markdownRenderer($message)->render(
-            $message->markdown, array_merge($data, $message->data()),
-        );
+        return function ($data) use ($message) {
+            $mailMessage = $data['message'] ?? null;
+            $data = array_merge($data, $message->data());
+
+            return $this->markdownRenderer($message)->render(
+                $message->markdown,
+                InlineImageRenderer::render($data, $mailMessage),
+            );
+        };
     }
 
     /**
@@ -124,9 +131,14 @@ class MailChannel
      */
     protected function buildMarkdownText($message)
     {
-        return fn ($data) => $this->markdownRenderer($message)->renderText(
-            $message->markdown, array_merge($data, $message->data()),
-        );
+        return function ($data) use ($message) {
+            $data = array_merge($data, $message->data());
+
+            return $this->markdownRenderer($message)->renderText(
+                $message->markdown,
+                InlineImageRenderer::render($data, null, true),
+            );
+        };
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/InlineImage.php
+++ b/src/Illuminate/Notifications/Messages/InlineImage.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Mail\Attachment;
+use Illuminate\Mail\Message;
+use Illuminate\Support\HtmlString;
+use InvalidArgumentException;
+
+class InlineImage
+{
+    /**
+     * The attachment that should be embedded.
+     *
+     * @var \Illuminate\Mail\Attachment
+     */
+    public $attachment;
+
+    /**
+     * The alternative text for the image.
+     *
+     * @var string|null
+     */
+    public $alt;
+
+    /**
+     * The image width.
+     *
+     * @var int|string|null
+     */
+    public $width;
+
+    /**
+     * The image height.
+     *
+     * @var int|string|null
+     */
+    public $height;
+
+    /**
+     * The image style.
+     *
+     * @var string|null
+     */
+    public $style;
+
+    /**
+     * Create a new inline image.
+     *
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $image
+     * @param  string|null  $alt
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  string|null  $style
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($image, $alt = '', $width = null, $height = null, $style = null)
+    {
+        if ($image instanceof Attachable) {
+            $image = $image->toMailAttachment();
+        }
+
+        if (is_string($image)) {
+            $image = Attachment::fromPath($image);
+        }
+
+        if (! $image instanceof Attachment) {
+            throw new InvalidArgumentException('Inline images must be a path, an attachment, or an attachable instance.');
+        }
+
+        $this->attachment = $image;
+        $this->alt = $alt;
+        $this->width = $width;
+        $this->height = $height;
+        $this->style = $style;
+    }
+
+    /**
+     * Render the image for an HTML mail message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return \Illuminate\Support\HtmlString
+     */
+    public function toHtml(Message $message)
+    {
+        $attributes = [
+            'src' => $message->embed($this->attachment),
+            'alt' => $this->alt ?? '',
+        ];
+
+        if (! is_null($this->width)) {
+            $attributes['width'] = $this->width;
+        }
+
+        if (! is_null($this->height)) {
+            $attributes['height'] = $this->height;
+        }
+
+        if (! is_null($this->style)) {
+            $attributes['style'] = $this->style;
+        }
+
+        if (is_null($this->alt)) {
+            $attributes['aria-hidden'] = 'true';
+        }
+
+        $attributes = array_map(
+            fn ($attribute, $value) => $attribute.'="'.htmlspecialchars(
+                $value,
+                ENT_QUOTES | ENT_SUBSTITUTE,
+                'UTF-8',
+            ).'"',
+            array_keys($attributes),
+            $attributes,
+        );
+
+        return new HtmlString('<img '.implode(' ', $attributes).'>');
+    }
+
+    /**
+     * Get the plain text representation of the image.
+     *
+     * @return string
+     */
+    public function toText()
+    {
+        return $this->alt ?? '';
+    }
+}

--- a/src/Illuminate/Notifications/Messages/InlineImageLine.php
+++ b/src/Illuminate/Notifications/Messages/InlineImageLine.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Mail\Message;
+use Illuminate\Support\HtmlString;
+
+class InlineImageLine
+{
+    /**
+     * The text before the image.
+     *
+     * @var \Illuminate\Contracts\Support\Htmlable|string|null
+     */
+    public $before;
+
+    /**
+     * The inline image.
+     *
+     * @var \Illuminate\Notifications\Messages\InlineImage
+     */
+    public $image;
+
+    /**
+     * The text after the image.
+     *
+     * @var \Illuminate\Contracts\Support\Htmlable|string|null
+     */
+    public $after;
+
+    /**
+     * Create a new inline image line.
+     *
+     * @param  \Illuminate\Notifications\Messages\InlineImage  $image
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|null  $before
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|null  $after
+     */
+    public function __construct(InlineImage $image, $before = null, $after = null)
+    {
+        $this->before = $before;
+        $this->image = $image;
+        $this->after = $after;
+    }
+
+    /**
+     * Render the line for an HTML mail message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return \Illuminate\Support\HtmlString
+     */
+    public function toHtml(Message $message)
+    {
+        return new HtmlString(implode(' ', array_filter([
+            $this->stringify($this->before),
+            $this->image->toHtml($message)->toHtml(),
+            $this->stringify($this->after),
+        ], fn ($part) => $part !== null && $part !== '')));
+    }
+
+    /**
+     * Get the plain text representation of the line.
+     *
+     * @return string
+     */
+    public function toText()
+    {
+        return trim(implode(' ', array_filter([
+            $this->stringify($this->before, true),
+            $this->image->toText(),
+            $this->stringify($this->after, true),
+        ], fn ($part) => $part !== null && $part !== '')));
+    }
+
+    /**
+     * Convert a line part into a string.
+     *
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|null  $part
+     * @param  bool  $stripTags
+     * @return string|null
+     */
+    protected function stringify($part, $stripTags = false)
+    {
+        if ($part instanceof Htmlable) {
+            return $stripTags ? strip_tags($part->toHtml()) : $part->toHtml();
+        }
+
+        return $stripTags
+            ? (! is_null($part) ? strip_tags($part) : null)
+            : (! is_null($part) ? e($part) : null);
+    }
+}

--- a/src/Illuminate/Notifications/Messages/InlineImageRenderer.php
+++ b/src/Illuminate/Notifications/Messages/InlineImageRenderer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+use Illuminate\Mail\Message as MailMessage;
+use LogicException;
+
+class InlineImageRenderer
+{
+    /**
+     * Resolve inline images in the notification's line data.
+     *
+     * @param  array  $data
+     * @param  \Illuminate\Mail\Message|null  $mailMessage
+     * @param  bool  $text
+     * @return array
+     *
+     * @throws \LogicException
+     */
+    public static function render(array $data, $mailMessage = null, $text = false)
+    {
+        foreach (['introLines', 'outroLines'] as $key) {
+            if (! isset($data[$key])) {
+                continue;
+            }
+
+            $data[$key] = array_map(function ($line) use ($mailMessage, $text) {
+                if ($line instanceof InlineImage) {
+                    return $text
+                        ? $line->toText()
+                        : static::renderHtml($line, $mailMessage);
+                }
+
+                if ($line instanceof InlineImageLine) {
+                    return $text
+                        ? $line->toText()
+                        : static::renderHtml($line, $mailMessage);
+                }
+
+                return $line;
+            }, $data[$key]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Render an inline image line for an HTML mail message.
+     *
+     * @param  \Illuminate\Notifications\Messages\InlineImage|\Illuminate\Notifications\Messages\InlineImageLine  $line
+     * @param  \Illuminate\Mail\Message|null  $mailMessage
+     * @return \Illuminate\Support\HtmlString
+     *
+     * @throws \LogicException
+     */
+    protected static function renderHtml($line, $mailMessage)
+    {
+        if (! $mailMessage instanceof MailMessage) {
+            throw new LogicException('Inline notification images can only be rendered while sending a mail message.');
+        }
+
+        return $line->toHtml($mailMessage);
+    }
+}

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Messages;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -9,6 +10,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Conditionable;
 
 class MailMessage extends SimpleMessage implements Renderable
@@ -184,6 +186,151 @@ class MailMessage extends SimpleMessage implements Renderable
     public function theme($theme)
     {
         $this->theme = $theme;
+
+        return $this;
+    }
+
+    /**
+     * Add an image to the notification.
+     *
+     * The image may be a path, an attachment, or an attachable instance. For
+     * in-memory data, use the imageFromData method.
+     *
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $image
+     * @param  string|null  $alt
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  string|null  $style
+     * @return $this
+     */
+    public function image($image, $alt = '', $width = null, $height = null, $style = null)
+    {
+        return $this->addInlineImageLine(new InlineImage($image, $alt, $width, $height, $style));
+    }
+
+    /**
+     * Add in-memory data as an inline image to the notification.
+     *
+     * @param  string|resource|\Closure  $data
+     * @param  string  $name
+     * @param  string|null  $alt
+     * @param  string|null  $mime
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  string|null  $style
+     * @return $this
+     */
+    public function imageFromData($data, $name, $alt = '', $mime = null, $width = null, $height = null, $style = null)
+    {
+        $attachment = Attachment::fromData(
+            $data instanceof Closure ? $data : fn () => $data,
+            $name,
+        );
+
+        if (! is_null($mime)) {
+            $attachment->withMime($mime);
+        }
+
+        return $this->image($attachment, $alt, $width, $height, $style);
+    }
+
+    /**
+     * Add an inline image from storage to the notification.
+     *
+     * @param  string  $path
+     * @param  string|null  $alt
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function imageFromStorage($path, $alt = '', $name = null, array $options = [])
+    {
+        return $this->imageFromStorageDisk(null, $path, $alt, $name, $options);
+    }
+
+    /**
+     * Add an inline image from storage to the notification.
+     *
+     * @param  string|null  $disk
+     * @param  string  $path
+     * @param  string|null  $alt
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function imageFromStorageDisk($disk, $path, $alt = '', $name = null, array $options = [])
+    {
+        $attachment = Attachment::fromStorageDisk($disk, $path);
+
+        if (! is_null($name)) {
+            $attachment->as($name);
+        }
+
+        if (isset($options['mime'])) {
+            $attachment->withMime($options['mime']);
+        }
+
+        return $this->image(
+            $attachment,
+            $alt,
+            $options['width'] ?? null,
+            $options['height'] ?? null,
+            $options['style'] ?? null,
+        );
+    }
+
+    /**
+     * Add a line of text before an image.
+     *
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|array|null  $line
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $image
+     * @param  string|null  $alt
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  string|null  $style
+     * @return $this
+     */
+    public function lineBeforeImage($line, $image, $alt = '', $width = null, $height = null, $style = null)
+    {
+        return $this->addInlineImageLine(new InlineImageLine(
+            new InlineImage($image, $alt, $width, $height, $style),
+            $this->formatLine($line),
+        ));
+    }
+
+    /**
+     * Add a line of text after an image.
+     *
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|array|null  $line
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $image
+     * @param  string|null  $alt
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  string|null  $style
+     * @return $this
+     */
+    public function lineAfterImage($line, $image, $alt = '', $width = null, $height = null, $style = null)
+    {
+        return $this->addInlineImageLine(new InlineImageLine(
+            new InlineImage($image, $alt, $width, $height, $style),
+            null,
+            $this->formatLine($line),
+        ));
+    }
+
+    /**
+     * Add a structured inline image line to the notification.
+     *
+     * @param  \Illuminate\Notifications\Messages\InlineImage|\Illuminate\Notifications\Messages\InlineImageLine  $line
+     * @return $this
+     */
+    protected function addInlineImageLine($line)
+    {
+        if (! $this->actionText) {
+            $this->introLines[] = $line;
+        } else {
+            $this->outroLines[] = $line;
+        }
 
         return $this;
     }
@@ -441,8 +588,19 @@ class MailMessage extends SimpleMessage implements Renderable
 
         $markdown = Container::getInstance()->make(Markdown::class);
 
-        return $markdown->theme($this->theme ?: $markdown->getTheme())
-            ->render($this->markdown, $this->data());
+        return new HtmlString(
+            Container::getInstance()->make('mailer')->render(
+                fn ($data) => $markdown->theme($this->theme ?: $markdown->getTheme())
+                    ->render(
+                        $this->markdown,
+                        InlineImageRenderer::render(
+                            array_merge($data, $this->data()),
+                            $data['message'] ?? null,
+                        ),
+                    ),
+                $this->data(),
+            )
+        );
     }
 
     /**

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Notifications;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Mail\Attachment;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
@@ -88,6 +89,71 @@ class SendingMailableNotificationsTest extends TestCase
         $contents = $mailTransport->messages()[1]->getOriginalMessage()->toString();
         $this->assertStringNotContainsString('<body style=3D"color: test;">', $contents);
     }
+
+    public function testCanEmbedInlineImagesInMarkdownNotification()
+    {
+        $user = MailableNotificationUser::forceCreate([
+            'email' => 'nuno@laravel.com',
+        ]);
+
+        $user->notify(new InlineImageNotification());
+
+        $message = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage();
+        $html = $message->getHtmlBody();
+        $text = $message->getTextBody();
+        $attachments = $message->getAttachments();
+
+        $this->assertCount(3, $attachments);
+        $this->assertStringContainsString('Before the image.', $html);
+        $this->assertStringContainsString('After the image.', $html);
+        $this->assertStringContainsString('Before the image.', $text);
+        $this->assertStringContainsString('After the image.', $text);
+        $this->assertStringNotContainsString('<img', $text);
+        $this->assertStringNotContainsString('cid:', $text);
+
+        foreach ($attachments as $index => $attachment) {
+            $this->assertSame('inline', $attachment->getDisposition());
+            $this->assertSame('image/png', $attachment->getContentType());
+            $this->assertSame(
+                ['first.png', 'second.png', 'third.png'][$index],
+                $attachment->getFilename(),
+            );
+            $this->assertSame(
+                ['first image', 'second image', 'third image'][$index],
+                base64_decode($attachment->bodyToString()),
+            );
+            $this->assertNotEmpty($attachment->getContentId());
+            $this->assertStringContainsString(
+                'src="cid:'.$attachment->getContentId().'"',
+                $html,
+            );
+        }
+
+        $this->assertStringContainsString(
+            'alt="First image" width="24" height="24" style="vertical-align: middle;"',
+            $html,
+        );
+
+        $secondImagePosition = strpos($html, 'src="cid:'.$attachments[1]->getContentId());
+        $thirdImagePosition = strpos($html, 'src="cid:'.$attachments[2]->getContentId());
+        $beforeLinePosition = strpos($html, 'Before the image.');
+        $afterLinePosition = strpos($html, 'After the image.');
+
+        $this->assertNotFalse($secondImagePosition);
+        $this->assertNotFalse($thirdImagePosition);
+        $this->assertNotFalse($beforeLinePosition);
+        $this->assertNotFalse($afterLinePosition);
+        $this->assertTrue($beforeLinePosition < $secondImagePosition);
+        $this->assertTrue($thirdImagePosition < $afterLinePosition);
+    }
+
+    public function testCanRenderInlineImages()
+    {
+        $html = (new InlineImageNotification)->toMail(null)->render()->toHtml();
+
+        $this->assertStringContainsString('src="data:image/png;base64,', $html);
+        $this->assertStringNotContainsString('src="cid:', $html);
+    }
 }
 
 class MailableNotificationUser extends Model
@@ -119,5 +185,33 @@ class MarkdownNotification extends Notification
         }
 
         return $message;
+    }
+}
+
+class InlineImageNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Inline image notification')
+            ->imageFromData('first image', 'first.png', 'First image', 'image/png', 24, 24, 'vertical-align: middle;')
+            ->lineBeforeImage(
+                'Before the image.',
+                Attachment::fromData(fn () => 'second image', 'second.png')->withMime('image/png'),
+                'Second image',
+                24,
+                24,
+                'vertical-align: middle;',
+            )
+            ->lineAfterImage(
+                'After the image.',
+                Attachment::fromData(fn () => 'third image', 'third.png')->withMime('image/png'),
+                'Third image',
+            );
     }
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Mail\Attachment;
+use Illuminate\Notifications\Messages\InlineImage;
+use Illuminate\Notifications\Messages\InlineImageLine;
 use Illuminate\Notifications\Messages\MailMessage;
 use PHPUnit\Framework\TestCase;
 
@@ -33,6 +35,82 @@ class NotificationMailMessageTest extends TestCase
         $message->template('notifications::foo');
 
         $this->assertSame('notifications::foo', $message->markdown);
+    }
+
+    public function testItCanAddAnImage()
+    {
+        $attachment = Attachment::fromData(fn () => 'image data', 'logo.png')
+            ->withMime('image/png');
+        $message = new MailMessage;
+
+        $message->image($attachment, 'Company logo', 24, 24, 'vertical-align: middle;');
+
+        $this->assertInstanceOf(InlineImage::class, $message->introLines[0]);
+        $this->assertSame($attachment, $message->introLines[0]->attachment);
+        $this->assertSame('Company logo', $message->introLines[0]->alt);
+        $this->assertSame(24, $message->introLines[0]->width);
+        $this->assertSame(24, $message->introLines[0]->height);
+        $this->assertSame('vertical-align: middle;', $message->introLines[0]->style);
+    }
+
+    public function testItCanAddALineBeforeAnImage()
+    {
+        $attachment = Attachment::fromData(fn () => 'image data', 'logo.png');
+        $message = new MailMessage;
+
+        $message->lineBeforeImage('Before the image.', $attachment, 'Company logo', null, null, 'vertical-align: middle;');
+
+        $this->assertInstanceOf(InlineImageLine::class, $message->introLines[0]);
+        $this->assertSame('Before the image.', $message->introLines[0]->before);
+        $this->assertNull($message->introLines[0]->after);
+        $this->assertSame($attachment, $message->introLines[0]->image->attachment);
+        $this->assertSame('vertical-align: middle;', $message->introLines[0]->image->style);
+    }
+
+    public function testItCanAddALineAfterAnImage()
+    {
+        $attachment = Attachment::fromData(fn () => 'image data', 'logo.png');
+        $message = new MailMessage;
+
+        $message->lineAfterImage('After the image.', $attachment, 'Company logo');
+
+        $this->assertInstanceOf(InlineImageLine::class, $message->introLines[0]);
+        $this->assertNull($message->introLines[0]->before);
+        $this->assertSame('After the image.', $message->introLines[0]->after);
+        $this->assertSame($attachment, $message->introLines[0]->image->attachment);
+    }
+
+    public function testItCanAddImageFromData()
+    {
+        $message = new MailMessage;
+
+        $message->imageFromData('image data', 'logo.png', 'Company logo', 'image/png');
+
+        $this->assertInstanceOf(InlineImage::class, $message->introLines[0]);
+        $this->assertSame('logo.png', $message->introLines[0]->attachment->as);
+        $this->assertSame('image/png', $message->introLines[0]->attachment->mime);
+    }
+
+    public function testItCanAddImageFromStorageWithOptions()
+    {
+        $this->bootstrapFilesystem();
+
+        file_put_contents($this->filesystemRoot.'/reports/report.txt', 'image data');
+
+        $message = new MailMessage;
+        $message->imageFromStorage('reports/report.txt', 'Report', 'report.png', [
+            'mime' => 'image/png',
+            'width' => 16,
+            'height' => 16,
+            'style' => 'vertical-align: middle;',
+        ]);
+
+        $this->assertInstanceOf(InlineImage::class, $message->introLines[0]);
+        $this->assertSame('report.png', $message->introLines[0]->attachment->as);
+        $this->assertSame('image/png', $message->introLines[0]->attachment->mime);
+        $this->assertSame(16, $message->introLines[0]->width);
+        $this->assertSame(16, $message->introLines[0]->height);
+        $this->assertSame('vertical-align: middle;', $message->introLines[0]->style);
     }
 
     public function testHtmlAndPlainView()


### PR DESCRIPTION
This contribution grew from testing SVG and other image assets in Markdown mail notifications: callers needed to declare them from `toMail()` without embedding raw HTML or creating a view for each notification. It adds a render-time inline-image pipeline that resolves a CID against the active mail message, preserves a text fallback, and emits escaped `<img>` markup for the standard Markdown notification template.

The declaration supports `image(...)`, `imageFromData(...)`, `imageFromStorage(...)` / `imageFromStorageDisk(...)`, and `lineBeforeImage(...)` / `lineAfterImage(...)`, with optional dimensions, alternative text, MIME type, and per-image style. This keeps the framework independent of Blade Icons while allowing SVG, PNG, and other image representations supplied through paths, attachments, attachables, raw data, or storage. Published notification templates and mail themes remain available for surrounding layout and styling; the implementation handles embedding and image metadata while callers choose an asset representation suitable for their mail clients.

```php
return (new MailMessage)
    ->imageFromData($svg, 'status.svg', 'Status', 'image/svg+xml', 16, 16, 'vertical-align: middle;')
    ->lineAfterImage('View details', $attachment, null, 16, 16, 'vertical-align: -0.125em;');
```
