### PR TITLE
[13.x] Prefer consitent assertions

### DIFF
--- a/tests/Cache/CacheDynamoDbStoreTest.php
+++ b/tests/Cache/CacheDynamoDbStoreTest.php
@@ -23,8 +23,8 @@ class CacheDynamoDbStoreTest extends TestCase
                 && str_contains($dynamo->args['UpdateExpression'], 'SET')
         );
 
-        $this->assertTrue(
-            $ttl === $dynamo->args['ExpressionAttributeValues'][':expiry']['N']
+        $this->assertSame(
+            $ttl, $dynamo->args['ExpressionAttributeValues'][':expiry']['N']
             - $dynamo->args['ExpressionAttributeValues'][':now']['N']
         );
     }

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -48,7 +48,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithArrayCast();
         $this->assertEquals(['foo' => null], $instance->attributesToArray());
 
-        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
     }
 
     public function testUnsettingCachedAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3822,7 +3822,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
 
         $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2004,7 +2004,7 @@ class HttpRequestTest extends TestCase
 
         Request::create('', 'GET')->json();
 
-        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
     }
 
     public function testItClampsValues()

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -42,7 +42,7 @@ class JsonResourceTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
 
         $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -212,7 +212,7 @@ class ImageManagerTest extends TestCase
         $image = $manager->fromUpload($file);
 
         $this->assertInstanceOf(Image::class, $image);
-        $this->assertSame(file_get_contents($file->getRealPath()), $image->toBytes());
+        $this->assertStringEqualsFile($file->getRealPath(), $image->toBytes());
         $this->assertSame($file, $image->file());
     }
 

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -69,7 +69,7 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
     {
         $user = ModelWithoutUuidPrimaryKey::create();
 
-        $this->assertTrue(is_int($user->id));
+        $this->assertIsInt($user->id);
         $this->assertTrue(Str::isUuid($user->foo));
         $this->assertTrue(Str::isUuid($user->bar));
     }
@@ -109,7 +109,7 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
 
         $user->saveQuietly();
 
-        $this->assertTrue(is_int($user->id));
+        $this->assertIsInt($user->id);
         $this->assertTrue(Str::isUuid($user->foo));
         $this->assertTrue(Str::isUuid($user->bar));
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -379,7 +379,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $columns = Schema::getColumns('foo');
 
         $this->assertCount(1, $columns);
-        $this->assertTrue($columns[0]['name'] === 'bar');
+        $this->assertSame($columns[0]['name'], 'bar');
     }
 
     public function testGetIndexes()

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -152,14 +152,14 @@ class MigratorTest extends TestCase
             // Returns an empty array because we are in pretend mode.
             $tablesEmpty = DB::select("SELECT name FROM sqlite_master WHERE type='table'");
 
-            $this->assertTrue([] === $tablesEmpty);
+            $this->assertSame([], $tablesEmpty);
 
             // Returns an array with two tables because we ignore pretend mode.
             $tablesList = DB::withoutPretending(function (): array {
                 return DB::select("SELECT name FROM sqlite_master WHERE type='table'");
             });
 
-            $this->assertTrue([] !== $tablesList);
+            $this->assertNotSame([], $tablesList);
 
             // The following would not be possible in pretend mode, if the
             // method DB::withoutPretending() would not exists,
@@ -171,13 +171,13 @@ class MigratorTest extends TestCase
 
                 $columnsEmpty = DB::select("PRAGMA table_info($table->name)");
 
-                $this->assertTrue([] === $columnsEmpty);
+                $this->assertSame([], $columnsEmpty);
 
                 $columnsList = DB::withoutPretending(function () use ($table): array {
                     return DB::select("PRAGMA table_info($table->name)");
                 });
 
-                $this->assertTrue([] !== $columnsList);
+                $this->assertNotSame([], $columnsList);
                 $this->assertCount(2, $columnsList);
 
                 // Confirm that we are still in pretend mode. This column should

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -202,7 +202,7 @@ class DebouncedJobTest extends QueueTestCase
         $lock->release($jobA, $ownerA);
 
         // B should still be the current owner.
-        $this->assertTrue($lock->getCurrentOwner($jobB) === $ownerB);
+        $this->assertSame($lock->getCurrentOwner($jobB), $ownerB);
     }
 
     public function testReleaseClearsMaxWaitTimestamp()

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -106,8 +106,8 @@ class ProcessTest extends TestCase
 
         $poolResults = $pool->wait();
 
-        $this->assertTrue($output[0]['out'] !== []);
-        $this->assertTrue($output[1]['out'] !== []);
+        $this->assertNotSame($output[0]['out'], []);
+        $this->assertNotSame($output[1]['out'], []);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[0]);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[1]);
         $this->assertStringContainsString('ProcessTest.php', $poolResults[0]->output());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1925,7 +1925,7 @@ class SupportStrTest extends TestCase
 
     public function testPasswordCreation()
     {
-        $this->assertTrue(strlen(Str::password()) === 32);
+        $this->assertSame(strlen(Str::password()), 32);
 
         $this->assertStringNotContainsString(' ', Str::password());
         $this->assertStringContainsString(' ', Str::password(spaces: true));


### PR DESCRIPTION
Swaps `assertTrue($x === $y)` style checks for `assertSame()`/`assertNotSame()` so failures show what actually differed instead of just `false`.