### PR TITLE
[13.x] Isolate cloud agent requests from global HTTP client configuration

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -322,11 +322,13 @@ class Queue implements QueueContract, ClearableQueue
      */
     protected function agentRequest()
     {
-        return Http::baseUrl('http://localhost')->withOptions([
-            'curl' => [
-                CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
-            ],
-        ]);
+        return Http::withoutGlobalConfiguration(
+            fn () => Http::baseUrl('http://localhost')->withOptions([
+                'curl' => [
+                    CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
+                ],
+            ])
+        );
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -156,6 +156,27 @@ class Factory
     }
 
     /**
+     * Execute a callback while requests are created without global middleware or global options.
+     *
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
+     */
+    public function withoutGlobalConfiguration(Closure $callback)
+    {
+        [$middleware, $options] = [$this->globalMiddleware, $this->globalOptions];
+
+        [$this->globalMiddleware, $this->globalOptions] = [[], []];
+
+        try {
+            return $callback();
+        } finally {
+            [$this->globalMiddleware, $this->globalOptions] = [$middleware, $options];
+        }
+    }
+
+    /**
      * Create a new response instance for use during stubbing.
      *
      * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Factory globalRequestMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalResponseMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalOptions(\Closure|array $options)
+ * @method static mixed withoutGlobalConfiguration(\Closure $callback)
  * @method static \GuzzleHttp\Promise\PromiseInterface response(\Psr\Http\Message\StreamInterface|array|string|resource|null $body = null, int $status = 200, array $headers = [])
  * @method static \GuzzleHttp\Psr7\Response psr7Response(\Psr\Http\Message\StreamInterface|array|string|resource|null $body = null, int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\Client\RequestException failedRequest(\Psr\Http\Message\StreamInterface|array|string|resource|null $body = null, int $status = 200, array $headers = [])

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -228,6 +228,35 @@ class QueueTest extends TestCase
         $this->assertSame([], $eventsFake->emitted);
     }
 
+    public function testAgentRequestsIgnoreGlobalClientConfiguration()
+    {
+        $options = null;
+        $hasGlobalHeader = null;
+
+        $this->fakeEvents();
+        Http::globalOptions([
+            'force_ip_resolve' => 'v4',
+            'connect_timeout' => 5,
+            'timeout' => 30,
+        ]);
+        Http::globalRequestMiddleware(fn ($request) => $request->withHeader('X-Global', 'Foo'));
+        Http::fake(function ($request, $requestOptions) use (&$options, &$hasGlobalHeader) {
+            if (str_ends_with($request->url(), '/next')) {
+                $options = $requestOptions;
+                $hasGlobalHeader = $request->hasHeader('X-Global');
+            }
+        });
+
+        [$queue] = $this->fakeQueue();
+
+        $queue->pop();
+
+        $this->assertIsArray($options);
+        $this->assertArrayNotHasKey('force_ip_resolve', $options);
+        $this->assertSame(10, $options['connect_timeout']);
+        $this->assertFalse($hasGlobalHeader);
+    }
+
     public function testItEmitsStartedEventWhenJobIsSuccessfullyPopped()
     {
         $this->travelTo('2000-01-02 03:04:05.060708');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2320,6 +2320,41 @@ class HttpClientTest extends TestCase
         $this->assertSame(['connect_timeout' => 20, 'crypto_method' => 33, 'http_errors' => true, 'timeout' => 30], $request->getOptions());
     }
 
+    public function testGlobalConfigurationCanBeDisabledForRequestsCreatedWithinCallback()
+    {
+        $this->factory->fake();
+        $this->factory->globalOptions(['force_ip_resolve' => 'v4']);
+        $this->factory->globalRequestMiddleware(fn ($request) => $request->withHeader('X-Global', 'Foo'));
+
+        $request = $this->factory->withoutGlobalConfiguration(fn () => $this->factory->createPendingRequest());
+        $request->get('http://laravel.com/agent');
+
+        $this->factory->createPendingRequest()->get('http://laravel.com/global');
+
+        $this->assertArrayNotHasKey('force_ip_resolve', $request->getOptions());
+        $this->factory->assertSent(fn (Request $request) => $request->url() === 'http://laravel.com/agent' && ! $request->hasHeader('X-Global'));
+        $this->factory->assertSent(fn (Request $request) => $request->url() === 'http://laravel.com/global' && $request->hasHeader('X-Global'));
+    }
+
+    public function testGlobalConfigurationIsRestoredAfterWithoutGlobalConfigurationCallback()
+    {
+        $middleware = fn ($handler) => $handler;
+
+        $this->factory->globalOptions(['force_ip_resolve' => 'v4']);
+        $this->factory->globalMiddleware($middleware);
+
+        try {
+            $this->factory->withoutGlobalConfiguration(function () {
+                throw new Exception('boom');
+            });
+        } catch (Exception) {
+            //
+        }
+
+        $this->assertSame('v4', $this->factory->createPendingRequest()->getOptions()['force_ip_resolve']);
+        $this->assertSame([$middleware], $this->factory->getGlobalMiddleware());
+    }
+
     public function testMultipleRequestsAreSentInThePool()
     {
         $this->factory->fake([


### PR DESCRIPTION
When an application registers global HTTP client options:

```php
Http::globalOptions([
    'force_ip_resolve' => 'v4',
]);
```

...they are applied to every request created through the `Http` facade — including the framework's own cloud-agent unix socket long-poll in `Foundation\Cloud\Queue::agentRequest()`, where `force_ip_resolve => v4` breaks the socket connection. Any global option (`proxy`, etc.) or global middleware (host rewriting, request signing) can break agent traffic the same way, so neutralizing individual options isn't viable — agent requests need to be isolated from application-level client configuration entirely.

This adds `Factory::withoutGlobalConfiguration(Closure $callback)`: requests created inside the callback receive no global middleware and no global options, restored via `try`/`finally`. `agentRequest()` now creates its pending request inside that callback.

Design notes:

- **Callback-scoped rather than fluent** (mirroring `Schema::withoutForeignKeyConstraints()` / `Model::withoutEvents()`): globals are applied at `PendingRequest` construction, so they can't be removed fluently after the fact — and a factory-only fluent method invites `Http::retry(3)->withoutGlobalConfiguration()`, which would throw since the `PendingRequest` already exists.
- **Not a bare `new PendingRequest`**: `Http::fake()` stubs and `preventStrayRequests()` are only wired through `Factory::createPendingRequest()`, so bypassing the factory would break HTTP faking for agent traffic in both framework and application test suites. Inside the callback the normal facade path is used, so faking keeps working unchanged.

Tests cover the factory method directly (globals excluded inside the callback with a positive control, state restored even when the callback throws) and the queue regression (agent request carries no forced IP version, no global middleware header, and default rather than global `connect_timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)