### PR TITLE
[13.x] Fix paginate() total count when using distinct with join

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1133,7 +1133,16 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->toBase()->getCountForPagination();
+        $countColumns = ['*'];
+
+        if ($this->query->distinct && $columns !== ['*']) {
+            $countColumns = array_map(fn ($column) => str_contains($column, '*')
+                ? $this->model->getQualifiedKeyName()
+                : $column,
+            $columns);
+        }
+
+        $total = value($total) ?? $this->toBase()->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total) ?: $this->model->getPerPage();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3615,7 +3615,14 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->getCountForPagination();
+        $countColumns = ['*'];
+
+        if ($this->distinct && $columns !== ['*']
+            && empty(array_filter($columns, fn ($column) => str_contains($column, '*')))) {
+            $countColumns = $columns;
+        }
+
+        $total = value($total) ?? $this->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total);
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -398,6 +398,33 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
     }
 
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinct()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10, ['users.*']);
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
     public function testCountForPaginationWithGrouping()
     {
         EloquentTestUser::insert([


### PR DESCRIPTION
## Summary

When using `paginate()` on a query that combines `distinct()` and `join`, the value returned by the paginator's `total()` could differ from the actual number of rows after duplicates were removed.

This happens because the count query executed internally for pagination uses `COUNT(*)`, and does not take `DISTINCT` or the selected columns into account.

## Cause

Both `Eloquent\Builder::paginate()` and `Query\Builder::paginate()` call `getCountForPagination()` without specifying columns. As a result, the default value, `['*']`, is used.

On the other hand, `Grammar::compileAggregate()` only applies `DISTINCT` when the aggregate column is not `*`.

Therefore, even when `distinct()` is specified, the generated count query becomes something like `COUNT(*)`.

## Reproduction

For example, this occurs when paginating a query that uses both `distinct()` and `join`:

```php
$users = User::query()
    ->select('users.*')
    ->join('posts', 'posts.user_id', '=', 'users.id')
    ->distinct()
    ->paginate(15);
```

Before this fix, the pagination count query used `COUNT(*)`, so rows increased by the `join` could be counted as-is.

```sql
select count(*) as aggregate
from `users`
inner join `posts` on `posts`.`user_id` = `users`.`id`
```

As a result, `$users->total()` could return the number of joined rows instead of the number of users after applying `DISTINCT`.

After this fix, in `Eloquent\Builder`, `users.*` is replaced with the model's qualified primary key, and the count query uses `COUNT(DISTINCT ...)`.

```sql
select count(distinct `users`.`id`) as aggregate
from `users`
inner join `posts` on `posts`.`user_id` = `users`.`id`
```

This ensures that `$users->total()` returns the number of users after applying `DISTINCT`.

## Changes

When `distinct` is enabled and the selected columns are not `['*']`, the selected columns are now passed to `getCountForPagination()`.

This allows the count query to use `COUNT(DISTINCT ...)` when the target columns for `DISTINCT` can be determined.

### Eloquent Builder

In `Eloquent\Builder`, when a selected column contains a wildcard such as `users.*`, it is replaced with the model's primary key.

```text
users.* -> users.id
```

This prevents invalid SQL such as `COUNT(DISTINCT users.*)` from being generated.

### Query Builder

Since `Query\Builder` cannot infer the model's primary key, selections containing a wildcard such as `users.*` continue to fall back to `['*']`.
