### PR TITLE
[13.x] Fix getRememberToken return type documentation

### DIFF
--- a/src/Illuminate/Contracts/Auth/Authenticatable.php
+++ b/src/Illuminate/Contracts/Auth/Authenticatable.php
@@ -35,7 +35,7 @@ interface Authenticatable
     /**
      * Get the token value for the "remember me" session.
      *
-     * @return string
+     * @return string|null
      */
     public function getRememberToken();
 


### PR DESCRIPTION
The `Authenticatable` contract documents `getRememberToken()` as returning `string`, while the default `Authenticatable` trait documents `string|null` and returns `null` when no remember token name is configured.

This updates the contract PHPDoc to match the existing implementation and resolves return type compatibility errors reported by static analysis tools such as PHPStan.