### PR TITLE
[13.x] Add image orientation helpers

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -498,6 +498,38 @@ class Image implements Stringable
     }
 
     /**
+     * Get the aspect ratio of the processed image.
+     */
+    public function aspectRatio(): float
+    {
+        return $this->width() / $this->height();
+    }
+
+    /**
+     * Check if the image has a landscape orientation.
+     */
+    public function isLandscape(): bool
+    {
+        return $this->aspectRatio() > 1;
+    }
+
+    /**
+     * Check if the image has a portrait orientation.
+     */
+    public function isPortrait(): bool
+    {
+        return $this->aspectRatio() < 1;
+    }
+
+    /**
+     * Check if the image is square.
+     */
+    public function isSquare(): bool
+    {
+        return $this->aspectRatio() === 1.0;
+    }
+
+    /**
      * Get the dominant (average) color of the image as a hex string.
      */
     public function dominantColor(): string

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -1079,63 +1079,63 @@ class ImageTest extends TestCase
     {
         $image = new Image($this->fakeImageContents(800, 600));
 
-        $this->assertEquals(true, $image->isLandscape());
+        $this->assertTrue($image->isLandscape());
     }
 
     public function test_is_landscape_returns_false_for_width_smaller_than_height()
     {
         $image = new Image($this->fakeImageContents(600, 800));
 
-        $this->assertEquals(false, $image->isLandscape());
+        $this->assertFalse($image->isLandscape());
     }
 
     public function test_is_landscape_returns_false_for_width_equal_to_height()
     {
         $image = new Image($this->fakeImageContents(600, 600));
 
-        $this->assertEquals(false, $image->isLandscape());
+        $this->assertFalse($image->isLandscape());
     }
 
     public function test_is_portrait_returns_true_for_height_larger_than_width()
     {
         $image = new Image($this->fakeImageContents(600, 800));
 
-        $this->assertEquals(true, $image->isPortrait());
+        $this->assertTrue($image->isPortrait());
     }
 
     public function test_is_portrait_returns_false_for_height_smaller_than_width()
     {
         $image = new Image($this->fakeImageContents(800, 600));
 
-        $this->assertEquals(false, $image->isPortrait());
+        $this->assertFalse($image->isPortrait());
     }
 
     public function test_is_portrait_returns_false_for_height_equal_to_width()
     {
         $image = new Image($this->fakeImageContents(600, 600));
 
-        $this->assertEquals(false, $image->isPortrait());
+        $this->assertFalse($image->isPortrait());
     }
 
     public function test_is_square_returns_true_for_width_equal_to_height()
     {
         $image = new Image($this->fakeImageContents(600, 600));
 
-        $this->assertEquals(true, $image->isSquare());
+        $this->assertTrue($image->isSquare());
     }
 
     public function test_is_square_returns_false_for_width_larger_than_height()
     {
         $image = new Image($this->fakeImageContents(800, 600));
 
-        $this->assertEquals(false, $image->isSquare());
+        $this->assertFalse($image->isSquare());
     }
 
     public function test_is_square_returns_false_for_width_smaller_than_height()
     {
         $image = new Image($this->fakeImageContents(600, 800));
 
-        $this->assertEquals(false, $image->isSquare());
+        $this->assertFalse($image->isSquare());
     }
 
     public function test_cover_does_not_set_scale()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -1068,6 +1068,76 @@ class ImageTest extends TestCase
         $this->assertNull($options->coverHeight);
     }
 
+    public function test_aspect_ratio_returns_correct_value()
+    {
+        $image = new Image($this->fakeImageContents(800, 600));
+
+        $this->assertEquals(4 / 3, $image->aspectRatio());
+    }
+
+    public function test_is_landscape_returns_true_for_width_larger_than_height()
+    {
+        $image = new Image($this->fakeImageContents(800, 600));
+
+        $this->assertEquals(true, $image->isLandscape());
+    }
+
+    public function test_is_landscape_returns_false_for_width_smaller_than_height()
+    {
+        $image = new Image($this->fakeImageContents(600, 800));
+
+        $this->assertEquals(false, $image->isLandscape());
+    }
+
+    public function test_is_landscape_returns_false_for_width_equal_to_height()
+    {
+        $image = new Image($this->fakeImageContents(600, 600));
+
+        $this->assertEquals(false, $image->isLandscape());
+    }
+
+    public function test_is_portrait_returns_true_for_height_larger_than_width()
+    {
+        $image = new Image($this->fakeImageContents(600, 800));
+
+        $this->assertEquals(true, $image->isPortrait());
+    }
+
+    public function test_is_portrait_returns_false_for_height_smaller_than_width()
+    {
+        $image = new Image($this->fakeImageContents(800, 600));
+
+        $this->assertEquals(false, $image->isPortrait());
+    }
+
+    public function test_is_portrait_returns_false_for_height_equal_to_width()
+    {
+        $image = new Image($this->fakeImageContents(600, 600));
+
+        $this->assertEquals(false, $image->isPortrait());
+    }
+
+    public function test_is_square_returns_true_for_width_equal_to_height()
+    {
+        $image = new Image($this->fakeImageContents(600, 600));
+
+        $this->assertEquals(true, $image->isSquare());
+    }
+
+    public function test_is_square_returns_false_for_width_larger_than_height()
+    {
+        $image = new Image($this->fakeImageContents(800, 600));
+
+        $this->assertEquals(false, $image->isSquare());
+    }
+
+    public function test_is_square_returns_false_for_width_smaller_than_height()
+    {
+        $image = new Image($this->fakeImageContents(600, 800));
+
+        $this->assertEquals(false, $image->isSquare());
+    }
+
     public function test_cover_does_not_set_scale()
     {
         $image = $this->makeImage();


### PR DESCRIPTION
### Description
This pull request introduces four simple but useful geometric helper methods to the new `Illuminate\Image` component: 
-`aspectRatio()` 
-`isPortrait()` 
-`isLandscape()`
-`isSquare()`

Currently, determining the layout orientation of an image requires manual mathematical comparison of its width and height properties. These fluent methods abstract that logic to improve developer experience and code readability when handling conditional image processing.

### Practical Examples

```php
use Illuminate\Support\Facades\Image;

$image = Image::read($request->file('avatar'));

// 1. Get the float representation of the aspect ratio
$ratio = $image->aspectRatio(); // e.g., 1.77777777778 for 16:9

// 2. Conditional processing based on geometric orientation
// Using conditional methods to transform the image based on its orientation
$image
    ->when($image->isPortrait(), fn ($img) => $img->scale(height: 1200)) // Optimally scale vertical images for mobile viewports
    ->when($image->isLandscape(), fn ($img) => $img->scale(width: 1920)) // Optimally scale horizontal images for desktop banners
    ->when($image->isSquare(), fn ($img) => $img->cover(400, 400)) // Generate a perfect thumbnail profile from square uploads
;
```

### Edge Cases Handled
* **`isSquare()`**: Returns `true` if `width === height`. Returns `false` otherwise.
* **`isPortrait()`**: Returns `true` if `height > width`. Returns `false` if the image is square.
* **`isLandscape()`**: Returns `true` if `width > height`. Returns `false` if the image is square.
