### PR TITLE
[13.x] Move Testbench-based tests to tests/Integration

### DIFF
--- a/tests/Integration/Log/ContextTest.php
+++ b/tests/Integration/Log/ContextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -152,8 +152,8 @@ class ContextTest extends TestCase
                 'array' => 'a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}',
                 'hash' => 'a:1:{s:3:"foo";s:3:"bar";}',
                 'object' => 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}',
-                'enum' => 'E:31:"Illuminate\Tests\Log\Suit:Clubs";',
-                'backed_enum' => 'E:43:"Illuminate\Tests\Log\StringBackedSuit:Clubs";',
+                'enum' => 'E:43:"Illuminate\Tests\Integration\Log\Suit:Clubs";',
+                'backed_enum' => 'E:55:"Illuminate\Tests\Integration\Log\StringBackedSuit:Clubs";',
             ],
             'hidden' => [
                 'number' => 'i:55;',

--- a/tests/Integration/Log/JsonFormatterTest.php
+++ b/tests/Integration/Log/JsonFormatterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;

--- a/tests/Integration/Log/LogManagerTest.php
+++ b/tests/Integration/Log/LogManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;

--- a/tests/Integration/Mail/MailFailoverTransportTest.php
+++ b/tests/Integration/Mail/MailFailoverTransportTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Orchestra\Testbench\TestCase;
-use Symfony\Component\Mailer\Transport\RoundRobinTransport;
+use Symfony\Component\Mailer\Transport\FailoverTransport;
 
-class MailRoundRobinTransportTest extends TestCase
+class MailFailoverTransportTest extends TestCase
 {
-    public function testGetRoundRobinTransportWithConfiguredTransports(): void
+    public function testGetFailoverTransportWithConfiguredTransports(): void
     {
-        $this->app['config']->set('mail.default', 'roundrobin');
+        $this->app['config']->set('mail.default', 'failover');
 
         $this->app['config']->set('mail.mailers', [
-            'roundrobin' => [
-                'transport' => 'roundrobin',
+            'failover' => [
+                'transport' => 'failover',
                 'mailers' => [
                     'sendmail',
                     'array',
@@ -31,12 +31,12 @@ class MailRoundRobinTransportTest extends TestCase
         ]);
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
+        $this->assertInstanceOf(FailoverTransport::class, $transport);
     }
 
-    public function testGetRoundRobinTransportWithLaravel6StyleMailConfiguration(): void
+    public function testGetFailoverTransportWithLaravel6StyleMailConfiguration(): void
     {
-        $this->app['config']->set('mail.driver', 'roundrobin');
+        $this->app['config']->set('mail.driver', 'failover');
 
         $this->app['config']->set('mail.mailers', [
             'sendmail',
@@ -46,6 +46,6 @@ class MailRoundRobinTransportTest extends TestCase
         $this->app['config']->set('mail.sendmail', '/usr/sbin/sendmail -bs');
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
+        $this->assertInstanceOf(FailoverTransport::class, $transport);
     }
 }

--- a/tests/Integration/Mail/MailLogTransportTest.php
+++ b/tests/Integration/Mail/MailLogTransportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Message;

--- a/tests/Integration/Mail/MailManagerTest.php
+++ b/tests/Integration/Mail/MailManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use InvalidArgumentException;
 use Orchestra\Testbench\Attributes\WithConfig;

--- a/tests/Integration/Mail/MailRoundRobinTransportTest.php
+++ b/tests/Integration/Mail/MailRoundRobinTransportTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Orchestra\Testbench\TestCase;
-use Symfony\Component\Mailer\Transport\FailoverTransport;
+use Symfony\Component\Mailer\Transport\RoundRobinTransport;
 
-class MailFailoverTransportTest extends TestCase
+class MailRoundRobinTransportTest extends TestCase
 {
-    public function testGetFailoverTransportWithConfiguredTransports(): void
+    public function testGetRoundRobinTransportWithConfiguredTransports(): void
     {
-        $this->app['config']->set('mail.default', 'failover');
+        $this->app['config']->set('mail.default', 'roundrobin');
 
         $this->app['config']->set('mail.mailers', [
-            'failover' => [
-                'transport' => 'failover',
+            'roundrobin' => [
+                'transport' => 'roundrobin',
                 'mailers' => [
                     'sendmail',
                     'array',
@@ -31,12 +31,12 @@ class MailFailoverTransportTest extends TestCase
         ]);
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(FailoverTransport::class, $transport);
+        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
     }
 
-    public function testGetFailoverTransportWithLaravel6StyleMailConfiguration(): void
+    public function testGetRoundRobinTransportWithLaravel6StyleMailConfiguration(): void
     {
-        $this->app['config']->set('mail.driver', 'failover');
+        $this->app['config']->set('mail.driver', 'roundrobin');
 
         $this->app['config']->set('mail.mailers', [
             'sendmail',
@@ -46,6 +46,6 @@ class MailFailoverTransportTest extends TestCase
         $this->app['config']->set('mail.sendmail', '/usr/sbin/sendmail -bs');
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(FailoverTransport::class, $transport);
+        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
     }
 }

--- a/tests/Integration/Pipeline/PipelineTransactionTest.php
+++ b/tests/Integration/Pipeline/PipelineTransactionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Pipeline;
+namespace Illuminate\Tests\Integration\Pipeline;
 
 use Exception;
 use Illuminate\Database\Events\TransactionBeginning;

--- a/tests/Integration/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Integration/Queue/FailOnExceptionMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;

--- a/tests/Integration/Queue/QueueDelayTest.php
+++ b/tests/Integration/Queue/QueueDelayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Integration/Queue/QueueSizeTest.php
+++ b/tests/Integration/Queue/QueueSizeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Integration/Support/StorageFacadeTest.php
+++ b/tests/Integration/Support/StorageFacadeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;

--- a/tests/Integration/Support/SupportMailTest.php
+++ b/tests/Integration/Support/SupportMailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;

--- a/tests/Integration/Support/SupportMaintenanceModeTest.php
+++ b/tests/Integration/Support/SupportMaintenanceModeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Support\Facades\MaintenanceMode;

--- a/tests/Integration/View/ClearCommandTest.php
+++ b/tests/Integration/View/ClearCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\View;
+namespace Illuminate\Tests\Integration\View;
 
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;


### PR DESCRIPTION
These tests extend `Orchestra\Testbench\TestCase` but lived outside `tests/Integration/`. Moved them to match where the rest of the Testbench-backed test suite lives, no behavior changes.