### PR TITLE
[13.x] Respect backed enum queue names when queueing mailables

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
@@ -475,7 +476,7 @@ class Mailer implements MailerContract, MailQueueContract
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        if (is_string($queue)) {
+        if (is_string($queue) || $queue instanceof BackedEnum) {
             $view->onQueue($queue);
         }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -239,6 +239,17 @@ class MailableQueuedTest extends TestCase
         $this->assertEquals($mailable->deduplicationId(...), $pushedJob->deduplicator->getClosure());
     }
 
+    public function testQueueSetsBackedEnumQueueOnMailable(): void
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = new Mailer(...$this->getMocks());
+        $mailer->setQueue($queueFake);
+
+        $mailer->queue(new MailableQueueableStub, MailableQueue::Emails);
+
+        $queueFake->assertPushedOn('emails', SendQueuedMailable::class);
+    }
+
     public function testLaterSetsQueueOnMailable(): void
     {
         $queueFake = new QueueFake(new Application);
@@ -292,6 +303,11 @@ class MailableQueueableStub extends Mailable implements ShouldQueue
 
         return $this;
     }
+}
+
+enum MailableQueue: string
+{
+    case Emails = 'emails';
 }
 
 class MailableQueueableStubWithMessageGroup extends Mailable implements ShouldQueue


### PR DESCRIPTION
When a backed enum is passed as the queue argument to `Mailer::queue()`, it is ignored because the method only forwards string queue names.

This causes the mailable to be dispatched to the default queue even though `Mailer::queue()` documents `BackedEnum| string|null`.

This PR forwards backed enum queue names to the mailable, where `Queueable::onQueue()` resolves the enum to its backing value.

A regression test verifies that a backed enum queue name is applied to the queued job. Existing string and null behavior is unchanged.