### PR TITLE
[13.x] Add Command::replace() and Command::disable()

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -232,6 +232,14 @@ class Application extends SymfonyApplication implements ApplicationContract
             $command->setLaravel($this->laravel);
         }
 
+        if ($command instanceof SymfonyCommand) {
+            Command::resolveOverrides($command);
+
+            if (Command::overridden($command)) {
+                return null;
+            }
+        }
+
         return $this->addToParent($command);
     }
 
@@ -244,6 +252,24 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected function addToParent(SymfonyCommand|callable $command)
     {
         return parent::addCommand($command);
+    }
+
+    /**
+     * Determine if the given command exists, resolving replaced commands to their replacement.
+     */
+    #[\Override]
+    public function has(string $name): bool
+    {
+        return parent::has(Command::replacementFor($name));
+    }
+
+    /**
+     * Get a registered command, resolving replaced commands to their replacement.
+     */
+    #[\Override]
+    public function get(string $name): SymfonyCommand
+    {
+        return parent::get(Command::replacementFor($name));
     }
 
     /**
@@ -261,7 +287,11 @@ class Application extends SymfonyApplication implements ApplicationContract
 
             if (! is_null($commandName)) {
                 foreach (explode('|', $commandName) as $name) {
-                    $this->commandMap[$name] = $command;
+                    Command::resolveOverrides($command, $name);
+
+                    if (! Command::overridden($name)) {
+                        $this->commandMap[$name] = $command;
+                    }
                 }
 
                 return null;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -92,6 +92,15 @@ class Command extends SymfonyCommand
     protected $aliases;
 
     /**
+     * The commands that have been replaced or disabled, keyed by command name or class name.
+     *
+     * A null value indicates the command has been disabled entirely.
+     *
+     * @var array<string, string|null>
+     */
+    protected static $overrides = [];
+
+    /**
      * Create a new console command instance.
      */
     public function __construct()
@@ -381,6 +390,112 @@ class Command extends SymfonyCommand
         parent::setHidden($this->hidden = $hidden);
 
         return $this;
+    }
+
+    /**
+     * Run the given command in place of another command.
+     *
+     * The replaced command will no longer be registered with the console application.
+     * Both commands may be given as a command name or as a command class name.
+     *
+     * @param  string  $command
+     * @param  string  $replacement
+     * @return void
+     */
+    public static function replace($command, $replacement)
+    {
+        static::$overrides[$command] = $replacement;
+    }
+
+    /**
+     * Prevent the given commands from being registered with the console application.
+     *
+     * The commands may be given as command names or as command class names.
+     *
+     * @param  string  ...$commands
+     * @return void
+     */
+    public static function disable(...$commands)
+    {
+        foreach ($commands as $command) {
+            static::$overrides[$command] = null;
+        }
+    }
+
+    /**
+     * Determine if the given command has been replaced or disabled.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string|null  $command
+     * @return bool
+     */
+    public static function overridden($command)
+    {
+        if (static::$overrides === []) {
+            return false;
+        }
+
+        if ($command instanceof SymfonyCommand) {
+            return static::overridden($command->getName()) || static::overridden($command::class);
+        }
+
+        return ! is_null($command) && array_key_exists($command, static::$overrides);
+    }
+
+    /**
+     * Resolve the overrides that were registered using the given command's class name.
+     *
+     * Class names are exchanged for the command's name as soon as the command is
+     * registered with the console application, so that overrides configured by
+     * class name may be resolved by name when a command is looked up or run.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  string|null  $name
+     * @return void
+     */
+    public static function resolveOverrides($command, $name = null)
+    {
+        if (static::$overrides === []) {
+            return;
+        }
+
+        if ($command instanceof SymfonyCommand) {
+            [$command, $name] = [$command::class, $command->getName()];
+        }
+
+        if (is_null($name)) {
+            return;
+        }
+
+        if (array_key_exists($command, static::$overrides) && ! array_key_exists($name, static::$overrides)) {
+            static::$overrides[$name] = static::$overrides[$command];
+        }
+
+        foreach (static::$overrides as $overridden => $replacement) {
+            if ($replacement === $command) {
+                static::$overrides[$overridden] = $name;
+            }
+        }
+    }
+
+    /**
+     * Get the name of the command that should be run in place of the given command.
+     *
+     * @param  string  $command
+     * @return string
+     */
+    public static function replacementFor($command)
+    {
+        return static::$overrides[$command] ?? $command;
+    }
+
+    /**
+     * Flush the replaced and disabled commands.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$overrides = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Command;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
@@ -180,6 +181,7 @@ trait InteractsWithTestCaseLifecycle
 
         AboutCommand::flushState();
         Artisan::forgetBootstrappers();
+        Command::flushState();
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();

--- a/tests/Console/CommandOverridesTest.php
+++ b/tests/Console/CommandOverridesTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Events\Dispatcher as EventsDispatcher;
+use Illuminate\Foundation\Application as FoundationApplication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+class CommandOverridesTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Command::flushState();
+    }
+
+    public function testReplacedCommandRunsTheReplacement()
+    {
+        Command::replace('vendor:make-user', 'user:make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertSame(0, $artisan->call('vendor:make-user'));
+        $this->assertStringContainsString('user:make', $artisan->output());
+    }
+
+    public function testReplacedCommandIsRemovedFromTheCommandList()
+    {
+        Command::replace('vendor:make-user', 'user:make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertArrayHasKey('user:make', $artisan->all());
+    }
+
+    public function testReplacedCommandIsFoundAsTheReplacement()
+    {
+        Command::replace('vendor:make-user', 'user:make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertTrue($artisan->has('vendor:make-user'));
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->get('vendor:make-user'));
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->find('vendor:make-user'));
+    }
+
+    public function testLazilyRegisteredCommandsMayBeReplaced()
+    {
+        Command::replace('lazy:vendor-make-user', 'user:make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([LazyVendorMakeUserCommand::class, UserMakeCommand::class]);
+        $artisan->setContainerCommandLoader();
+
+        $this->assertArrayNotHasKey('lazy:vendor-make-user', $artisan->all());
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->find('lazy:vendor-make-user'));
+    }
+
+    public function testDisabledCommandIsNotRegistered()
+    {
+        Command::disable('vendor:make-user');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertFalse($artisan->has('vendor:make-user'));
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertArrayHasKey('user:make', $artisan->all());
+    }
+
+    public function testDisabledCommandMayNotBeCalled()
+    {
+        Command::disable('vendor:make-user');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class]);
+
+        $this->expectException(CommandNotFoundException::class);
+
+        $artisan->call('vendor:make-user');
+    }
+
+    public function testLazilyRegisteredCommandsMayBeDisabled()
+    {
+        Command::disable('lazy:vendor-make-user');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([LazyVendorMakeUserCommand::class]);
+        $artisan->setContainerCommandLoader();
+
+        $this->assertFalse($artisan->has('lazy:vendor-make-user'));
+        $this->assertArrayNotHasKey('lazy:vendor-make-user', $artisan->all());
+
+        $this->expectException(CommandNotFoundException::class);
+
+        $artisan->find('lazy:vendor-make-user');
+    }
+
+    public function testMultipleCommandsMayBeDisabledAtOnce()
+    {
+        Command::disable('vendor:make-user', 'user:make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertArrayNotHasKey('user:make', $artisan->all());
+    }
+
+    public function testCommandsMayBeReplacedUsingClassNames()
+    {
+        Command::replace(VendorMakeUserCommand::class, UserMakeCommand::class);
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->find('vendor:make-user'));
+        $this->assertSame(0, $artisan->call('vendor:make-user'));
+        $this->assertStringContainsString('user:make', $artisan->output());
+    }
+
+    public function testCommandNamesAndClassNamesMayBeMixed()
+    {
+        Command::replace('vendor:make-user', UserMakeCommand::class);
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->find('vendor:make-user'));
+    }
+
+    public function testClassNamesMayBeReplacedByCommandNames()
+    {
+        Command::replace(VendorMakeUserCommand::class, 'user:make');
+        Command::disable(LazyVendorMakeUserCommand::class, 'lazy:user-make');
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([
+            VendorMakeUserCommand::class, UserMakeCommand::class,
+            LazyVendorMakeUserCommand::class, LazyUserMakeCommand::class,
+        ]);
+        $artisan->setContainerCommandLoader();
+
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertInstanceOf(UserMakeCommand::class, $artisan->find('vendor:make-user'));
+        $this->assertArrayNotHasKey('lazy:vendor-make-user', $artisan->all());
+        $this->assertArrayNotHasKey('lazy:user-make', $artisan->all());
+    }
+
+    public function testLazilyRegisteredCommandsMayBeReplacedUsingClassNames()
+    {
+        Command::replace(LazyVendorMakeUserCommand::class, LazyUserMakeCommand::class);
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([LazyVendorMakeUserCommand::class, LazyUserMakeCommand::class]);
+        $artisan->setContainerCommandLoader();
+
+        $this->assertArrayNotHasKey('lazy:vendor-make-user', $artisan->all());
+        $this->assertArrayHasKey('lazy:user-make', $artisan->all());
+        $this->assertInstanceOf(LazyUserMakeCommand::class, $artisan->find('lazy:vendor-make-user'));
+    }
+
+    public function testCommandsMayBeDisabledUsingClassNames()
+    {
+        Command::disable(VendorMakeUserCommand::class, LazyVendorMakeUserCommand::class);
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, LazyVendorMakeUserCommand::class, UserMakeCommand::class]);
+        $artisan->setContainerCommandLoader();
+
+        $this->assertFalse($artisan->has('vendor:make-user'));
+        $this->assertFalse($artisan->has('lazy:vendor-make-user'));
+        $this->assertArrayNotHasKey('vendor:make-user', $artisan->all());
+        $this->assertArrayNotHasKey('lazy:vendor-make-user', $artisan->all());
+        $this->assertArrayHasKey('user:make', $artisan->all());
+    }
+
+    public function testStateMayBeFlushed()
+    {
+        Command::disable('vendor:make-user');
+        Command::replace('user:make', 'vendor:make-user');
+
+        Command::flushState();
+
+        $artisan = $this->getArtisan();
+        $artisan->resolveCommands([VendorMakeUserCommand::class, UserMakeCommand::class]);
+
+        $this->assertArrayHasKey('vendor:make-user', $artisan->all());
+        $this->assertArrayHasKey('user:make', $artisan->all());
+    }
+
+    protected function getArtisan()
+    {
+        $container = new FoundationApplication();
+
+        return new Application($container, new EventsDispatcher($container), $container->version());
+    }
+}
+
+class VendorMakeUserCommand extends Command
+{
+    protected $signature = 'vendor:make-user';
+
+    public function handle()
+    {
+        $this->output->write('vendor:make-user');
+    }
+}
+
+class UserMakeCommand extends Command
+{
+    protected $signature = 'user:make';
+
+    public function handle()
+    {
+        $this->output->write('user:make');
+    }
+}
+
+#[AsCommand('lazy:vendor-make-user')]
+class LazyVendorMakeUserCommand extends Command
+{
+    //
+}
+
+#[AsCommand('lazy:user-make')]
+class LazyUserMakeCommand extends Command
+{
+    //
+}


### PR DESCRIPTION
This PR adds a mechanism for replacing and disabling Artisan commands from a service provider. 

```php
use Illuminate\Console\Command;

public function boot(): void
{
    Command::replace('filament:make-user', 'user:make');

    Command::disable('vendor:some-command', 'another:command');
}
```

`replace()` removes the old command from the command list and executes the replacement when the old command is invoked. `disable()` removes the command entirely - it cannot be executed and does not appear in `artisan list`, completion, or "Did you mean" suggestions.

Both arguments can be provided either as command names or as class strings, in any combination:

```php
Command::replace('filament:make-user', 'user:make');
Command::replace('filament:make-user', UserMakeCommand::class);
Command::replace(MakeUserCommand::class, 'user:make');
Command::replace(MakeUserCommand::class, UserMakeCommand::class);

Command::disable('some:command', MakeUserCommand::class);
```

## Use cases

### Replacing package commands with custom ones
A classic example is `filament:make-user`. In a real-world project, the user model is often much richer than what the package assumes - it may require a `team_id`, role assignment, additional profile fields etc. The package command may then create a record that is formally valid but incomplete or even inconsistent with the application. Today, the only options are overriding the binding (while the package command remains in the list) or adding a note to the README saying, "Please don’t use this command." After this change:

```php
Command::replace('filament:make-user', 'user:make');
```

Anyone who enters `php artisan filament:make-user` out of habit or based on the package documentation will get the team’s custom command instead - with no documentation changes and no risk of accidentally using the old one.

### Disabling unused commands from third-party packages

Packages install commands that may be irrelevant or even dangerous in a given project - commands that reset data, clear indexes, or generate unused layers. They remain in `artisan list`, cluttering it with dozens of entries, and each one is only a command away from being run in production. `Command::disable()` removes them from the registry, so the list shows only what actually makes sense for the project.

### Restricting what an agent/LLM can execute

Increasingly, commands are not entered by a human but by an assistant working in the repository, with `artisan list` serving as its primary source of information about available operations. If a command is listed, it will eventually be used. Disabling destructive commands means they are not only hidden but also impossible to invoke - instead, a `CommandNotFoundException` is thrown. This provides application-level protection, independent of the allowlist configured for a particular AI tool.

## Notes
- `Command::replace()` and `Command::disable()` must be called before the kernel builds the Artisan application - `boot()` in a service provider is safe.
- When specifying a class, matching is performed against the exact class string. If a application registers a subclass of the specified command, using the command name is more reliable.
- Chains (`replace('a', 'b')` together with `replace('b', 'c')`) are not resolved recursively by design, as doing so could allow a cycle to be created.