### PR TITLE
[13x] Alignment of Soft Delete for Pivot Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -126,11 +126,15 @@ trait AsPivot
     /**
      * Delete the pivot model record from the database.
      *
+     * Soft deletable pivots defer to the parent implementation so that the
+     * "deleted at" column, the model's own state, and force deletes are
+     * all handled by the soft deleting trait.
+     *
      * @return int
      */
     public function delete()
     {
-        if (isset($this->attributes[$this->getKeyName()])) {
+        if (isset($this->attributes[$this->getKeyName()]) || static::isSoftDeletable()) {
             return (int) parent::delete();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -51,11 +51,14 @@ class MorphPivot extends Pivot
     /**
      * Delete the pivot model record from the database.
      *
+     * Soft deletable pivots defer to the parent implementation, which keys the
+     * delete by the morph type via "setKeysForSelectQuery".
+     *
      * @return int
      */
     public function delete()
     {
-        if (isset($this->attributes[$this->getKeyName()])) {
+        if (isset($this->attributes[$this->getKeyName()]) || static::isSoftDeletable()) {
             return (int) parent::delete();
         }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
@@ -128,6 +129,22 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals(1, $rowsAffected);
     }
 
+    public function testDeleteMethodDefersToTheParentForSoftDeletablePivots()
+    {
+        $pivot = $this->getMockBuilder(DatabaseEloquentPivotTestSoftDeletingStub::class)
+            ->onlyMethods(['newQueryWithoutRelationships', 'performDeleteOnModel'])
+            ->getMock();
+        $pivot->setPivotKeys('foreign', 'other');
+        $pivot->foreign = 'foreign.value';
+        $pivot->other = 'other.value';
+        $pivot->exists = true;
+        $pivot->expects($this->never())->method('newQueryWithoutRelationships');
+        $pivot->expects($this->once())->method('performDeleteOnModel');
+
+        $rowsAffected = $pivot->delete();
+        $this->assertSame(1, $rowsAffected);
+    }
+
     public function testPivotModelTableNameIsSingular()
     {
         $pivot = new Pivot;
@@ -214,6 +231,11 @@ class DatabaseEloquentPivotTestJsonCastStub extends Pivot
     protected $casts = [
         'foo' => 'json',
     ];
+}
+
+class DatabaseEloquentPivotTestSoftDeletingStub extends Pivot
+{
+    use SoftDeletes;
 }
 
 class DummyModel extends Model

--- a/tests/Database/DatabaseEloquentSoftDeletingPivotTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletingPivotTest.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentSoftDeletingPivotTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->setEventDispatcher(new Dispatcher);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function createSchema()
+    {
+        $this->schema()->create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('post_tag', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        $this->schema()->create('taggables', function ($table) {
+            $table->increments('id');
+            $table->integer('tag_id');
+            $table->integer('taggable_id');
+            $table->string('taggable_type');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('posts');
+        $this->schema()->drop('tags');
+        $this->schema()->drop('post_tag');
+        $this->schema()->drop('taggables');
+
+        Eloquent::unsetEventDispatcher();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Tests...
+     */
+    public function testDeleteSoftDeletesTheUnderlyingRow()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $post->tags->first()->pivot->delete();
+
+        $this->assertNotNull($this->pivotRow()->deleted_at);
+    }
+
+    public function testDeleteSynchronizesTheStateOfTheModelInstance()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $pivot = $post->tags->first()->pivot;
+        $pivot->delete();
+
+        $this->assertNotNull($pivot->deleted_at);
+        $this->assertTrue($pivot->trashed());
+        $this->assertTrue($pivot->exists);
+        $this->assertNotNull($pivot->updated_at);
+    }
+
+    public function testDeleteReturnsTheNumberOfAffectedRows()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $this->assertSame(1, $post->tags->first()->pivot->delete());
+    }
+
+    public function testDeleteFiresTheSoftDeletedEvent()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $fired = false;
+
+        SoftDeletingPivotTestPostTag::softDeleted(function () use (&$fired) {
+            $fired = true;
+        });
+
+        $post->tags->first()->pivot->delete();
+
+        $this->assertTrue($fired);
+    }
+
+    public function testForceDeleteRemovesTheUnderlyingRow()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $post->tags->first()->pivot->forceDelete();
+
+        $this->assertNull($this->pivotRow());
+    }
+
+    public function testRestoreClearsTheDeletedAtColumn()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $pivot = $post->tags->first()->pivot;
+        $pivot->delete();
+        $pivot->restore();
+
+        $this->assertFalse($pivot->trashed());
+        $this->assertNull($this->pivotRow()->deleted_at);
+    }
+
+    public function testDetachSoftDeletesThePivotRow()
+    {
+        [$post, $tag] = $this->createPostWithTag();
+
+        $post->tags()->detach($tag->id);
+
+        $this->assertNotNull($this->pivotRow()->deleted_at);
+    }
+
+    public function testPivotsWithoutSoftDeletesStillHardDelete()
+    {
+        [$post] = $this->createPostWithTag();
+
+        $rowsAffected = $post->plainTags->first()->pivot->delete();
+
+        $this->assertSame(1, $rowsAffected);
+        $this->assertNull($this->pivotRow());
+    }
+
+    public function testMorphPivotDeleteSoftDeletesTheUnderlyingRow()
+    {
+        [$post] = $this->createPostWithMorphedTag();
+
+        $pivot = $post->morphedTags->first()->pivot;
+        $pivot->delete();
+
+        $this->assertNotNull($this->connection()->table('taggables')->first()->deleted_at);
+        $this->assertTrue($pivot->trashed());
+    }
+
+    public function testMorphPivotForceDeleteRemovesTheUnderlyingRow()
+    {
+        [$post] = $this->createPostWithMorphedTag();
+
+        $post->morphedTags->first()->pivot->forceDelete();
+
+        $this->assertSame(0, $this->connection()->table('taggables')->count());
+    }
+
+    public function testMorphPivotDeleteIsScopedToTheMorphType()
+    {
+        [$post] = $this->createPostWithMorphedTag();
+
+        $this->connection()->table('taggables')->insert([
+            'tag_id' => 1,
+            'taggable_id' => 1,
+            'taggable_type' => SoftDeletingPivotTestTag::class,
+        ]);
+
+        $post->morphedTags->first()->pivot->delete();
+
+        $this->assertSame(1, $this->connection()->table('taggables')
+            ->whereNull('deleted_at')
+            ->where('taggable_type', SoftDeletingPivotTestTag::class)
+            ->count());
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function createPostWithTag()
+    {
+        $post = SoftDeletingPivotTestPost::create(['title' => 'post']);
+        $tag = SoftDeletingPivotTestTag::create(['name' => 'tag']);
+
+        $post->tags()->attach($tag);
+
+        return [$post->load('tags', 'plainTags'), $tag];
+    }
+
+    protected function createPostWithMorphedTag()
+    {
+        $post = SoftDeletingPivotTestPost::create(['title' => 'post']);
+        $tag = SoftDeletingPivotTestTag::create(['name' => 'tag']);
+
+        $post->morphedTags()->attach($tag);
+
+        return [$post->load('morphedTags'), $tag];
+    }
+
+    protected function pivotRow()
+    {
+        return $this->connection()->table('post_tag')->first();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class SoftDeletingPivotTestPost extends Eloquent
+{
+    protected $table = 'posts';
+    protected $guarded = [];
+
+    public function tags()
+    {
+        return $this->belongsToMany(SoftDeletingPivotTestTag::class, 'post_tag', 'post_id', 'tag_id')
+            ->using(SoftDeletingPivotTestPostTag::class)
+            ->withTimestamps();
+    }
+
+    public function plainTags()
+    {
+        return $this->belongsToMany(SoftDeletingPivotTestTag::class, 'post_tag', 'post_id', 'tag_id')
+            ->using(SoftDeletingPivotTestPlainPostTag::class)
+            ->withTimestamps();
+    }
+
+    public function morphedTags()
+    {
+        return $this->morphToMany(SoftDeletingPivotTestTag::class, 'taggable', 'taggables', 'taggable_id', 'tag_id')
+            ->using(SoftDeletingPivotTestTaggable::class)
+            ->withTimestamps();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class SoftDeletingPivotTestTag extends Eloquent
+{
+    protected $table = 'tags';
+    protected $guarded = [];
+}
+
+/**
+ * Eloquent Models...
+ */
+class SoftDeletingPivotTestPostTag extends Pivot
+{
+    use SoftDeletes;
+
+    protected $table = 'post_tag';
+}
+
+/**
+ * Eloquent Models...
+ */
+class SoftDeletingPivotTestPlainPostTag extends Pivot
+{
+    protected $table = 'post_tag';
+}
+
+/**
+ * Eloquent Models...
+ */
+class SoftDeletingPivotTestTaggable extends MorphPivot
+{
+    use SoftDeletes;
+
+    protected $table = 'taggables';
+}


### PR DESCRIPTION
**Before**: Using `forceDelete()` on a pivot model with `SoftDeletes` silently fails and leaves the model in the database.
**After**: Soft deleting pivot models correctly defer to `parent::delete()` and the model is really deleted, so the pivot models now align with all models when using `SoftDeletes`

No B/C because any devs that currently use pivots + softDeletes need to write custom eloquent queries that do all the work currently not being done by the relationships.

<details>

## Summary

A pivot model that uses `SoftDeletes` doesn't go through the soft deleting trait when it's deleted. Most visibly, **`forceDelete()` is a silent no-op** where it soft deletes the row and returns as if it had removed it.

This only affects pivots hydrated from a relation (`$post->tags->first()->pivot`), because `belongsToMany` selects only the pivot key columns, so `id` isn't among the attributes. Pivots loaded with `withPivot('id')`, or through `detach()`, already take the correct path.

## Cause

`AsPivot::delete()` bypasses `Model::delete()` entirely whenever the primary key isn't among the loaded attributes, so `performDeleteOnModel()` (and therefore `SoftDeletes::runSoftDelete()`) is never reached. `SoftDeletes::forceDelete()` sets `$forceDeleting` and then calls `$this->delete()`, which lands in `AsPivot::delete()`, a method that has **no knowledge of that flag**.

## Fix

`AsPivot::delete()` exists only to key the delete on the foreign key pair rather than the primary key. But `AsPivot::setKeysForSaveQuery()` already does exactly that, and both `performDeleteOnModel()` and `runSoftDelete()` route through it. So for a soft deletable pivot, plain `Model::delete()` is already correct, it simply isn't reached.

One `||` condition is required, in `AsPivot::delete()` and `MorphPivot::delete()`:

```php
if (isset($this->attributes[$this->getKeyName()]) || static::isSoftDeletable()) {
    return (int) parent::delete();
}
```

- `MorphPivot` needs no extra where: its `setKeysForSelectQuery()` already appends the morph type constraint, and `setKeysForSaveQuery()` defers to it, so the constraint survives the delegation. There's a test asserting this.
- re-deleting an already trashed pivot now refreshes deleted_at. `runSoftDelete()` uses the unscoped `newModelQuery()`, whereas the old path used the scoped `newQueryWithoutRelationships()` and matched zero rows. This matches how every other `SoftDeletes` model behaves.

</details>

## In Practice

The codebase I work on daily requires the convention of using Models + SoftDeletes to serve as Pivot models so that changes to relationships can be tracked and reported. It is a hard business requirement. We currently need to write and maintain multiple complex join queries which are concerned with the `deleted_at` columns to work with the relationships which go through these pivot models and we cannot apply the `AsPivot` trait because it prevents proper deletion. 

Having this proposed change would allow us to greatly simplify our implementations and unlock the other benefits of using real pivot models.

## Follow up

- `getCurrentlyAttachedPivotsForIds()` uses the raw `newPivotQuery()`, so `sync()` still counts trashed pivot rows as attached. Addressing that means giving `attach()` restore semantics too.