### PR TITLE
[13.x] Use new Collection instead of Collection::make in tests

### DIFF
--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -31,7 +31,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
             ->makePartial()
             ->shouldAllowMockingProtectedMethods()
             ->shouldReceive('getArrayableRelations')->andReturn([
-                'arrayable_relation' => Collection::make(['foo' => 'bar']),
+                'arrayable_relation' => new Collection(['foo' => 'bar']),
                 'invalid_relation' => 'invalid',
                 'null_relation' => null,
             ])

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1493,7 +1493,7 @@ class ResourceTest extends TestCase
 
     public function testKeysArePreservedInAnAnonymousCollectionIfTheResourceIsFlaggedToPreserveKeys()
     {
-        $data = Collection::make([
+        $data = (new Collection([
             [
                 'id' => 1,
                 'authorId' => 5,
@@ -1509,7 +1509,7 @@ class ResourceTest extends TestCase
                 'authorId' => 42,
                 'bookId' => 12,
             ],
-        ])->keyBy->id;
+        ]))->keyBy->id;
 
         Route::get('/', function () use ($data) {
             return ResourceWithPreservedKeys::collection($data);
@@ -1526,10 +1526,10 @@ class ResourceTest extends TestCase
 
     public function testKeysArePreservedInAnAnonymousCollectionUsingPreserveKeysMethod()
     {
-        $data = Collection::make([
+        $data = (new Collection([
             ['id' => 1, 'title' => 'Test'],
             ['id' => 2, 'title' => 'Test 2'],
-        ])->keyBy->id;
+        ]))->keyBy->id;
 
         Route::get('/', function () use ($data) {
             return JsonResource::collection($data)->preserveKeys();

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -39,13 +39,13 @@ class SupportLazyCollectionTest extends TestCase
     {
         $array = [1, 2, 3];
 
-        $data = LazyCollection::make(Collection::make($array));
+        $data = LazyCollection::make(new Collection($array));
 
         $this->assertSame($array, $data->all());
 
         $array = ['a' => 1, 'b' => 2, 'c' => 3];
 
-        $data = LazyCollection::make(Collection::make($array));
+        $data = LazyCollection::make(new Collection($array));
 
         $this->assertSame($array, $data->all());
     }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -57,8 +57,8 @@ class SupportMessageBagTest extends TestCase
     public function testMessageBagsCanConvertToArrays()
     {
         $container = new MessageBag([
-            Collection::make(['foo', 'bar']),
-            Collection::make(['baz', 'qux']),
+            new Collection(['foo', 'bar']),
+            new Collection(['baz', 'qux']),
         ]);
         $this->assertSame([['foo', 'bar'], ['baz', 'qux']], $container->getMessages());
     }


### PR DESCRIPTION
Small consistency tweak — replaces `Collection::make()` calls with `new Collection()` in a handful of test files.