### PR TITLE
[13.x] Add support for partial indexes

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -78,6 +78,7 @@ class MySqlProcessor extends Processor
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => $name === 'primary',
+                'where' => null,
             ];
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -115,6 +115,7 @@ class PostgresProcessor extends Processor
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,
+                'where' => $result->where,
             ];
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -124,7 +124,7 @@ class Processor
      * Process the results of an indexes query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, columns: list<string>, type: string|null, unique: bool, primary: bool}>
+     * @return list<array{name: string, columns: list<string>, type: string|null, unique: bool, primary: bool, where: string|null}>
      */
     public function processIndexes($results)
     {

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -69,6 +69,7 @@ class SQLiteProcessor extends Processor
                 'type' => null,
                 'unique' => (bool) $result->unique,
                 'primary' => $isPrimary,
+                'where' => $this->parseIndexPredicate($result->definition ?? null),
             ];
         }, $results);
 
@@ -77,6 +78,25 @@ class SQLiteProcessor extends Processor
         }
 
         return $indexes;
+    }
+
+    /**
+     * Extract the predicate of a partial index from its "CREATE INDEX" statement.
+     *
+     * SQLite exposes no pragma for the predicate of a partial index, so it has to be
+     * recovered from the statement stored in "sqlite_master". The first ") where"
+     * in that statement always terminates the index's column list.
+     *
+     * @param  string|null  $definition
+     * @return string|null
+     */
+    protected function parseIndexPredicate($definition)
+    {
+        if (! $definition || ! preg_match('/\)\s*where\s+(.+)$/is', $definition, $matches)) {
+            return null;
+        }
+
+        return trim($matches[1]);
     }
 
     /** @inheritDoc */

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -97,6 +97,7 @@ class SqlServerProcessor extends Processor
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,
+                'where' => $result->where,
             ];
         }, $results);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -232,7 +232,7 @@ class Blueprint
                         ? 'vectorIndex'
                         : $index;
 
-                    $this->{$indexMethod}($column->name);
+                    $this->addFluentIndexPredicate($this->{$indexMethod}($column->name), $column);
                     $column->{$index} = null;
 
                     continue 2;
@@ -256,13 +256,29 @@ class Blueprint
                         ? 'vectorIndex'
                         : $index;
 
-                    $this->{$indexMethod}($column->name, $column->{$index});
+                    $this->addFluentIndexPredicate($this->{$indexMethod}($column->name, $column->{$index}), $column);
                     $column->{$index} = null;
 
                     continue 2;
                 }
             }
         }
+    }
+
+    /**
+     * Apply the predicate fluently specified on a column to its index.
+     *
+     * @param  \Illuminate\Database\Schema\IndexDefinition  $index
+     * @param  \Illuminate\Database\Schema\ColumnDefinition  $column
+     * @return \Illuminate\Database\Schema\IndexDefinition
+     */
+    protected function addFluentIndexPredicate($index, $column)
+    {
+        if (! is_null($column->where)) {
+            $index->where($column->where);
+        }
+
+        return $index;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -91,6 +91,7 @@ class BlueprintState
             },
             'index' => $index['name'],
             'columns' => $index['columns'],
+            'where' => $index['where'] ?? null,
         ]))->partition(fn ($index) => $index->name === 'primary');
 
         $this->indexes = $indexes->all();

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Fluent;
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method $this useCurrentOnUpdate() Set the TIMESTAMP column to use CURRENT_TIMESTAMP when updating (MySQL)
  * @method $this virtualAs(string|\Illuminate\Contracts\Database\Query\Expression $expression) Create a virtual generated column (MySQL/PostgreSQL/SQLite)
+ * @method $this where(\Closure|\Illuminate\Contracts\Database\Query\Expression|string $predicate) Only index the rows matching the given predicate (PostgreSQL/SQLite/SqlServer)
  */
 class ColumnDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Closure;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use RuntimeException;
 use UnitEnum;
 
@@ -238,6 +240,56 @@ abstract class Grammar extends BaseGrammar
     public function compileDropFullText(Blueprint $blueprint, Fluent $command)
     {
         throw new RuntimeException('This database driver does not support fulltext index removal.');
+    }
+
+    /**
+     * Compile the "where" clause of a partial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileIndexPredicate(Blueprint $blueprint, Fluent $command)
+    {
+        if (is_null($command->where)) {
+            return '';
+        }
+
+        $predicate = trim($this->getIndexPredicate($blueprint, $command->where));
+
+        return $predicate === '' ? '' : ' where '.$predicate;
+    }
+
+    /**
+     * Resolve the given partial index predicate into raw SQL.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $predicate
+     * @return string
+     */
+    protected function getIndexPredicate(Blueprint $blueprint, $predicate)
+    {
+        if ($this->isExpression($predicate)) {
+            return $this->getValue($predicate);
+        }
+
+        if (! $predicate instanceof Closure) {
+            return $predicate;
+        }
+
+        $predicate($query = $this->connection->query()->from($blueprint->getTable()));
+
+        $grammar = $this->connection->getQueryGrammar();
+
+        // The query grammar prefixes the compiled constraints with the "where" keyword,
+        // which the index syntax supplies itself. Index predicates also may not carry
+        // any bindings, so the values are inlined into the resulting SQL statement.
+        return $grammar->substituteBindingsIntoRawSql(
+            Str::after($grammar->compileWheres($query), 'where '),
+            $this->connection->prepareBindings($query->getRawBindings()['where'])
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -494,14 +494,33 @@ class MySqlGrammar extends Grammar
      */
     protected function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
-        return sprintf('alter table %s add %s %s%s(%s)%s',
+        return sprintf('alter table %s add %s %s%s(%s)%s%s',
             $this->wrapTable($blueprint),
             $type,
             $this->wrap($command->index),
             $command->algorithm ? ' using '.$command->algorithm : '',
             $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command),
             $command->lock ? ', lock='.$command->lock : ''
         );
+    }
+
+    /**
+     * Compile the "where" clause of a partial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileIndexPredicate(Blueprint $blueprint, Fluent $command)
+    {
+        if (! is_null($command->where)) {
+            throw new RuntimeException('This database driver does not support partial indexes.');
+        }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Stringable;
 use LogicException;
+use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
@@ -186,7 +187,8 @@ class PostgresGrammar extends Grammar
     {
         return sprintf(
             "select ic.relname as name, string_agg(a.attname, ',' order by indseq.ord) as columns, "
-            .'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary" '
+            .'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary", '
+            .'pg_get_expr(i.indpred, i.indrelid) as "where" '
             .'from pg_index i '
             .'join pg_class tc on tc.oid = i.indrelid '
             .'join pg_namespace tn on tn.oid = tc.relnamespace '
@@ -195,7 +197,7 @@ class PostgresGrammar extends Grammar
             .'join lateral unnest(i.indkey) with ordinality as indseq(num, ord) on true '
             .'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
             .'where tc.relname = %s and tn.nspname = %s '
-            .'group by ic.relname, am.amname, i.indisunique, i.indisprimary',
+            .'group by ic.relname, am.amname, i.indisunique, i.indisprimary, pg_get_expr(i.indpred, i.indrelid)',
             $this->quoteString($table),
             $schema ? $this->quoteString($schema) : 'current_schema()'
         );
@@ -338,6 +340,25 @@ class PostgresGrammar extends Grammar
             $uniqueStatement .= ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
         }
 
+        // A unique constraint may not be backed by a partial index, so a predicate forces
+        // the index to be created on its own instead of via a constraint. Constraint only
+        // options such as "deferrable" have no equivalent on a bare index in that case...
+        if ($predicate = $this->compileIndexPredicate($blueprint, $command)) {
+            if (! is_null($command->deferrable)) {
+                throw new RuntimeException('PostgreSQL does not support deferrable partial unique indexes.');
+            }
+
+            return [sprintf('create unique index %s%s on %s%s (%s)%s%s',
+                $command->online ? 'concurrently ' : '',
+                $this->wrap($command->index),
+                $this->wrapTable($blueprint),
+                $command->algorithm ? ' using '.$command->algorithm : '',
+                $this->columnize($command->columns),
+                is_null($command->nullsNotDistinct) ? '' : ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct'),
+                $predicate
+            )];
+        }
+
         if ($command->online || $command->algorithm) {
             $createIndexSql = sprintf('create unique index %s%s on %s%s (%s)',
                 $command->online ? 'concurrently ' : '',
@@ -382,12 +403,13 @@ class PostgresGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s%s on %s%s (%s)',
+        return sprintf('create index %s%s on %s%s (%s)%s',
             $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command)
         );
     }
 
@@ -408,11 +430,12 @@ class PostgresGrammar extends Grammar
             return "to_tsvector({$this->quoteString($language)}, {$this->wrap($column)})";
         }, $command->columns);
 
-        return sprintf('create index %s%s on %s using gin ((%s))',
+        return sprintf('create index %s%s on %s using gin ((%s))%s',
             $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            implode(' || ', $columns)
+            implode(' || ', $columns),
+            $this->compileIndexPredicate($blueprint, $command)
         );
     }
 
@@ -457,12 +480,13 @@ class PostgresGrammar extends Grammar
     {
         $columns = $this->columnizeWithOperatorClass($command->columns, $command->operatorClass);
 
-        return sprintf('create index %s%s on %s%s (%s)',
+        return sprintf('create index %s%s on %s%s (%s)%s',
             $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $columns
+            $columns,
+            $this->compileIndexPredicate($blueprint, $command)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -187,17 +187,22 @@ class SQLiteGrammar extends Grammar
      */
     public function compileIndexes($schema, $table)
     {
+        $schema ??= 'main';
+
         return sprintf(
-            'select \'primary\' as name, group_concat(col) as columns, 1 as "unique", 1 as "primary" '
+            'select \'primary\' as name, group_concat(col) as columns, 1 as "unique", 1 as "primary", null as "definition" '
             .'from (select name as col from pragma_table_xinfo(%s, %s) where pk > 0 order by pk, cid) group by name '
-            .'union select name, group_concat(col) as columns, "unique", origin = \'pk\' as "primary" '
-            .'from (select il.*, ii.name as col from pragma_index_list(%s, %s) il, pragma_index_info(il.name, %s) ii order by il.seq, ii.seqno) '
-            .'group by name, "unique", "primary"',
-            $table = $this->quoteString($table),
-            $schema = $this->quoteString($schema ?? 'main'),
-            $table,
-            $schema,
-            $schema
+            .'union select name, group_concat(col) as columns, "unique", origin = \'pk\' as "primary", "definition" '
+            .'from (select il.*, ii.name as col, '
+            .'(select m.sql from %s.sqlite_master m where m.type = \'index\' and m.name = il.name) as "definition" '
+            .'from pragma_index_list(%s, %s) il, pragma_index_info(il.name, %s) ii order by il.seq, ii.seqno) '
+            .'group by name, "unique", "primary", "definition"',
+            $quotedTable = $this->quoteString($table),
+            $quotedSchema = $this->quoteString($schema),
+            $this->wrapValue($schema),
+            $quotedTable,
+            $quotedSchema,
+            $quotedSchema
         );
     }
 
@@ -399,11 +404,12 @@ class SQLiteGrammar extends Grammar
     {
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
-        return sprintf('create unique index %s%s on %s (%s)',
+        return sprintf('create unique index %s%s on %s (%s)%s',
             $schema ? $this->wrapValue($schema).'.' : '',
             $this->wrap($command->index),
             $this->wrapTable($table),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command)
         );
     }
 
@@ -418,11 +424,12 @@ class SQLiteGrammar extends Grammar
     {
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
-        return sprintf('create index %s%s on %s (%s)',
+        return sprintf('create index %s%s on %s (%s)%s',
             $schema ? $this->wrapValue($schema).'.' : '',
             $this->wrap($command->index),
             $this->wrapTable($table),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command)
         );
     }
 
@@ -651,7 +658,7 @@ class SQLiteGrammar extends Grammar
             return [
                 $this->compileDropUnique($blueprint, new IndexDefinition(['index' => $index['name']])),
                 $this->compileUnique($blueprint,
-                    new IndexDefinition(['index' => $command->to, 'columns' => $index['columns']])
+                    new IndexDefinition(['index' => $command->to, 'columns' => $index['columns'], 'where' => $index['where'] ?? null])
                 ),
             ];
         }
@@ -659,7 +666,7 @@ class SQLiteGrammar extends Grammar
         return [
             $this->compileDropIndex($blueprint, new IndexDefinition(['index' => $index['name']])),
             $this->compileIndex($blueprint,
-                new IndexDefinition(['index' => $command->to, 'columns' => $index['columns']])
+                new IndexDefinition(['index' => $command->to, 'columns' => $index['columns'], 'where' => $index['where'] ?? null])
             ),
         ];
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -152,14 +152,15 @@ class SqlServerGrammar extends Grammar
     {
         return sprintf(
             "select idx.name as name, string_agg(col.name, ',') within group (order by idxcol.key_ordinal) as columns, "
-            .'idx.type_desc as [type], idx.is_unique as [unique], idx.is_primary_key as [primary] '
+            .'idx.type_desc as [type], idx.is_unique as [unique], idx.is_primary_key as [primary], '
+            .'idx.filter_definition as [where] '
             .'from sys.indexes as idx '
             .'join sys.tables as tbl on idx.object_id = tbl.object_id '
             .'join sys.schemas as scm on tbl.schema_id = scm.schema_id '
             .'join sys.index_columns as idxcol on idx.object_id = idxcol.object_id and idx.index_id = idxcol.index_id '
             .'join sys.columns as col on idxcol.object_id = col.object_id and idxcol.column_id = col.column_id '
             .'where tbl.name = %s and scm.name = %s '
-            .'group by idx.name, idx.type_desc, idx.is_unique, idx.is_primary_key',
+            .'group by idx.name, idx.type_desc, idx.is_unique, idx.is_primary_key, idx.filter_definition',
             $this->quoteString($table),
             $schema ? $this->quoteString($schema) : 'schema_name()',
         );
@@ -272,10 +273,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create unique index %s on %s (%s)%s',
+        return sprintf('create unique index %s on %s (%s)%s%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command),
             $command->online ? ' with (online = on)' : ''
         );
     }
@@ -289,10 +291,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s on %s (%s)%s',
+        return sprintf('create index %s on %s (%s)%s%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $this->columnize($command->columns),
+            $this->compileIndexPredicate($blueprint, $command),
             $command->online ? ' with (online = on)' : ''
         );
     }

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Fluent;
  * @method $this lock(('none'|'shared'|'default'|'exclusive') $value) Specify the DDL lock mode for the index operation (MySQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
+ * @method $this where(\Closure|\Illuminate\Contracts\Database\Query\Expression|string $predicate) Only index the rows matching the given predicate (PostgreSQL/SQLite/SqlServer)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
@@ -364,6 +365,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingPartialIndexIsNotSupported()
+    {
+        $this->expectExceptionObject(new RuntimeException('This database driver does not support partial indexes.'));
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->where('deleted_at is null');
+        $blueprint->toSql();
     }
 
     public function testAddingIndex()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -14,6 +14,7 @@ use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
@@ -310,6 +311,72 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKey()
+    {
+        // A unique constraint may not be backed by a partial index, so the index has
+        // to be created directly rather than through an "add constraint" statement...
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->where('deleted_at is null');
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") where deleted_at is null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialUniqueKeyWithNullsNotDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->nullsNotDistinct()->where('deleted_at is null');
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") nulls not distinct where deleted_at is null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialUniqueKeyConcurrently()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->online()->where('deleted_at is null');
+
+        $this->assertSame(
+            ['create unique index concurrently "bar" on "users" ("foo") where deleted_at is null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingDeferrablePartialUniqueKeyIsNotSupported()
+    {
+        $this->expectExceptionObject(new RuntimeException('PostgreSQL does not support deferrable partial unique indexes.'));
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->deferrable()->where('deleted_at is null');
+        $blueprint->toSql();
+    }
+
+    public function testAddingPartialIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['foo', 'bar'], 'baz')->where(new Expression('"foo" is not null'));
+
+        $this->assertSame(
+            ['create index "baz" on "users" ("foo", "bar") where "foo" is not null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialIndexFluentlyOnColumn()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('foo')->index()->where('deleted_at is null');
+
+        $this->assertSame([
+            'alter table "users" add column "foo" varchar(255) not null',
+            'create index "users_foo_index" on "users" ("foo") where deleted_at is null',
+        ], $blueprint->toSql());
     }
 
     public function testAddingUniqueKeyWithNullsNotDistinct()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -230,6 +230,58 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKey()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->where('deleted_at is null');
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") where deleted_at is null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['foo', 'bar'], 'baz')->where(new Expression('"foo" is not null'));
+
+        $this->assertSame(
+            ['create index "baz" on "users" ("foo", "bar") where "foo" is not null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialIndexFluentlyOnColumn()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('foo')->unique()->where('deleted_at is null');
+
+        $this->assertSame([
+            'alter table "users" add column "foo" varchar not null',
+            'create unique index "users_foo_unique" on "users" ("foo") where deleted_at is null',
+        ], $blueprint->toSql());
+    }
+
+    public function testAddingPartialIndexUsingAQueryBuilder()
+    {
+        $db = new Manager;
+        $db->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+
+        $connection = $db->getConnection();
+        $connection->useDefaultSchemaGrammar();
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->unique('foo', 'bar')->where(
+            fn ($query) => $query->whereNotNull('foo')->where('type', 'active')
+        );
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") where "foo" is not null and "type" = \'active\''],
+            $blueprint->toSql()
+        );
+    }
+
     public function testAddingUniqueKeyWithSchema()
     {
         $blueprint = new Blueprint($this->getConnection(), 'foo.users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -278,6 +278,40 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKey()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->where('[deleted_at] is null');
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") where [deleted_at] is null'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialUniqueKeyOnline()
+    {
+        // The filter of a filtered index has to precede the index options...
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->online()->where('[deleted_at] is null');
+
+        $this->assertSame(
+            ['create unique index "bar" on "users" ("foo") where [deleted_at] is null with (online = on)'],
+            $blueprint->toSql()
+        );
+    }
+
+    public function testAddingPartialIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['foo', 'bar'], 'baz')->where(new Expression('[foo] is not null'));
+
+        $this->assertSame(
+            ['create index "baz" on "users" ("foo", "bar") where [foo] is not null'],
+            $blueprint->toSql()
+        );
+    }
+
     public function testAddingUniqueKeyOnline()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -92,5 +93,44 @@ SQL);
         $indexes = Schema::getIndexes('table');
 
         $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
+    }
+
+    public function testPartialIndexIsEnforcedAndSurvivesATableRebuild()
+    {
+        Schema::create('teams', fn (Blueprint $table) => $table->id());
+
+        Schema::create('table', function (Blueprint $table) {
+            $table->id();
+            $table->string('email');
+            $table->softDeletes();
+
+            $table->unique('email')->where(fn ($query) => $query->whereNull('deleted_at'));
+        });
+
+        $this->assertSame(
+            '"deleted_at" is null',
+            collect(Schema::getIndexes('table'))->firstWhere('name', 'table_email_unique')['where']
+        );
+
+        // Adding a constrained column forces SQLite to rebuild the table, which
+        // regenerates its indexes from the introspected schema. The predicate of
+        // the partial index has to be carried over to the rebuilt index...
+        Schema::table('table', function (Blueprint $table) {
+            $table->foreignId('team_id')->nullable()->constrained();
+        });
+
+        $this->assertSame(
+            '"deleted_at" is null',
+            collect(Schema::getIndexes('table'))->firstWhere('name', 'table_email_unique')['where']
+        );
+
+        DB::table('table')->insert(['email' => 'taylor@laravel.com', 'deleted_at' => null]);
+        DB::table('table')->insert(['email' => 'taylor@laravel.com', 'deleted_at' => '2026-01-01 00:00:00']);
+
+        $this->assertSame(2, DB::table('table')->count());
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        DB::table('table')->insert(['email' => 'taylor@laravel.com', 'deleted_at' => null]);
     }
 }


### PR DESCRIPTION
Adds a `where` modifier to index definitions so an index can be limited to the rows matching a predicate:

```php
// Fluent on the index definition
$table->unique(['c1', 'c2'])->where('c1 is null');

// Fluent on the column
$table->string('c1')->nullable()->unique()->where(fn ($q) => $q->whereNotNull('c1'));

// Closure form — portable, compiled by the query grammar, bindings inlined
$table->index('c1')->where(fn ($q) => $q->where('c1', 'a')->whereNull('c2'));
// → create index "..." on "orders" ("c1") where "c1" = 'a' and "c2" is null
```

The predicate accepts a raw string, an expression, or a closure over a query builder, in which case the constraints are compiled by the query grammar and their bindings inlined, since DDL statements may not carry any bindings.

Today this requires dropping to `DB::statement('create unique index ... where ...')`, which works until the migration touches something SQLite cannot alter in place — adding a foreign key, changing a column — at which point the table is rebuilt, its indexes are regenerated from introspection, and the predicate is silently lost along with the uniqueness guarantee it was enforcing.

### Driver support

Partial indexes are supported on PostgreSQL, SQLite and SQL Server. MySQL and MariaDB have no equivalent, so a predicate throws a `RuntimeException` there rather than being silently dropped.

A unique constraint may not be backed by a partial index on PostgreSQL, so a predicate compiles the index directly instead of through an `add constraint` statement. Constraint-only options have no equivalent on a bare index, so combining `where` with `deferrable` throws rather than dropping the deferrability.

SQLite exposes no pragma for the predicate of a partial index, so it is read back from `sqlite_master` and is now carried through the table rebuild that emulates the unsupported `alter table` operations, which would otherwise regenerate the index without its predicate.

### Introspection

`Schema::getIndexes()` now returns a `where` key alongside the existing ones, holding the predicate as reported by the database (`pg_get_expr(indpred, indrelid)` on PostgreSQL, `sys.indexes.filter_definition` on SQL Server, parsed from the index definition on SQLite) or `null`. Anything implementing a custom schema processor will want to add the key.

### Notes for review

- On a `ColumnDefinition` the predicate is a single attribute, so a column declared with both `->unique()` and `->index()` applies the same predicate to both indexes. Splitting it per index method would mean tracking predicates per fluent index rather than per column — happy to change this if the shared predicate is the wrong default.
- SQLite and PostgreSQL 17 are covered by integration tests run against live databases, including a regression test asserting the predicate survives a table rebuild and still enforces uniqueness. SQL Server is covered by grammar unit tests only.