### PR TITLE
Add stray disk prevention to Storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -49,6 +49,20 @@ class FilesystemManager implements FactoryContract
     protected $disks = [];
 
     /**
+     * The array of explicitly set filesystem drivers.
+     *
+     * @var array
+     */
+    protected $customDisks = [];
+
+    /**
+     * Indicates that an exception should be thrown if any disk is not faked.
+     *
+     * @var bool
+     */
+    protected $preventStrayDisks = false;
+
+    /**
      * The registered custom driver creators.
      *
      * @var array
@@ -109,6 +123,8 @@ class FilesystemManager implements FactoryContract
      */
     public function build($config)
     {
+        $this->ensureDiskIsAllowed('ondemand');
+
         return $this->resolve('ondemand', is_array($config) ? $config : [
             'driver' => 'local',
             'root' => $config,
@@ -123,6 +139,8 @@ class FilesystemManager implements FactoryContract
      */
     protected function get($name)
     {
+        $this->ensureDiskIsAllowed($name);
+
         return $this->disks[$name] ?? $this->resolve($name);
     }
 
@@ -369,8 +387,47 @@ class FilesystemManager implements FactoryContract
     public function set($name, $disk)
     {
         $this->disks[$name] = $disk;
+        $this->customDisks[$name] = true;
 
         return $this;
+    }
+
+    /**
+     * Indicate that an exception should be thrown if any disk is not faked.
+     *
+     * @param  bool  $prevent
+     * @return $this
+     */
+    public function preventStrayDisks(bool $prevent = true)
+    {
+        $this->preventStrayDisks = $prevent;
+
+        return $this;
+    }
+
+    /**
+     * Determine if stray disks are being prevented.
+     *
+     * @return bool
+     */
+    public function preventingStrayDisks()
+    {
+        return $this->preventStrayDisks;
+    }
+
+    /**
+     * Ensure the given disk is allowed to be accessed.
+     *
+     * @param  string  $name
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function ensureDiskIsAllowed($name)
+    {
+        if ($this->preventStrayDisks && ! isset($this->customDisks[$name])) {
+            throw new RuntimeException("Attempted to access disk [{$name}] without a matching fake.");
+        }
     }
 
     /**
@@ -413,7 +470,7 @@ class FilesystemManager implements FactoryContract
     public function forgetDisk($disk)
     {
         foreach ((array) $disk as $diskName) {
-            unset($this->disks[$diskName]);
+            unset($this->disks[$diskName], $this->customDisks[$diskName]);
         }
 
         return $this;
@@ -429,7 +486,7 @@ class FilesystemManager implements FactoryContract
     {
         $name ??= $this->getDefaultDriver();
 
-        unset($this->disks[$name]);
+        unset($this->disks[$name], $this->customDisks[$name]);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -17,6 +17,8 @@ use function Illuminate\Support\enum_value;
  * @method static \Illuminate\Contracts\Filesystem\Cloud createS3Driver(array $config)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem createScopedDriver(array $config)
  * @method static \Illuminate\Filesystem\FilesystemManager set(string $name, mixed $disk)
+ * @method static \Illuminate\Filesystem\FilesystemManager preventStrayDisks(bool $prevent = true)
+ * @method static bool preventingStrayDisks()
  * @method static string getDefaultDriver()
  * @method static string getDefaultCloudDriver()
  * @method static \Illuminate\Filesystem\FilesystemManager forgetDisk(array|string $disk)

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -10,6 +10,7 @@ use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\UnableToReadFile;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use stdClass;
 
 class FilesystemManagerTest extends TestCase
@@ -40,6 +41,100 @@ class FilesystemManagerTest extends TestCase
         ]));
 
         rmdir(__DIR__.'/../../my-custom-path');
+    }
+
+    public function testStrayDisksAreAllowedByDefault()
+    {
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = [
+                'filesystems.disks.local' => [
+                    'driver' => 'local',
+                    'root' => 'my-custom-path',
+                ],
+            ];
+        }));
+
+        $this->assertInstanceOf(Filesystem::class, $filesystem->disk('local'));
+    }
+
+    public function testStrayDisksCanBePrevented()
+    {
+        $filesystem = new FilesystemManager(new Application);
+
+        $filesystem->preventStrayDisks();
+
+        $this->expectExceptionObject(new RuntimeException('Attempted to access disk [s3] without a matching fake.'));
+
+        $filesystem->disk('s3');
+    }
+
+    public function testPreviouslyResolvedDisksArePrevented()
+    {
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = [
+                'filesystems.disks.local' => [
+                    'driver' => 'local',
+                    'root' => 'my-custom-path',
+                ],
+            ];
+        }));
+
+        $filesystem->disk('local');
+        $filesystem->preventStrayDisks();
+
+        $this->expectExceptionObject(new RuntimeException('Attempted to access disk [local] without a matching fake.'));
+
+        $filesystem->disk('local');
+    }
+
+    public function testExplicitlySetDisksAreAllowedWhenPreventingStrayDisks()
+    {
+        $filesystem = new FilesystemManager(new Application);
+        $disk = new stdClass;
+
+        $filesystem->preventStrayDisks()->set('fake', $disk);
+
+        $this->assertSame($disk, $filesystem->disk('fake'));
+    }
+
+    public function testForgottenDisksAreNoLongerAllowedWhenPreventingStrayDisks()
+    {
+        $filesystem = new FilesystemManager(new Application);
+
+        $filesystem->set('fake', new stdClass);
+        $filesystem->preventStrayDisks()->forgetDisk('fake');
+
+        $this->expectExceptionObject(new RuntimeException('Attempted to access disk [fake] without a matching fake.'));
+
+        $filesystem->disk('fake');
+    }
+
+    public function testOnDemandDisksCanBePrevented()
+    {
+        $filesystem = new FilesystemManager(new Application);
+
+        $filesystem->preventStrayDisks();
+
+        $this->expectExceptionObject(new RuntimeException('Attempted to access disk [ondemand] without a matching fake.'));
+
+        $filesystem->build('my-custom-path');
+    }
+
+    public function testPreventingStrayDisksCanBeDisabled()
+    {
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = [
+                'filesystems.disks.local' => [
+                    'driver' => 'local',
+                    'root' => 'my-custom-path',
+                ],
+            ];
+        }));
+
+        $filesystem->preventStrayDisks()->preventStrayDisks(false);
+
+        $this->assertFalse($filesystem->preventingStrayDisks());
+        $this->assertInstanceOf(Filesystem::class, $filesystem->disk('local'));
     }
 
     public function testCanBuildReadOnlyDisks()

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -60,6 +60,16 @@ class StorageFacadeTest extends TestCase
         $this->assertNull(Storage::persistentFake(StorageDisk::Test)->get('nonExistentFile'));
         $this->assertNull(Storage::fake(StorageDisk::Public)->get('nonExistentFile'));
     }
+
+    public function testStorageFakesAreAllowedWhenPreventingStrayDisks()
+    {
+        Storage::preventStrayDisks();
+
+        $fake = Storage::fake('test');
+
+        $this->assertSame($fake, Storage::disk('test'));
+        $this->assertTrue(Storage::preventingStrayDisks());
+    }
 }
 
 enum StorageDisk: string


### PR DESCRIPTION
Storage fakes do not currently provide a way to fail when application code resolves an unfaked disk, so tests can silently write to configured services such as S3. This adds an opt-in `Storage::preventStrayDisks()` guard while continuing to allow disks installed with `Storage::fake()`, `persistentFake()`, or `set()`.

This belongs in core because only the filesystem manager can distinguish configured disks from runtime test replacements before resolving an adapter.

```php
// Before: resolves the configured S3 disk.
Storage::disk("s3")->put("report.pdf", $contents);

Storage::preventStrayDisks();
Storage::fake("local");

// After: throws because the S3 disk was not faked.
Storage::disk("s3")->put("report.pdf", $contents);
```
Related to: https://github.com/laravel/framework/discussions/42580