### PR TITLE
Use serve defaults for dev command

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -55,7 +55,7 @@ class DevCommands
             return;
         }
 
-        self::artisan('serve --host=localhost', 'server');
+        self::artisan('serve', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
 
         if (function_exists('pcntl_fork')) {

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -302,6 +302,7 @@ class FoundationDevCommandsTest extends TestCase
 
         $names = array_column($commands, 'name');
         $this->assertContains('server', $names);
+        $this->assertSame('php artisan serve', collect($commands)->firstWhere('name', 'server')['command']);
         $this->assertContains('queue', $names);
         $this->assertContains('logs', $names);
         $this->assertContains('vite', $names);


### PR DESCRIPTION
# Use the `serve` command defaults for `artisan dev`

Laravel's previous default `composer dev` script started the development server with:

```shell
php artisan serve
```

This allowed `ServeCommand` to determine the host from `SERVER_HOST`, falling back to `127.0.0.1`. For example, applications could expose the development server to their local network with:

```shell
SERVER_HOST=0.0.0.0 composer dev
```

This regression became part of the default application skeleton in [laravel/laravel#6849](https://github.com/laravel/laravel/pull/6849), merged on August 3, 2026. That pull request replaced the existing `npx concurrently` script with `@php artisan dev` with the intention of preserving the same day-to-day behavior.

However, `Illuminate\Foundation\DevCommands::registerDefaults()` registers the server process with an explicit host:

```php
self::artisan('serve --host=localhost', 'server');
```

`DevCommands::artisan()` prefixes this value with `php artisan`, producing `php artisan serve --host=localhost`. Because the command-line option takes precedence over `ServeCommand`'s environment-based default, `SERVER_HOST` is ignored. Running the example above still starts the server on `localhost`, even though running `SERVER_HOST=0.0.0.0 php artisan serve` directly works as expected.

This pull request removes the explicit host from the default development command so that `artisan dev` starts the server with `php artisan serve`, matching the previous Composer script. The default remains a loopback address through `ServeCommand`, while applications can once again use `SERVER_HOST` when they need a different binding.

A regression assertion verifies that the registered server process does not add its own host option.
