### PR TITLE
[13.x] Restore missing model deletion for broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -78,7 +78,7 @@ class BroadcastEvent implements ShouldQueue
         $this->backoff = $this->getAttributeValue($event, Backoff::class, 'backoff');
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
         $this->maxExceptions = $this->getAttributeValue($event, MaxExceptions::class, 'maxExceptions');
-        $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels');
+        $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? true;
     }
 
     /**

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -133,6 +133,25 @@ class BroadcastEventTest extends TestCase
         $this->assertSame(['foo', 'bar'], $job->middleware());
     }
 
+    public function testDeletesWhenMissingModelsByDefault()
+    {
+        $job = new BroadcastEvent(new TestBroadcastEvent);
+
+        $this->assertTrue($job->deleteWhenMissingModels);
+    }
+
+    public function testDeletingWhenMissingModelsCanBeDisabled()
+    {
+        $event = new class
+        {
+            public $deleteWhenMissingModels = false;
+        };
+
+        $job = new BroadcastEvent($event);
+
+        $this->assertFalse($job->deleteWhenMissingModels);
+    }
+
     public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent()
     {
         $event = new class


### PR DESCRIPTION
When a queued broadcast event does not explicitly configure missing-model behavior, `BroadcastEvent` replaces its default `$deleteWhenMissingModels` value of `true` with `null`.

The queue payload consequently records `deleteWhenMissingModels` as `false`. If an Eloquent model serialized with the event is deleted before the queue worker processes it, the broadcast job fails with a `ModelNotFoundException` instead of being quietly discarded.

This PR preserves the existing `true` default when the underlying event does not provide a value.

Events that explicitly set `$deleteWhenMissingModels` to `false` continue to opt out of this behavior.

Regression tests have been added for both the default behavior and the explicit opt-out.
