### PR TITLE
[11.x] Isolate cloud agent requests from global HTTP client configuration

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -340,11 +340,13 @@ class Queue implements QueueContract, ClearableQueue
      */
     protected function agentRequest()
     {
-        return Http::baseUrl('http://localhost')->withOptions([
-            'curl' => [
-                CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
-            ],
-        ]);
+        return Http::withoutGlobalConfiguration(
+            fn () => Http::baseUrl('http://localhost')->withOptions([
+                'curl' => [
+                    CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
+                ],
+            ])
+        );
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -146,6 +146,27 @@ class Factory
     }
 
     /**
+     * Execute a callback while requests are created without global middleware or global options.
+     *
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
+     */
+    public function withoutGlobalConfiguration(Closure $callback)
+    {
+        [$middleware, $options] = [$this->globalMiddleware, $this->globalOptions];
+
+        [$this->globalMiddleware, $this->globalOptions] = [[], []];
+
+        try {
+            return $callback();
+        } finally {
+            [$this->globalMiddleware, $this->globalOptions] = [$middleware, $options];
+        }
+    }
+
+    /**
      * Create a new response instance for use during stubbing.
      *
      * @param  array|string|null  $body

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Factory globalRequestMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalResponseMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalOptions(\Closure|array $options)
+ * @method static mixed withoutGlobalConfiguration(\Closure $callback)
  * @method static \GuzzleHttp\Promise\PromiseInterface response(array|string|null $body = null, int $status = 200, array $headers = [])
  * @method static \GuzzleHttp\Promise\PromiseInterface failedConnection(string|null $message = null)
  * @method static \Illuminate\Http\Client\ResponseSequence sequence(array $responses = [])

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -189,6 +189,35 @@ class QueueTest extends TestCase
         $this->assertSame([], $eventsFake->emitted);
     }
 
+    public function testAgentRequestsIgnoreGlobalClientConfiguration()
+    {
+        $options = null;
+        $hasGlobalHeader = null;
+
+        $this->fakeEvents();
+        Http::globalOptions([
+            'force_ip_resolve' => 'v4',
+            'connect_timeout' => 5,
+            'timeout' => 30,
+        ]);
+        Http::globalRequestMiddleware(fn ($request) => $request->withHeader('X-Global', 'Foo'));
+        Http::fake(function ($request, $requestOptions) use (&$options, &$hasGlobalHeader) {
+            if (str_ends_with($request->url(), '/next')) {
+                $options = $requestOptions;
+                $hasGlobalHeader = $request->hasHeader('X-Global');
+            }
+        });
+
+        [$queue] = $this->fakeQueue();
+
+        $queue->pop();
+
+        $this->assertIsArray($options);
+        $this->assertArrayNotHasKey('force_ip_resolve', $options);
+        $this->assertSame(10, $options['connect_timeout']);
+        $this->assertFalse($hasGlobalHeader);
+    }
+
     public function testItEmitsStartedEventWhenJobIsSuccessfullyPopped()
     {
         $this->travelTo('2000-01-02 03:04:05.060708');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1709,6 +1709,41 @@ class HttpClientTest extends TestCase
         $this->assertSame(['connect_timeout' => 20, 'crypto_method' => 33, 'http_errors' => true, 'timeout' => 30], $request->getOptions());
     }
 
+    public function testGlobalConfigurationCanBeDisabledForRequestsCreatedWithinCallback()
+    {
+        $this->factory->fake();
+        $this->factory->globalOptions(['force_ip_resolve' => 'v4']);
+        $this->factory->globalRequestMiddleware(fn ($request) => $request->withHeader('X-Global', 'Foo'));
+
+        $request = $this->factory->withoutGlobalConfiguration(fn () => $this->factory->createPendingRequest());
+        $request->get('http://laravel.com/agent');
+
+        $this->factory->createPendingRequest()->get('http://laravel.com/global');
+
+        $this->assertArrayNotHasKey('force_ip_resolve', $request->getOptions());
+        $this->factory->assertSent(fn (Request $request) => $request->url() === 'http://laravel.com/agent' && ! $request->hasHeader('X-Global'));
+        $this->factory->assertSent(fn (Request $request) => $request->url() === 'http://laravel.com/global' && $request->hasHeader('X-Global'));
+    }
+
+    public function testGlobalConfigurationIsRestoredAfterWithoutGlobalConfigurationCallback()
+    {
+        $middleware = fn ($handler) => $handler;
+
+        $this->factory->globalOptions(['force_ip_resolve' => 'v4']);
+        $this->factory->globalMiddleware($middleware);
+
+        try {
+            $this->factory->withoutGlobalConfiguration(function () {
+                throw new Exception('boom');
+            });
+        } catch (Exception) {
+            //
+        }
+
+        $this->assertSame('v4', $this->factory->createPendingRequest()->getOptions()['force_ip_resolve']);
+        $this->assertSame([$middleware], $this->factory->getGlobalMiddleware());
+    }
+
     public function testMultipleRequestsAreSentInThePool()
     {
         $this->factory->fake([


### PR DESCRIPTION
Backport of #61064 to 11.x. Clean cherry-pick apart from the `Http` facade docblock (11.x has a smaller `@method` list around `response()`).

When an application registers global HTTP client options or middleware (e.g. `Http::globalOptions(['force_ip_resolve' => 'v4'])`), they are applied to every request created through the `Http` facade — including the cloud-agent unix socket long-poll in `Foundation\Cloud\Queue::agentRequest()`, where `force_ip_resolve => v4` breaks the socket connection.

This adds `Factory::withoutGlobalConfiguration(Closure $callback)` — requests created inside the callback receive no global middleware and no global options, restored via `try`/`finally` — and creates the agent's pending requests inside it. Callback-scoped like `Schema::withoutForeignKeyConstraints()` / `Model::withoutEvents()`; `Http::fake()` and `preventStrayRequests()` are unaffected since requests inside the callback still flow through `Factory::createPendingRequest()`.

Verified locally: `tests/Foundation/Cloud/QueueTest` (66 OK, 2 pre-existing deprecations also present on base 11.x) and `tests/Http/HttpClientTest` (189 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)