### PR TITLE
[14.x] Adjust Queue pause methods

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -42,7 +42,7 @@ class PauseCommand extends Command
             return 1;
         }
 
-        $manager->pause($connection, $queue);
+        $manager->pause($queue, $connection);
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused.");
 

--- a/src/Illuminate/Queue/Console/ResumeCommand.php
+++ b/src/Illuminate/Queue/Console/ResumeCommand.php
@@ -42,7 +42,7 @@ class ResumeCommand extends Command
     {
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
-        $manager->resume($connection, $queue);
+        $manager->resume($queue, $connection);
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been resumed.");
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -216,14 +216,16 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Pause a queue by its connection and name.
+     * Pause a queue by its name and connection.
      *
-     * @param  string  $connection
      * @param  string  $queue
+     * @param  string|null  $connection
      * @return void
      */
-    public function pause($connection, $queue)
+    public function pause($queue, $connection = null)
     {
+        $connection ??= $this->getDefaultDriver();
+
         $this->app['cache']
             ->store()
             ->forever("illuminate:queue:paused:{$connection}:{$queue}", true);
@@ -234,15 +236,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Pause a queue by its connection and name for a given amount of time.
+     * Pause a queue by its name and connection for a given amount of time.
      *
-     * @param  string  $connection
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $ttl
+     * @param  string|null  $connection
      * @return void
      */
-    public function pauseFor($connection, $queue, $ttl)
+    public function pauseFor($queue, $ttl, $connection = null)
     {
+        $connection ??= $this->getDefaultDriver();
+
         $this->app['cache']
             ->store()
             ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
@@ -253,14 +257,16 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Resume a paused queue by its connection and name.
+     * Resume a paused queue by its name and connection.
      *
-     * @param  string  $connection
      * @param  string  $queue
+     * @param  string|null  $connection
      * @return void
      */
-    public function resume($connection, $queue)
+    public function resume($queue, $connection = null)
     {
+        $connection ??= $this->getDefaultDriver();
+
         $this->app['cache']
             ->store()
             ->forget("illuminate:queue:paused:{$connection}:{$queue}");
@@ -273,12 +279,14 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Determine if a queue is paused.
      *
-     * @param  string  $connection
      * @param  string  $queue
+     * @param  string|null  $connection
      * @return bool
      */
-    public function isPaused($connection, $queue)
+    public function isPaused($queue, $connection = null)
     {
+        $connection ??= $this->getDefaultDriver();
+
         return (bool) $this->app['cache']
             ->store()
             ->get("illuminate:queue:paused:{$connection}:{$queue}", false);
@@ -287,12 +295,14 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Determine which of the given queues are currently paused.
      *
-     * @param  string  $connection
      * @param  array  $queues
+     * @param  string|null  $connection
      * @return array
      */
-    public function getPausedQueues($connection, $queues)
+    public function getPausedQueues($queues, $connection = null)
     {
+        $connection ??= $this->getDefaultDriver();
+
         $keys = array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues);
 
         $states = $this->app['cache']->store()->many($keys);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -486,7 +486,7 @@ class Worker
             return [];
         }
 
-        return $this->manager->getPausedQueues($connectionName, $queues);
+        return $this->manager->getPausedQueues($queues, $connectionName);
     }
 
     /**

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -43,67 +43,67 @@ class QueuePauseResumeTest extends TestCase
 
     public function testPauseQueueWithConnection()
     {
-        $this->manager->pause('redis', 'default');
+        $this->manager->pause('default', 'redis');
 
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
     }
 
     public function testPauseQueueWithTTL()
     {
-        $this->manager->pauseFor('redis', 'default', 30);
+        $this->manager->pauseFor('default', 30, 'redis');
 
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
 
         Carbon::setTestNow(Carbon::now()->addMinute());
-        $this->assertFalse($this->manager->isPaused('redis', 'default'));
+        $this->assertFalse($this->manager->isPaused('default', 'redis'));
     }
 
     public function testPauseQueueIndefinitely()
     {
-        $this->manager->pause('redis', 'default');
+        $this->manager->pause('default', 'redis');
 
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
 
         Carbon::setTestNow(Carbon::now()->addYear());
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
     }
 
     public function testResumeQueue()
     {
-        $this->manager->pause('redis', 'default');
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+        $this->manager->pause('default', 'redis');
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
 
-        $this->manager->resume('redis', 'default');
-        $this->assertFalse($this->manager->isPaused('redis', 'default'));
+        $this->manager->resume('default', 'redis');
+        $this->assertFalse($this->manager->isPaused('default', 'redis'));
     }
 
     public function testPausingQueueOnOneConnectionDoesNotAffectAnother()
     {
-        $this->manager->pause('redis', 'default');
+        $this->manager->pause('default', 'redis');
 
-        $this->assertTrue($this->manager->isPaused('redis', 'default'));
-        $this->assertFalse($this->manager->isPaused('database', 'default'));
+        $this->assertTrue($this->manager->isPaused('default', 'redis'));
+        $this->assertFalse($this->manager->isPaused('default', 'database'));
     }
 
     public function testPausingDifferentQueuesOnSameConnection()
     {
-        $this->manager->pause('redis', 'emails');
-        $this->manager->pause('redis', 'notifications');
+        $this->manager->pause('emails', 'redis');
+        $this->manager->pause('notifications', 'redis');
 
-        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
-        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
-        $this->assertFalse($this->manager->isPaused('redis', 'default'));
+        $this->assertTrue($this->manager->isPaused('emails', 'redis'));
+        $this->assertTrue($this->manager->isPaused('notifications', 'redis'));
+        $this->assertFalse($this->manager->isPaused('default', 'redis'));
     }
 
     public function testResumingOnlyAffectsSpecificQueue()
     {
-        $this->manager->pause('redis', 'emails');
-        $this->manager->pause('redis', 'notifications');
+        $this->manager->pause('emails', 'redis');
+        $this->manager->pause('notifications', 'redis');
 
-        $this->manager->resume('redis', 'emails');
+        $this->manager->resume('emails', 'redis');
 
-        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
-        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+        $this->assertFalse($this->manager->isPaused('emails', 'redis'));
+        $this->assertTrue($this->manager->isPaused('notifications', 'redis'));
     }
 
     public function testPauseDispatchesQueuePausedEvent()
@@ -116,7 +116,7 @@ class QueuePauseResumeTest extends TestCase
             $dispatchedEvent = $event;
         });
 
-        $this->manager->pause('redis', 'default');
+        $this->manager->pause('default', 'redis');
 
         $this->assertInstanceOf(QueuePaused::class, $dispatchedEvent);
         $this->assertSame('redis', $dispatchedEvent->connection);
@@ -134,7 +134,7 @@ class QueuePauseResumeTest extends TestCase
             $dispatchedEvent = $event;
         });
 
-        $this->manager->pauseFor('redis', 'emails', 60);
+        $this->manager->pauseFor('emails', 60, 'redis');
 
         $this->assertInstanceOf(QueuePaused::class, $dispatchedEvent);
         $this->assertSame('redis', $dispatchedEvent->connection);
@@ -152,7 +152,7 @@ class QueuePauseResumeTest extends TestCase
             $dispatchedEvent = $event;
         });
 
-        $this->manager->resume('database', 'notifications');
+        $this->manager->resume('notifications', 'database');
 
         $this->assertInstanceOf(QueueResumed::class, $dispatchedEvent);
         $this->assertSame('database', $dispatchedEvent->connection);
@@ -161,14 +161,14 @@ class QueuePauseResumeTest extends TestCase
 
     public function testGetPausedQueues()
     {
-        $this->assertSame([], $this->manager->getPausedQueues('redis', ['default', 'emails']));
+        $this->assertSame([], $this->manager->getPausedQueues(['default', 'emails'], 'redis'));
 
-        $this->manager->pause('redis', 'emails');
-        $this->manager->pause('redis', 'notifications');
+        $this->manager->pause('emails', 'redis');
+        $this->manager->pause('notifications', 'redis');
 
         $this->assertSame(
             ['emails', 'notifications'],
-            $this->manager->getPausedQueues('redis', ['default', 'emails', 'notifications'])
+            $this->manager->getPausedQueues(['default', 'emails', 'notifications'], 'redis')
         );
     }
 

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -48,6 +48,14 @@ class QueuePauseResumeTest extends TestCase
         $this->assertTrue($this->manager->isPaused('default', 'redis'));
     }
 
+    public function testConnectionDefaultsToTheDefaultConnection()
+    {
+        $this->manager->pause('emails');
+
+        $this->assertTrue($this->manager->isPaused('emails', 'redis'));
+        $this->assertFalse($this->manager->isPaused('emails', 'database'));
+    }
+
     public function testPauseQueueWithTTL()
     {
         $this->manager->pauseFor('default', 30, 'redis');


### PR DESCRIPTION
These hurt to use as an end user, as you end up having to do 

```php
Queue::pause(Queue::getDefaultDriver(), 'some-queue');
``` 

All of the queue facade methods that call the drivers  like `Queue::size()`... default the connection -  so this PR changes the params around and defaults the connection so its nicer in user land. 

The context here, is we allow our users to pause certain queues from within the application, so I have been calling these methods and it hurts. 

**This is a B/C so targeted master / 14.x**