### PR TITLE
[13.x] Updated typehints for Support\Collection and Support\LazyCollection methods

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -790,6 +790,7 @@ class Arr
     /**
      * Pluck an array of values from an array.
      * 
+     * 
      * @template TKey of array-key
      * @template TValue of mixed
      * @template TPluckedItem of mixed

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -286,7 +286,7 @@ class Arr
      * @template TFirstDefault
      *
      * @param  iterable<TKey, TValue>  $array
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
@@ -789,17 +789,23 @@ class Arr
 
     /**
      * Pluck an array of values from an array.
+     * 
+     * @template TKey of array-key
+     * @template TValue of mixed
+     * @template TPluckedItem of mixed
+     * @template TPluckedKey of array-key
      *
-     * @param  iterable  $array
-     * @param  string|array|int|Closure|null  $value
-     * @param  string|array|Closure|null  $key
-     * @return array
+     * @param  iterable<TKey,TValue>  $array
+     * @param  (Closure(TValue):TPluckedItem)|array<array-key,string>|string|int|null  $value
+     * @param  (Closure(TValue):TPluckedKey)|array<array-key,string>|string|int|null  $key
+     * @return array<TPluckedKey ,TPluckedItem>
      */
     public static function pluck($array, $value, $key = null)
     {
         $results = [];
 
-        [$value, $key] = static::explodePluckParameters($value, $key);
+        $value = is_string($value) ? explode('.', $value) : $value;
+        $key = is_string($key) ? explode('.', $key) : $key;
 
         foreach ($array as $item) {
             $itemValue = $value instanceof Closure
@@ -832,7 +838,7 @@ class Arr
      *
      * @param  Closure|array|string  $value
      * @param  string|array|Closure|null  $key
-     * @return array
+     * @return array<int<0, 1>, mixed>
      */
     protected static function explodePluckParameters($value, $key)
     {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -789,8 +789,7 @@ class Arr
 
     /**
      * Pluck an array of values from an array.
-     * 
-     * 
+     *
      * @template TKey of array-key
      * @template TValue of mixed
      * @template TPluckedItem of mixed

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -208,7 +208,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|array-key  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key $key
      * @param  TValue|null  $value
      * @return bool
      */
@@ -228,7 +228,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item is not contained in the collection.
      *
-     * @param  mixed  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -241,9 +241,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item is not contained in the enumerable, using strict comparison.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key $key
+     * @param  TValue|null  $value
      * @return bool
      */
     public function doesntContainStrict($key, $operator = null, $value = null)
@@ -632,7 +631,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|null  $value
+     * @param  (callable(TValue, TKey): mixed)|(callable(TValue): mixed)|string|null  $value
      * @param  string|null  $glue
      * @return string
      */
@@ -728,6 +727,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
+     * 
+     * @phpstan-assert-if-true =TValue $this->first()
+     * @phpstan-assert-if-true =TValue $this->last()
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @return bool
@@ -741,6 +743,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains multiple items.
+     * 
+     * @phpstan-assert-if-true =TValue $this->first()
+     * @phpstan-assert-if-true =TValue $this->last()
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @return bool
@@ -794,7 +799,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get the last item from the collection.
-     *
+     * 
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
@@ -808,10 +813,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get the values of a given key.
+     * 
+     * @template TPluckedItem of mixed
+     * @template TPluckedKey of array-key
      *
-     * @param  \Closure|(callable(TValue):mixed)|string|int|array<array-key, string>|null  $value
-     * @param  \Closure|string|null  $key
-     * @return static<array-key, mixed>
+     * @param  (\Closure(TValue):TPluckedItem)|array<array-key,string>|string|int|null  $value
+     * @param  (\Closure(TValue):TPluckedKey)|array<array-key,string>|string|int|null  $key
+     * @return static<TPluckedKey, TPluckedItem>
      */
     public function pluck($value, $key = null)
     {
@@ -1465,6 +1473,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains a single item, optionally matching the given criteria.
+     * 
+     * @phpstan-assert-if-true =TValue $this->first()
+     * @phpstan-assert-if-true =TValue $this->last()
+     * @phpstan-assert-if-true =false $this->isEmpty()
+     * @phpstan-assert-if-true =true $this->isNotEmpty()
+     *
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|string|null  $key
      * @param  mixed  $operator

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -727,8 +727,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
-     * 
-     * 
+     *
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
      *
@@ -744,8 +743,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains multiple items.
-     * 
-     * 
+     *
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
      *
@@ -801,8 +799,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get the last item from the collection.
-     * 
-     * 
+     *
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
@@ -816,8 +813,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get the values of a given key.
-     * 
-     * 
+     *
      * @template TPluckedItem of mixed
      * @template TPluckedKey of array-key
      *
@@ -1477,8 +1473,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains a single item, optionally matching the given criteria.
-     * 
-     * 
+     *
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
      * @phpstan-assert-if-true =false $this->isEmpty()

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -208,7 +208,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */
@@ -241,7 +241,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item is not contained in the enumerable, using strict comparison.
      *
-     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */
@@ -728,6 +728,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
      * 
+     * 
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
      *
@@ -743,6 +744,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Determine if the collection contains multiple items.
+     * 
      * 
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
@@ -800,6 +802,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the last item from the collection.
      * 
+     * 
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
@@ -813,6 +816,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get the values of a given key.
+     * 
      * 
      * @template TPluckedItem of mixed
      * @template TPluckedKey of array-key
@@ -1474,11 +1478,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection contains a single item, optionally matching the given criteria.
      * 
+     * 
      * @phpstan-assert-if-true =TValue $this->first()
      * @phpstan-assert-if-true =TValue $this->last()
      * @phpstan-assert-if-true =false $this->isEmpty()
      * @phpstan-assert-if-true =true $this->isNotEmpty()
-     *
      *
      * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|string|null  $key
      * @param  mixed  $operator

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -819,7 +819,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (\Closure(TValue):TPluckedItem)|array<array-key,string>|string|int|null  $value
      * @param  (\Closure(TValue):TPluckedKey)|array<array-key,string>|string|int|null  $key
-     * @return static<($value is \Closure ? TPluckedKey : array-key), ($value is \Closure ? TPluckedItem : mixed)>
+     * @return static<($key is \Closure ? TPluckedKey : array-key), ($value is \Closure ? TPluckedItem : mixed)>
      */
     public function pluck($value, $key = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -819,7 +819,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (\Closure(TValue):TPluckedItem)|array<array-key,string>|string|int|null  $value
      * @param  (\Closure(TValue):TPluckedKey)|array<array-key,string>|string|int|null  $key
-     * @return static<TPluckedKey, TPluckedItem>
+     * @return static<($value is \Closure ? TPluckedKey : array-key), ($value is \Closure ? TPluckedItem : mixed)>
      */
     public function pluck($value, $key = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -187,7 +187,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -418,7 +418,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Run a filter over each of the items.
      *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @return static
      */
     public function filter(?callable $callback = null)
@@ -435,7 +435,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TFirstDefault
      *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
@@ -729,7 +729,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
      *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @return bool
      *
      * @deprecated 12.49.0 Use the `hasSole()` method instead.
@@ -742,7 +742,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection contains multiple items.
      *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @return bool
      *
      * @deprecated 12.50.0 Use the `hasMany()` method instead.
@@ -797,7 +797,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TLastDefault
      *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|null  $callback
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
@@ -809,7 +809,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  \Closure|string|int|array<array-key, string>|null  $value
+     * @param  \Closure|(callable(TValue):mixed)|string|int|array<array-key, string>|null  $value
      * @param  \Closure|string|null  $key
      * @return static<array-key, mixed>
      */
@@ -823,7 +823,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TMapValue
      *
-     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @param  (callable(TValue, TKey): TMapValue)|(callable(TValue): TMapValue)  $callback
      * @return static<TKey, TMapValue>
      */
     public function map(callable $callback)
@@ -1434,7 +1434,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue
@@ -1466,7 +1466,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection contains a single item, optionally matching the given criteria.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -1486,7 +1486,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -189,7 +189,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  string|array<string>|null  $key
+     * @param  string|array<array-key, string>|null  $key
      * @return array<int, float|int>|null
      */
     public function mode($key = null)
@@ -236,7 +236,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if an item exists in the enumerable.
      *
-     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -294,7 +294,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if an item is not contained in the enumerable.
      *
-     * @param  mixed  $key
+     * @param  (callable(TValue, TKey): bool)|(callable(TValue): bool)|TValue|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1116,7 +1116,7 @@ trait EnumeratesValues
      * @param  callable|string  $key
      * @param  string|null  $operator
      * @param  mixed  $value
-     * @return \Closure
+     * @return \Closure(TValue):bool|int<-1,1>
      */
     protected function operatorForWhere($key, $operator = null, $value = null)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -936,11 +936,11 @@ assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::ma
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string', 'string'));
 
 assertType('Illuminate\Support\Collection<string, string>',
-    $collection::make([['string' => 'string', 'key' => 'test']])->pluck(fn($item) => $item['string'], fn ($item) => $item['key'])
+    $collection::make([['string' => 'string', 'key' => 'test']])->pluck(fn ($item) => $item['string'], fn ($item) => $item['key'])
 );
 
-assertType('Illuminate\Support\Collection<(int|string), string>', $collection::make([['string' => 'string']])->pluck(fn($item) => $item['string']));
-assertType('Illuminate\Support\Collection<(int|string), array{string: string}>', $collection::make([['string' => 'string']])->pluck(fn($item) => $item));
+assertType('Illuminate\Support\Collection<(int|string), string>', $collection::make([['string' => 'string']])->pluck(fn ($item) => $item['string']));
+assertType('Illuminate\Support\Collection<(int|string), array{string: string}>', $collection::make([['string' => 'string']])->pluck(fn ($item) => $item));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(new User));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -935,9 +935,8 @@ assertType('User', $collection->pipeInto(User::class));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string'));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string', 'string'));
 
-
-assertType('Illuminate\Support\Collection<(string, string>', 
-    $collection::make([['string' => 'string', 'key' => 'test']])->pluck(fn ($item) => $item['string'], fn ($item) => $item['key'])
+assertType('Illuminate\Support\Collection<string, string>',
+    $collection::make([['string' => 'string', 'key' => 'test']])->pluck(fn($item) => $item['string'], fn ($item) => $item['key'])
 );
 
 assertType('Illuminate\Support\Collection<(int|string), string>', $collection::make([['string' => 'string']])->pluck(fn($item) => $item['string']));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -935,6 +935,14 @@ assertType('User', $collection->pipeInto(User::class));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string'));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string', 'string'));
 
+
+assertType('Illuminate\Support\Collection<(string, string>', 
+    $collection::make([['string' => 'string', 'key' => 'test']])->pluck(fn ($item) => $item['string'], fn ($item) => $item['key'])
+);
+
+assertType('Illuminate\Support\Collection<(int|string), string>', $collection::make([['string' => 'string']])->pluck(fn($item) => $item['string']));
+assertType('Illuminate\Support\Collection<(int|string), array{string: string}>', $collection::make([['string' => 'string']])->pluck(fn($item) => $item));
+
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(function ($user) {


### PR DESCRIPTION
This PR improves typehints and output of static analysis tools.

changes done: 
- extended generic types if possible
- correct current types according to underlying functions
- simplify conversion in Arr::pluck to better reflect the similarity of $value and $key