### PR TITLE
[13.x] Restore array support in Str::substrReplace

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1866,6 +1866,10 @@ class Str
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
+        if (is_array($string) || is_array($replace) || is_array($offset) || is_array($length)) {
+            return substr_replace($string, $replace, $offset, $length);
+        }
+
         if ($length === null) {
             $length = static::length($string);
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1866,17 +1866,48 @@ class Str
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
-        if (is_array($string) || is_array($replace) || is_array($offset) || is_array($length)) {
+        if (! is_array($string) && (is_array($offset) || is_array($length))) {
             return substr_replace($string, $replace, $offset, $length);
         }
 
-        if ($length === null) {
-            $length = static::length($string);
+        $replaceSubstring = function ($string, $replace, $offset, $length) {
+            if ($length === null) {
+                $length = static::length($string);
+            }
+
+            return mb_substr($string, 0, $offset)
+                .$replace
+                .mb_substr(mb_substr($string, $offset), $length);
+        };
+
+        $replacements = is_array($replace) ? array_values($replace) : null;
+
+        if (! is_array($string)) {
+            return $replaceSubstring(
+                $string,
+                $replacements === null ? $replace : ($replacements[0] ?? ''),
+                $offset,
+                $length,
+            );
         }
 
-        return mb_substr($string, 0, $offset)
-            .$replace
-            .mb_substr(mb_substr($string, $offset), $length);
+        $offsets = is_array($offset) ? array_values($offset) : null;
+        $lengths = is_array($length) ? array_values($length) : null;
+        $result = [];
+        $position = 0;
+
+        foreach ($string as $index => $value) {
+            $result[$index] = $replaceSubstring(
+                $value,
+                $replacements === null ? $replace : ($replacements[$position] ?? ''),
+                $offsets === null ? $offset : ($offsets[$position] ?? 0),
+                $lengths === null ? $length : ($lengths[$position] ?? null),
+            );
+
+            $position++;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
+use TypeError;
 use ValueError;
 
 class SupportStrTest extends TestCase
@@ -1391,6 +1392,54 @@ class SupportStrTest extends TestCase
             ['INV-****', 'INV-****'],
             Str::substrReplace(['INV-1234', 'INV-5678'], ['****', '****'], [4, 4], [4, 4])
         );
+
+        $this->assertSame(
+            ['first' => 'aXc', 'second' => 'Yef', 'third' => ''],
+            Str::substrReplace(
+                ['first' => 'abc', 'second' => 'def', 'third' => 'ghi'],
+                ['X', 'Y'],
+                [1],
+                [1, 1]
+            )
+        );
+
+        $this->assertSame('kengä', Str::substrReplace('kenkä', ['ng'], -3, 2));
+        $this->assertSame('ac', Str::substrReplace('abc', [], 1, 1));
+        $this->assertSame(
+            ['kengä', 'БXДЖ'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], ['ng', 'X'], [-3, 1], [2, 1])
+        );
+        $this->assertSame(
+            ['kXnkä', 'БXДЖ'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], 'X', 1, 1)
+        );
+        $this->assertSame(
+            ['keX', 'БГX'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], 'X', 2)
+        );
+        $this->assertSame(
+            ['first' => 'aXc', 'second' => 'deY'],
+            Str::substrReplace(
+                ['first' => 'abc', 'second' => 'def'],
+                ['second' => 'X', 'first' => 'Y'],
+                [10 => 1, 20 => 2],
+                [30 => 1, 40 => 1]
+            )
+        );
+    }
+
+    public function testSubstrReplaceWithArrayOffsetRequiresArraySubject()
+    {
+        $this->expectException(TypeError::class);
+
+        Str::substrReplace('abc', 'X', [1], 1);
+    }
+
+    public function testSubstrReplaceWithArrayLengthRequiresArraySubject()
+    {
+        $this->expectException(TypeError::class);
+
+        Str::substrReplace('abc', 'X', 1, [1]);
     }
 
     public function testTake()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1385,6 +1385,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('kenga', Str::substrReplace('kenka', 'ng', -3, 2));
     }
 
+    public function testSubstrReplaceWithArrays()
+    {
+        $this->assertSame(
+            ['INV-****', 'INV-****'],
+            Str::substrReplace(['INV-1234', 'INV-5678'], ['****', '****'], [4, 4], [4, 4])
+        );
+    }
+
     public function testTake()
     {
         $this->assertSame('ab', Str::take('abcdef', 2));


### PR DESCRIPTION
`Str::substrReplace()` supports array inputs, matching PHP's native `substr_replace()` behavior.

After the method was updated to handle multibyte strings, array arguments began being passed directly to `mb_substr()`. This causes a `TypeError` when using the documented array form.

This PR delegates calls containing array arguments to PHP's native `substr_replace()` implementation while preserving the existing multibyte-aware behavior for scalar strings.

A regression test has been added for replacing corresponding portions of multiple strings.