### PR TITLE
[13.x] Keep Eloquent on the direct connection during migrations

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1494,6 +1494,22 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the connection name that resolves back to this same connection.
+     *
+     * The read and write suffixes collapse to the base name so models resolved
+     * from a replica may still be written, while the "direct" suffix is kept
+     * so the name does not resolve back to the pooled connection.
+     *
+     * @return string|null
+     */
+    public function getNameWithDirectType()
+    {
+        return $this->readWriteType === 'direct'
+            ? $this->getNameWithReadWriteType()
+            : $this->getName();
+    }
+
+    /**
      * Get an option from the configuration options.
      *
      * @param  string|null  $option

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1791,7 +1791,7 @@ class Builder implements BuilderContract
         $attributes = array_merge($this->pendingAttributes, $attributes);
 
         return $this->model->newInstance($attributes)->setConnection(
-            $this->query->getConnection()->getName()
+            $this->query->getConnection()->getNameWithDirectType()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -373,7 +373,7 @@ abstract class Factory
     {
         $results->each(function ($model) {
             if (! isset($this->connection)) {
-                $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getName());
+                $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getNameWithDirectType());
             }
 
             $model->save();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1408,7 +1408,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
             if (! $this->getConnectionName() &&
                 $connection = $query->getConnection()) {
-                $this->setConnection($connection->getName());
+                $this->setConnection($connection->getNameWithDirectType());
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -204,7 +204,7 @@ class MorphTo extends BelongsTo
 
         return tap(new $class, function ($instance) {
             if (! $instance->getConnectionName()) {
-                $instance->setConnection($this->getConnection()->getName());
+                $instance->setConnection($this->getConnection()->getNameWithDirectType());
             }
         });
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -824,6 +824,30 @@ class DatabaseConnectionTest extends TestCase
         $this->assertSame('pgsql::direct', $connection->getNameWithReadWriteType());
     }
 
+    public function testNameWithDirectTypeKeepsTheDirectSuffix()
+    {
+        $connection = new Connection(new DatabaseConnectionTestMockPDO, 'database', '', [
+            'name' => 'pgsql',
+        ]);
+
+        $connection->setReadWriteType('direct');
+
+        $this->assertSame('pgsql::direct', $connection->getNameWithDirectType());
+    }
+
+    public function testNameWithDirectTypeCollapsesReadAndWriteTypes()
+    {
+        $connection = new Connection(new DatabaseConnectionTestMockPDO, 'database', '', [
+            'name' => 'pgsql',
+        ]);
+
+        foreach ([null, 'read', 'write'] as $readWriteType) {
+            $connection->setReadWriteType($readWriteType);
+
+            $this->assertSame('pgsql', $connection->getNameWithDirectType());
+        }
+    }
+
     public function testQueryExceptionContainsDirectConnectionDetailsWhenUsingDirectConnection()
     {
         $directPdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -37,7 +37,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             [456],
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()->expects('insert')->with(
             'insert into "related_table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)',
@@ -69,7 +69,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $sql = 'insert into "related_table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)';
         $bindings = ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
@@ -117,7 +117,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()
             ->expects('select')
@@ -162,7 +162,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $sql = 'insert into "related_table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)';
         $bindings = ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
@@ -234,7 +234,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()
             ->expects('select')
@@ -319,7 +319,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()
             ->expects('select')
@@ -429,7 +429,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()
             ->expects('update')
@@ -536,7 +536,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'SQLite',
         );
         $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $source->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $source->getConnection()
             ->expects('update')

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -28,7 +28,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()->expects('insert')->with(
             'insert into "table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)',
@@ -51,7 +51,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $sql = 'insert into "table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)';
         $bindings = ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
@@ -88,7 +88,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -117,7 +117,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -145,7 +145,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -187,7 +187,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -224,7 +224,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -252,7 +252,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -302,7 +302,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -344,7 +344,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -372,7 +372,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -416,7 +416,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -472,7 +472,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -500,7 +500,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -531,7 +531,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -558,7 +558,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -595,7 +595,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -613,7 +613,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -3003,6 +3003,34 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testNewModelInstanceIsBoundToTheDirectConnection()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getNameWithDirectType')->once()->andReturn('pgsql::direct');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('table');
+        $query->shouldReceive('getConnection')->andReturn($connection);
+
+        $builder = (new Builder($query))->setModel(new EloquentBuilderTestStub);
+
+        $this->assertSame('pgsql::direct', $builder->newModelInstance()->getConnectionName());
+    }
+
+    public function testNewModelInstanceIsBoundToTheBaseNameForReadWriteConnections()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getNameWithDirectType')->once()->andReturn('pgsql');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('table');
+        $query->shouldReceive('getConnection')->andReturn($connection);
+
+        $builder = (new Builder($query))->setModel(new EloquentBuilderTestStub);
+
+        $this->assertSame('pgsql', $builder->newModelInstance()->getConnectionName());
+    }
+
     protected function getMockModel()
     {
         $model = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -30,7 +30,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite', [456]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()->expects('insert')->with(
             'insert into "child_table" ("attr", "val", "parent_id", "updated_at", "created_at") values (?, ?, ?, ?, ?)',
@@ -55,7 +55,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $sql = 'insert into "child_table" ("attr", "val", "parent_id", "updated_at", "created_at") values (?, ?, ?, ?, ?)';
         $bindings = ['foo', 'bar', 123, '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
@@ -95,7 +95,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite', [456]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -125,7 +125,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -157,7 +157,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -202,7 +202,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite', [456]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -232,7 +232,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -269,7 +269,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -320,7 +320,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite', [456]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -343,7 +343,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')
@@ -373,7 +373,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $model->id = 123;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $model->getConnection()
             ->expects('select')

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->id = 123;
         $this->mockConnectionForModel($parent, 'SQLite', [789]);
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
         $parent->getConnection()->expects('insert')->with(
             'insert into "child" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)',
             ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
@@ -56,7 +56,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $sql = 'insert into "child" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)';
         $bindings = ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
@@ -104,7 +104,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite', [789]);
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')
@@ -139,7 +139,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')
@@ -179,7 +179,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')
@@ -237,7 +237,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite', [789]);
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')
@@ -275,7 +275,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')
@@ -323,7 +323,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
-        $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $parent->getConnection()->shouldReceive('getNameWithDirectType')->andReturn('sqlite');
 
         $parent->getConnection()
             ->expects('select')

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1097,6 +1097,29 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->exists);
     }
 
+    public function testNewModelIsBoundToTheDirectConnectionAfterInsert()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getNameWithDirectType')->once()->andReturn('sqlite::direct');
+        $query->shouldReceive('getConnection')->once()->andReturn($connection);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+
+        $model->name = 'taylor';
+
+        $this->assertTrue($model->save());
+        $this->assertSame('sqlite::direct', $model->getConnectionName());
+    }
+
     public function testInsertIsCanceledIfCreatingEventReturnsFalse()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
@@ -4201,7 +4224,7 @@ class EloquentModelSaveStub extends Model
         $grammar->shouldReceive('getBitwiseOperators')->andReturn([]);
         $grammar->shouldReceive('isExpression')->andReturnFalse();
         $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
-        $mock->shouldReceive('getName')->andReturn('name');
+        $mock->shouldReceive('getNameWithDirectType')->andReturn('name');
         $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
             return new BaseBuilder($mock, $grammar, $processor);
         });

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -147,6 +148,20 @@ class DatabaseEloquentMorphToTest extends TestCase
         $result = $relation->getResults();
 
         $this->assertEquals($newModel, $result);
+    }
+
+    public function testCreateModelByTypeKeepsTheDirectConnection()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getNameWithDirectType')->once()->andReturn('sqlite::direct');
+
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->once()->andReturn(new EloquentMorphToRelatedStub);
+        $builder->shouldReceive('getConnection')->once()->andReturn($connection);
+
+        $relation = Relation::noConstraints(fn () => new MorphTo($builder, new EloquentMorphToModelStub, 'foreign_key', 'id', 'morph_type', 'relation'));
+
+        $this->assertSame('sqlite::direct', $relation->createModelByType(EloquentMorphToRelatedStub::class)->getConnectionName());
     }
 
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()

--- a/tests/Integration/Database/Postgres/DatabasePgsqlPooledConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePgsqlPooledConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\Postgres;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use PDO;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -41,6 +42,35 @@ class DatabasePgsqlPooledConnectionTest extends PostgresTestCase
         $this->assertIsBool(DB::connection('pgsql')->getSchemaBuilder()->hasTable('migrations'));
     }
 
+    public function testEloquentModelsStayOnTheDirectConnection()
+    {
+        $direct = DB::connection('pgsql::direct');
+        $schema = $direct->getSchemaBuilder();
+
+        $schema->dropIfExists('pooled_direct_models');
+
+        try {
+            $direct->transaction(function () use ($schema) {
+                $schema->create('pooled_direct_models', function ($table) {
+                    $table->id();
+                    $table->string('name');
+                });
+
+                // Every model the builder produces has to keep the routing, whether it is created
+                // or hydrated. The table only exists inside this transaction, so anything falling
+                // back to the pooled connection can neither write to it nor read it back.
+                $created = PooledDirectModel::on('pgsql::direct')->create(['name' => 'direct']);
+                $retrieved = PooledDirectModel::on('pgsql::direct')->first();
+
+                $this->assertSame('pgsql::direct', $created->getConnectionName());
+                $this->assertSame('pgsql::direct', $retrieved->getConnectionName());
+                $this->assertSame('direct', $retrieved->name);
+            });
+        } finally {
+            $schema->dropIfExists('pooled_direct_models');
+        }
+    }
+
     public function testPooledConnectionCanBindBooleansWithEmulatedPrepares()
     {
         $schema = DB::connection('pgsql::direct')->getSchemaBuilder();
@@ -63,4 +93,13 @@ class DatabasePgsqlPooledConnectionTest extends PostgresTestCase
             $schema->dropIfExists('pooled_boolean_bindings');
         }
     }
+}
+
+class PooledDirectModel extends Model
+{
+    protected $table = 'pooled_direct_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
 }


### PR DESCRIPTION
The transaction-pooler support added in #60425 routes migrations to the `::direct` connection, and `Migrator::runMethod()` sets the default connection accordingly:

```php
// Migrations/Migrator.php:515
$this->resolver->setDefaultConnection($connection->getNameWithReadWriteType()); // "pgsql::direct"
```

`Builder::newModelInstance()` then throws that away:

```php
// Eloquent/Builder.php:1793
$this->query->getConnection()->getName()   // "pgsql"
```

`getName()` returns `getConfig('name')`, and `newModelInstance()` is the funnel for most models produced by a builder, `hydrate()` included. So a model created in a migration is written to the pooled connection, outside the migration's transaction, and a model read on the direct connection comes back bound to `"pgsql"`, taking any later `save()` or `delete()` with it. Statements that never build a model (mass `update()`, `delete()`, `upsert()`) stay on the direct connection.

On a fresh database this fails outright (`relation "..." does not exist`, since the table was created inside the direct connection's transaction). On an existing one it succeeds silently and is no longer rolled back with the DDL.

Dropping the suffix is right for `::read` / `::write`, where a model read from a replica must stay writable. `::direct` serves both reads and writes, so there it changes which server the statement reaches.

This adds `Connection::getNameWithDirectType()`, which keeps the suffix only for the direct variant, and uses it wherever Eloquent binds a model to a resolved connection name: `Builder::newModelInstance()`, `Factory::store()` (reachable through `migrate --seed`, which `MigrateCommand` runs inside `usingConnection()`), the new-model fallback in `Model::save()`, and `MorphTo::createModelByType()`. The latter two cover models created outside an Eloquent builder, such as relation-created and polymorphic models.

## Reproduction

With a `direct` endpoint configured, run a migration that creates a table and then writes to it through Eloquent. Either form lands on the pooled connection:

```php
Schema::create('examples', function (Blueprint $table) {
    $table->id();
});

Example::create([]);                       // binds the new model to "pgsql"
Example::on('pgsql::direct')->create([]);  // also "pgsql", newModelInstance() re-pins it
```

`migrate:fresh` fails with `relation "examples" does not exist`. A pooler is not needed to see it: pointing `direct` at the same host as the pooled connection is enough, since the two are separate `Connection` instances with separate transactions.

## Backward compatibility

`getNameWithDirectType()` returns the same value as `getName()` unless the connection is the `direct` variant. Read/write routing is untouched and covered by a test, and `getName()` and `getNameWithReadWriteType()` are unchanged.

## Tests

Unit tests cover both halves of the new method: that it keeps the `::direct` suffix for the direct variant, and that `null`, `read` and `write` still collapse to the base name, so read/write routing cannot regress. Two more assert that `newModelInstance()` binds a model to whichever of the two the connection reports.

The regression itself is covered by an integration test, added to the file #60425 introduced. It creates a table inside a transaction on the direct connection, then writes to it and reads it back through a model, so anything falling back to the pooled connection cannot see it. That test case already points `direct` at the same host as the pooled connection, so CI needs no extra service. Without the patch it fails with `relation "pooled_direct_models" does not exist (Connection: pgsql, ...)`.

Found while moving a production application onto this configuration, and verified there against PostgreSQL 18 behind PgBouncer 1.25.2 in `pool_mode = transaction`.
