### PR TITLE
[13.x] Clean up test teardown

### DIFF
--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Illuminate\Tests;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Lottery;
+use Illuminate\Support\Once;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
 use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
 
@@ -17,6 +22,12 @@ final class AfterEachTestSubscriber implements FinishedSubscriber
         }
 
         Carbon::setTestNow();
+        CarbonImmutable::setTestNow();
         date_default_timezone_set('UTC');
+
+        Str::resetFactoryState();
+        Sleep::fake(false);
+        Once::flush();
+        Lottery::determineResultNormally();
     }
 }

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -26,8 +26,6 @@ class CommandMutexTest extends TestCase
      */
     protected $commandMutex;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->command = new class extends Command implements Isolatable
@@ -47,8 +45,6 @@ class CommandMutexTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         $this->tearDownTheTestEnvironmentUsingMockery();

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -109,7 +109,6 @@ class DatabaseMigrationCreatorTest extends TestCase
             $this->assertSame($path.'/2026_07_13_144122_create_bs_table.php', $first);
             $this->assertSame($path.'/2026_07_13_144123_create_as_table.php', $second);
         } finally {
-            Carbon::setTestNow();
             $files->deleteDirectory($path);
         }
     }

--- a/tests/Integration/Cache/FailoverStoreTest.php
+++ b/tests/Integration/Cache/FailoverStoreTest.php
@@ -12,7 +12,6 @@ use Orchestra\Testbench\TestCase;
 #[WithConfig('cache.stores.array.serialize', false)]
 class FailoverStoreTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -28,8 +28,6 @@ class MemoizedStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -19,8 +19,6 @@ class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Database/Sqlite/Console/MigrateFreshCommandWithJournalModeWalTest.php
+++ b/tests/Integration/Database/Sqlite/Console/MigrateFreshCommandWithJournalModeWalTest.php
@@ -16,8 +16,6 @@ use function Orchestra\Testbench\default_skeleton_path;
 #[WithConfig('database.connections.sqlite.journal_mode', 'wal')]
 class MigrateFreshCommandWithJournalModeWalTest extends DatabaseTestCase
 {
-    /** {@inheritDoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $files = new Filesystem;

--- a/tests/Integration/Foundation/Console/ConfigPublishCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigPublishCommandTest.php
@@ -18,7 +18,6 @@ class ConfigPublishCommandTest extends TestCase
         'config-stubs/*.php',
     ];
 
-    #[\Override]
     protected function setUp(): void
     {
         $files = new Filesystem();

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -18,8 +18,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use LazilyRefreshDatabase;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         Model::shouldBeStrict(true);

--- a/tests/Integration/Log/ContextTest.php
+++ b/tests/Integration/Log/ContextTest.php
@@ -22,7 +22,6 @@ class ContextTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[\Override]
     protected function tearDown(): void
     {
         MyAddContextProcessor::$wasConstructed = false;

--- a/tests/Integration/Log/JsonFormatterTest.php
+++ b/tests/Integration/Log/JsonFormatterTest.php
@@ -17,7 +17,6 @@ use Throwable;
 
 final class JsonFormatterTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Mail/MarkdownParserTest.php
+++ b/tests/Integration/Mail/MarkdownParserTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class MarkdownParserTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         Markdown::flushState();

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -35,7 +35,6 @@ class DeleteModelWhenMissingTest extends QueueTestCase
         Schema::dropIfExists('delete_model_test_models');
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         DeleteMissingModelJob::$handled = false;

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -38,7 +38,6 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
         Schema::dropIfExists('delete_notification_test_models');
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         DeleteWhenMissingNotification::$sent = false;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -71,7 +71,6 @@ class ModelSerializationTest extends TestCase
         });
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         Relation::morphMap([], false);

--- a/tests/Integration/Queue/QueueTestCase.php
+++ b/tests/Integration/Queue/QueueTestCase.php
@@ -28,7 +28,6 @@ abstract class QueueTestCase extends TestCase
         $this->driver = $app['config']->get('queue.default', 'sync');
     }
 
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -33,8 +33,6 @@ class RedisQueueTest extends TestCase
      */
     private $container;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -27,8 +27,6 @@ class SerializableClosureV1CacheRouteTest extends TestCase
         ];
     }
 
-    /** {@inheritDoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $_ENV['APP_ROUTES_CACHE'] = realpath(join_paths(__DIR__, 'stubs', 'serializable-closure-v1', 'routes-v7.php'));
@@ -36,8 +34,6 @@ class SerializableClosureV1CacheRouteTest extends TestCase
         parent::setUp();
     }
 
-    /** {@inheritDoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -213,7 +213,7 @@ class ArtisanCommandTest extends TestCase
             ->expectsOutput()
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fail_if_doesnt_output_something_and_is_not_the_expected_output()
@@ -264,7 +264,7 @@ class ArtisanCommandTest extends TestCase
             ->expectsConfirmation('Do you want to continue?', true)
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_doesnt_expect_output_but_outputs_something()
@@ -275,7 +275,7 @@ class ArtisanCommandTest extends TestCase
             ->doesntExpectOutput()
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_doesnt_expect_output_and_does_expect_output()
@@ -287,7 +287,7 @@ class ArtisanCommandTest extends TestCase
             ->doesntExpectOutput('My name is Taylor Otwell')
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_the_output_does_not_contain()
@@ -320,6 +320,15 @@ class ArtisanCommandTest extends TestCase
                 }
             })
             ->assertExitCode(0);
+    }
+
+    /**
+     * Verify the PendingCommand mock expectations immediately, so an unmet
+     * expectation throws here and is caught by the test's expectException().
+     */
+    protected function verifyMockeryExpectationsNow(): void
+    {
+        m::close();
     }
 
     /**

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -18,8 +18,6 @@ use function Orchestra\Testbench\phpunit_version_compare;
 
 class BladeTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         artisan($this, 'view:clear');

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -8,11 +8,6 @@ use RuntimeException;
 
 class LotteryTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Lottery::determineResultNormally();
-    }
-
     public function testItCanWin()
     {
         $wins = false;

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -9,7 +9,6 @@ class OnceTest extends TestCase
 {
     protected function tearDown(): void
     {
-        Once::flush();
         Once::enable();
     }
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -14,11 +14,6 @@ use RuntimeException;
 
 class SleepTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Sleep::fake(false);
-    }
-
     public function testItSleepsForSeconds()
     {
         $start = microtime(true);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -14,13 +14,6 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
-    protected function tearDown(): void
-    {
-        Str::createRandomStringsNormally();
-    }
-
     public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));


### PR DESCRIPTION
Moves a few repeated per-test resets (Carbon/CarbonImmutable, Str random/uuid/ulid fakes, Sleep fake, Once cache, Lottery) into the existing AfterEachTestSubscriber instead of each test class doing it by hand. Also drops the `#[\Override]` attribute from the handful of setUp/tearDown methods that had it, since the rest of the suite doesn't use it.