### PR TITLE
[13.x] Preserve default denial response for Gate::forUser

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -858,7 +858,7 @@ class Gate implements GateContract
      */
     public function forUser($user)
     {
-        return new static(
+        $gate = new static(
             $this->container,
             fn () => $user,
             $this->abilities,
@@ -867,6 +867,10 @@ class Gate implements GateContract
             $this->afterCallbacks,
             $this->guessPolicyNamesUsingCallback,
         );
+
+        $gate->defaultDenialResponse = $this->defaultDenialResponse;
+
+        return $gate;
     }
 
     /**

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -638,6 +638,20 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame(3, $counter);
     }
 
+    public function testForUserMethodPreservesDefaultDenialResponse()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('view-secret', fn () => false);
+        $gate->defaultDenialResponse(Response::denyAsNotFound('Not found'));
+
+        $response = $gate->forUser((object) ['id' => 2])->inspect('view-secret');
+
+        $this->assertTrue($response->denied());
+        $this->assertSame('Not found', $response->message());
+        $this->assertSame(404, $response->status());
+    }
+
     #[DataProvider('notCallableDataProvider')]
     public function testDefineSecondParameterShouldBeStringOrCallable($callback)
     {


### PR DESCRIPTION
## Description

This PR ensures that `Gate::forUser()` preserves the Gate instance’s configured default denial response.

When an application configures a default denial response—for example, `Response::denyAsNotFound()` to avoid revealing whether a resource exists—authorization checks performed through `Gate::forUser($user)` currently lose that configuration. The derived Gate falls back to Laravel’s default denial response instead.

The issue occurs because `forUser()` copies the parent Gate’s abilities, policies, callbacks, and policy-name guesser,
but not its default denial response.

This change copies the configured default denial response to the Gate instance created for the specified user.


## Testing

- Added a regression test confirming `forUser()` preserves a configured not-found denial response.
- `./vendor/bin/phpunit tests/Auth/AuthAccessGateTest.php --no-coverage`
- `./vendor/bin/phpunit tests/Auth tests/Integration/Auth tests/Session/Middleware/AuthenticateSessionTest.php --no-coverage`