### PR TITLE
[13.x] Pass the HTTP method to retry callbacks for asynchronous HTTP requests

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1263,7 +1263,8 @@ class PendingRequest
             $shouldRetry = $this->retryWhenCallback ? call_user_func(
                 $this->retryWhenCallback,
                 $response instanceof Response ? $response->toException() : $response,
-                $this
+                $this,
+                $method,
             ) : true;
         } catch (Exception $exception) {
             return $exception;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2714,6 +2714,30 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(2);
     }
 
+    public function testAsyncRetryCallbackReceivesHttpMethod()
+    {
+        $method = null;
+
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['error'], 500)
+                ->push(['ok'], 200),
+        ]);
+
+        $response = $this->factory
+            ->async()
+            ->retry(2, 0, function ($exception, $request, $requestMethod) use (&$method) {
+                $method = $requestMethod;
+
+                return true;
+            }, false)
+            ->get('http://foo.com/get')
+            ->wait();
+
+        $this->assertSame('GET', $method);
+        $this->assertTrue($response->successful());
+    }
+
     public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([


### PR DESCRIPTION
Synchronous requests already provide the callback arguments `$exception`, `$request`, `$method`. The asynchronous retry path only provided the `$exception` and the `$request` causing an `ArgumentCountError`
