### PR TITLE
[13.x] Restore schedule group state when definition throws

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -337,9 +337,11 @@ class Schedule
         $this->groupStack[] = $this->attributes;
         $this->attributes = null;
 
-        $events($this);
-
-        array_pop($this->groupStack);
+        try {
+            $events($this);
+        } finally {
+            array_pop($this->groupStack);
+        }
     }
 
     /**

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -28,6 +28,23 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('0 0 * * *', $events[0]->expression);
     }
 
+    public function testGroupAttributesDoNotLeakAfterDefinitionException()
+    {
+        $schedule = new ScheduleClass;
+
+        try {
+            $schedule->daily()->group(function () {
+                throw new \RuntimeException;
+            });
+        } catch (\RuntimeException) {
+            // Continue registering unrelated scheduled tasks.
+        }
+
+        $schedule->command('inspire');
+
+        $this->assertSame('* * * * *', $schedule->events()[0]->expression);
+    }
+
     public function testGroupedScheduleCanOverrideGroupCronExpression()
     {
         Schedule::daily()->group(function () {


### PR DESCRIPTION
## Description

  Ensures `Schedule::group()` restores its internal group stack when the group-definition callback throws.

  Previously, if an application caught an exception while defining a schedule group and continued registering tasks, the failed group’s attributes could leak to later unrelated tasks. For example, commands defined after a failed `Schedule::daily()->group(...)` could incorrectly inherit the daily cron expression.

  This change wraps the group callback in a `try/finally` block so the internal state is always cleaned up.

## Testing

  - Added a regression test covering a caught exception during schedule group definition.
  - `./vendor/bin/phpunit tests/Integration/Console/Scheduling/ScheduleGroupTest.php --no-coverage`
  - `  ./vendor/bin/phpunit \
    tests/Console/ConfiguresPromptsTest.php \
    tests/Console/ConsoleApplicationTest.php \
    tests/Process/ProcessTest.php \
    --no-coverage`