### PR TITLE
[13.x] Add `updateAndTouch` to Eloquent Model and Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1283,6 +1283,24 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Update records in the database and touch the given columns.
+     *
+     * @param  array  $values
+     * @param  array|string  $columns
+     * @return int
+     */
+    public function updateAndTouch(array $values, array|string $columns)
+    {
+        $timestamp = $this->model->freshTimestamp();
+
+        foreach (Arr::wrap($columns) as $column) {
+            $values[$column] = $timestamp;
+        }
+
+        return $this->update($values);
+    }
+
+    /**
      * Insert new records or update the existing ones.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -80,6 +80,31 @@ trait HasTimestamps
     }
 
     /**
+     * Update the model and touch the given columns.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @param  array|string  $columns
+     * @param  array<string, mixed>  $options
+     * @return bool
+     */
+    public function updateAndTouch(array $attributes, array|string $columns, array $options = [])
+    {
+        if (! $this->exists) {
+            return false;
+        }
+
+        $this->fill($attributes);
+
+        $timestamp = $this->freshTimestamp();
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->{$column} = $timestamp;
+        }
+
+        return $this->save($options);
+    }
+
+    /**
      * Update the creation and update timestamps.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2606,6 +2606,42 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateAndTouchWithSingleColumn()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $query = new BaseBuilder($connection, new Grammar($connection), m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "foo" = ?, "published_at" = ?, "table"."updated_at" = ?', ['bar', $now, $now])->andReturn(1);
+
+        $result = $builder->updateAndTouch(['foo' => 'bar'], 'published_at');
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUpdateAndTouchWithMultipleColumns()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $query = new BaseBuilder($connection, new Grammar($connection), m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "foo" = ?, "published_at" = ?, "verified_at" = ?, "table"."updated_at" = ?', ['bar', $now, $now, $now])->andReturn(1);
+
+        $result = $builder->updateAndTouch(['foo' => 'bar'], ['published_at', 'verified_at']);
+        $this->assertEquals(1, $result);
+    }
+
     public function testUpdateWithTimestampValue()
     {
         $connection = m::mock(Connection::class);

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -35,6 +35,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
+            $table->timestamp('verified_at')->nullable();
+            $table->timestamp('activated_at')->nullable();
             $table->timestamps();
         });
 
@@ -124,6 +126,24 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertTrue($user->usesTimestamps());
         $this->assertTrue($now->equalTo($user->updated_at));
         $this->assertSame('bar@example.com', $user->email);
+    }
+
+    public function testUpdateAndTouch()
+    {
+        $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
+
+        Carbon::setTestNow($now = Carbon::now()->addHour());
+
+        $this->assertTrue($user->updateAndTouch(
+            ['email' => 'bar@example.com'],
+            ['verified_at', 'activated_at'],
+        ));
+
+        $user->refresh();
+
+        $this->assertSame('bar@example.com', $user->email);
+        $this->assertSame($now->toDateTimeString(), $user->verified_at);
+        $this->assertSame($now->toDateTimeString(), $user->activated_at);
     }
 
     public function testWithoutTimestampWhenAlreadyIgnoringTimestamps()
@@ -306,7 +326,7 @@ class UserWithCreatedAndUpdated extends Eloquent
 {
     protected $table = 'users';
 
-    protected $guarded = [];
+    protected $fillable = ['email'];
 }
 
 class UserWithCreated extends Eloquent


### PR DESCRIPTION
Hi there! This probably isn't something everyone needs, but it's a small gap I keep running into in the framework.

When you update a model and stamp a few timestamp columns at the same time, everything ends up in one flat array, and the columns that carry actual meaning get mixed in with the ones that are just bookkeeping:

```php
$post->update([
    'likes_counted_at'  => now(),
    'likes_count'       => $post->likes()->count(),
    'published_at'      => now(),
    'status'            => 'published',
]);
```

Reading that, it takes a second to work out what actually changed about the post versus what's just being marked as "happened now".

## Proposal

```php
$post->updateAndTouch([
    'likes_count' => $post->likes()->count(),
    'status'      => 'published',
], columns: ['likes_counted_at', 'published_at']);
```

Now the two kinds of columns are separated: values on the left are what changed, `columns` on the right are what's being touched. Same distinction `touch()` already makes, just usable in the middle of an update.

A few things fall out of it naturally:

- All the touched columns get the same timestamp, since it's resolved once via `freshTimestamp()`.
- It's still a single UPDATE. Doing `update()` then `touch()` would be two queries, and two rounds of model events.
- It reads as touching a column rather than assigning `now()` to it by hand, which is the habit worth encouraging.

You can of course already write this by hoisting `$now = now()` above the array, and plenty of people do. This is sugar over `update()`, no argument there. But it's the kind that makes the intent of the call obvious at a glance instead of leaving it to the reader.

## Also on the query builder

`touch()` lives on both the model and the builder today, so this follows the same shape and works for mass updates too:

```php
Post::whereKey($ids)->updateAndTouch([
    'status' => 'published',
], columns: ['published_at']);
```

Felt wrong to add it to one and not the other.

## Why in core, not a macro?

A macro fixes it per app, but only for those who remember to add it. In core, it would be readily available next to `touch()`, where people already look, encouraging broader use of this approach instead of manual timestamp assignment.
