### PR TITLE
[13.x] Adjust `creationTimeOfOldestPendingJob` for DatabaseQueue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -233,8 +233,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->where('queue', $this->getQueue($queue))
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
-            ->oldest('available_at')
-            ->value('available_at');
+            ->oldest('created_at')
+            ->value('created_at');
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -288,4 +288,21 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         $this->assertIsArray($jobQueuedEvent->payload());
         $this->assertSame('expected-job-uuid', $jobQueuedEvent->payload()['uuid']);
     }
+
+    public function testCreationTimeOfOldestPendingJobUsesTheCreationTime()
+    {
+        $this->connection()
+            ->table('jobs')
+            ->insert([
+                'id' => 1,
+                'queue' => $mock_queue_name = 'mock_queue_name',
+                'payload' => 'mock_payload',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->subMinute()->getTimestamp(),
+                'created_at' => $created_at = Carbon::now()->subMinutes(10)->getTimestamp(),
+            ]);
+
+        $this->assertEquals($created_at, $this->queue->creationTimeOfOldestPendingJob($mock_queue_name));
+    }
 }


### PR DESCRIPTION
I think this should be `created_at`, not `available_at`

When a job is dispatched with a delay, `available_at` is set in the future, so it isn't when the job was actually created, ie a job created at 09:00 and delayed until 10:00 means `creationTimeOfOldestPendingJob` reports 10:00 if the current time is past 10?  

Seeing as the doc bloc says `Get the creation timestamp of the oldest pending job, excluding delayed jobs.` I think it's right to report the created_at?

Where as the Redis driver reports the createdAt

This could be a bit of a B/C for end users to their tests, but I considered it a bug fix so I bring it here, I can move to 14.x if you prefer tho and potentially may need backporting to 12.x if you agree!