### PR TITLE
[13.x] Clamp paginator per-page and support configurable max

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -44,6 +44,13 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     protected $perPage;
 
     /**
+     * The maximum number of items that may be requested per page for this paginator instance.
+     *
+     * @var int|null
+     */
+    protected $maxPerPage;
+
+    /**
      * The base path to assign to all URLs.
      *
      * @var string
@@ -98,6 +105,39 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      * @var \Closure
      */
     protected static $currentCursorResolver;
+
+    /**
+     * The maximum number of items that may be requested per page for every instance of this paginator type.
+     *
+     * @var int|null
+     */
+    protected static $defaultMaxPerPage;
+
+    /**
+     * Set the maximum number of items that may be requested per page for every instance of this paginator type.
+     *
+     * @param  int|null  $max
+     * @return void
+     */
+    public static function setDefaultMaxPerPage($max)
+    {
+        static::$defaultMaxPerPage = $max;
+    }
+
+    /**
+     * Clamp the given "per page" value between 1 and the instance or global maximum, if one is set.
+     *
+     * @param  mixed  $perPage
+     * @return int
+     */
+    protected function resolvePerPage($perPage)
+    {
+        $perPage = max((int) $perPage, 1);
+
+        $max = $this->maxPerPage ?? static::$defaultMaxPerPage;
+
+        return is_null($max) ? $perPage : min($perPage, max((int) $max, 1));
+    }
 
     /**
      * Get the URL for a given cursor.

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -46,7 +46,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * The maximum number of items that may be requested per page for this paginator instance.
      *
-     * @var int|null
+     * @var positive-int|null
      */
     protected $maxPerPage;
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -39,6 +39,13 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     protected $perPage;
 
     /**
+     * The maximum number of items that may be requested per page for this paginator instance.
+     *
+     * @var int|null
+     */
+    protected $maxPerPage;
+
+    /**
      * The current page being "viewed".
      *
      * @var int
@@ -121,6 +128,13 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
      * @var \Closure
      */
     protected static $viewFactoryResolver;
+
+    /**
+     * The maximum number of items that may be requested per page for every instance of this paginator type.
+     *
+     * @var int|null
+     */
+    protected static $defaultMaxPerPage;
 
     /**
      * The default pagination view.
@@ -661,6 +675,32 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     {
         static::defaultView('pagination::bootstrap-5');
         static::defaultSimpleView('pagination::simple-bootstrap-5');
+    }
+
+    /**
+     * Set the maximum number of items that may be requested per page for every instance of this paginator type.
+     *
+     * @param  int|null  $max
+     * @return void
+     */
+    public static function setDefaultMaxPerPage($max)
+    {
+        static::$defaultMaxPerPage = $max;
+    }
+
+    /**
+     * Clamp the given "per page" value between 1 and the instance or global maximum, if one is set.
+     *
+     * @param  mixed  $perPage
+     * @return int
+     */
+    protected function resolvePerPage($perPage)
+    {
+        $perPage = max((int) $perPage, 1);
+
+        $max = $this->maxPerPage ?? static::$defaultMaxPerPage;
+
+        return is_null($max) ? $perPage : min($perPage, max((int) $max, 1));
     }
 
     /**

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -48,7 +48,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
             $this->{$key} = $value;
         }
 
-        $this->perPage = (int) $perPage;
+        $this->perPage = $this->resolvePerPage($perPage);
         $this->cursor = $cursor;
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -57,8 +57,8 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         }
 
         $this->total = $total;
-        $this->perPage = (int) $perPage;
-        $this->lastPage = max((int) ceil($total / max($this->perPage, 1)), 1);
+        $this->perPage = $this->resolvePerPage($perPage);
+        $this->lastPage = max((int) ceil($total / $this->perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : new Collection($items);

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -48,7 +48,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             $this->{$key} = $value;
         }
 
-        $this->perPage = $perPage;
+        $this->perPage = $this->resolvePerPage($perPage);
         $this->currentPage = $this->setCurrentPage($currentPage);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
 

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -9,6 +9,11 @@ use PHPUnit\Framework\TestCase;
 
 class CursorPaginatorTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        CursorPaginator::setDefaultMaxPerPage(null);
+    }
+
     public function testReturnsRelevantContextInformation()
     {
         $p = new CursorPaginator($array = [['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
@@ -163,6 +168,43 @@ class CursorPaginatorTest extends TestCase
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
         $this->assertStringContainsString('"id": 1', $results);
+    }
+
+    public function testPerPageIsClampedToAMinimumOfOne(): void
+    {
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 0, null);
+        $this->assertSame(1, $p->perPage());
+
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 0.5, null);
+        $this->assertSame(1, $p->perPage());
+
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], -1, null);
+        $this->assertSame(1, $p->perPage());
+    }
+
+    public function testPerPageIsClampedToTheInstanceMax(): void
+    {
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $p->perPage());
+    }
+
+    public function testPerPageIsClampedToTheDefaultMax(): void
+    {
+        CursorPaginator::setDefaultMaxPerPage(5);
+
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null);
+
+        $this->assertSame(5, $p->perPage());
+    }
+
+    public function testInstanceMaxTakesPrecedenceOverDefaultMax(): void
+    {
+        CursorPaginator::setDefaultMaxPerPage(5);
+
+        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $p->perPage());
     }
 
     protected function getCursor($params, $isNext = true)

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Generator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CursorPaginatorTest extends TestCase
@@ -170,21 +172,33 @@ class CursorPaginatorTest extends TestCase
         $this->assertStringContainsString('"id": 1', $results);
     }
 
-    public function testPerPageIsClampedToAMinimumOfOne(): void
+    #[DataProvider('invalidPerPageProvider')]
+    public function testPerPageIsClampedToAMinimumOfOne($perPage): void
     {
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 0, null);
-        $this->assertSame(1, $p->perPage());
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: $perPage,
+            cursor: null,
+        );
 
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 0.5, null);
         $this->assertSame(1, $p->perPage());
+    }
 
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], -1, null);
-        $this->assertSame(1, $p->perPage());
+    public static function invalidPerPageProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-1];
     }
 
     public function testPerPageIsClampedToTheInstanceMax(): void
     {
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null, ['maxPerPage' => 2]);
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $p->perPage());
     }
@@ -193,7 +207,11 @@ class CursorPaginatorTest extends TestCase
     {
         CursorPaginator::setDefaultMaxPerPage(5);
 
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null);
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+        );
 
         $this->assertSame(5, $p->perPage());
     }
@@ -202,7 +220,12 @@ class CursorPaginatorTest extends TestCase
     {
         CursorPaginator::setDefaultMaxPerPage(5);
 
-        $p = new CursorPaginator([['id' => 1], ['id' => 2]], 10, null, ['maxPerPage' => 2]);
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $p->perPage());
     }

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -247,7 +247,7 @@ class CursorPaginatorTest extends TestCase
         $this->assertSame(10, $p->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
     {
         $p = new CursorPaginator(
@@ -260,7 +260,7 @@ class CursorPaginatorTest extends TestCase
         $this->assertSame(1, $p->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
     {
         CursorPaginator::setDefaultMaxPerPage($max);
@@ -274,7 +274,7 @@ class CursorPaginatorTest extends TestCase
         $this->assertSame(1, $p->perPage());
     }
 
-    public static function invalidMaxProvider(): Generator
+    public static function dataProviderInvalidMax(): Generator
     {
         yield 'zero' => [0];
         yield 'float' => [0.5];

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Pagination;
 use Generator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ class CursorPaginatorTest extends TestCase
     protected function tearDown(): void
     {
         CursorPaginator::setDefaultMaxPerPage(null);
+        Paginator::setDefaultMaxPerPage(null);
     }
 
     public function testReturnsRelevantContextInformation()
@@ -182,6 +184,8 @@ class CursorPaginatorTest extends TestCase
         );
 
         $this->assertSame(1, $p->perPage());
+        $this->assertCount(1, $p->items());
+        $this->assertTrue($p->hasMorePages());
     }
 
     public static function invalidPerPageProvider(): Generator
@@ -228,6 +232,65 @@ class CursorPaginatorTest extends TestCase
         );
 
         $this->assertSame(2, $p->perPage());
+    }
+
+    public function testDefaultMaxIsNotSharedWithSimplePaginatorHierarchy(): void
+    {
+        Paginator::setDefaultMaxPerPage(2);
+
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+        );
+
+        $this->assertSame(10, $p->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+            options: ['maxPerPage' => $max],
+        );
+
+        $this->assertSame(1, $p->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        CursorPaginator::setDefaultMaxPerPage($max);
+
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 10,
+            cursor: null,
+        );
+
+        $this->assertSame(1, $p->perPage());
+    }
+
+    public static function invalidMaxProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-5];
+    }
+
+    public function testMinimumAndMaximumClampsCanCollide(): void
+    {
+        $p = new CursorPaginator(
+            items: new Collection([['id' => 1], ['id' => 2]]),
+            perPage: 0,
+            cursor: null,
+            options: ['maxPerPage' => 1],
+        );
+
+        $this->assertSame(1, $p->perPage());
     }
 
     protected function getCursor($params, $isNext = true)

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -161,7 +161,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame(5, $paginator->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
     {
         $paginator = new LengthAwarePaginator(
@@ -175,7 +175,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame(1, $paginator->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
     {
         LengthAwarePaginator::setDefaultMaxPerPage($max);
@@ -190,7 +190,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame(1, $paginator->perPage());
     }
 
-    public static function invalidMaxProvider(): Generator
+    public static function dataProviderInvalidMax(): Generator
     {
         yield 'zero' => [0];
         yield 'float' => [0.5];

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pagination;
 
 use Generator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -80,6 +81,7 @@ class LengthAwarePaginatorTest extends TestCase
         );
 
         $this->assertSame(1, $paginator->perPage());
+        $this->assertSame(4, $paginator->lastPage());
     }
 
     public static function invalidPerPageProvider(): Generator
@@ -129,6 +131,83 @@ class LengthAwarePaginatorTest extends TestCase
         );
 
         $this->assertSame(2, $paginator->perPage());
+    }
+
+    public function testLastPageReflectsTheClampedMax(): void
+    {
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 100,
+            perPage: 1000,
+            currentPage: 1,
+            options: ['maxPerPage' => 10],
+        );
+
+        $this->assertSame(10, $paginator->perPage());
+        $this->assertSame(10, $paginator->lastPage());
+    }
+
+    public function testDefaultMaxIsSharedBetweenPaginatorAndLengthAwarePaginator(): void
+    {
+        Paginator::setDefaultMaxPerPage(5);
+
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+        );
+
+        $this->assertSame(5, $paginator->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => $max],
+        );
+
+        $this->assertSame(1, $paginator->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        LengthAwarePaginator::setDefaultMaxPerPage($max);
+
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+        );
+
+        $this->assertSame(1, $paginator->perPage());
+    }
+
+    public static function invalidMaxProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-5];
+    }
+
+    public function testMinimumAndMaximumClampsCanCollide(): void
+    {
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 0,
+            currentPage: 1,
+            options: ['maxPerPage' => 1],
+        );
+
+        $this->assertSame(1, $paginator->perPage());
     }
 
     public function testLengthAwarePaginatorOnFirstAndLastPage()

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Generator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class LengthAwarePaginatorTest extends TestCase
@@ -66,21 +69,35 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame(1, $paginator->perPage());
     }
 
-    public function testPerPageIsClampedToAMinimumOfOne(): void
+    #[DataProvider('invalidPerPageProvider')]
+    public function testPerPageIsClampedToAMinimumOfOne($perPage): void
     {
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0, 1);
-        $this->assertSame(1, $paginator->perPage());
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3', 'item4']),
+            total: 4,
+            perPage: $perPage,
+            currentPage: 1,
+        );
 
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0.5, 1);
         $this->assertSame(1, $paginator->perPage());
+    }
 
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, -1, 1);
-        $this->assertSame(1, $paginator->perPage());
+    public static function invalidPerPageProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-1];
     }
 
     public function testPerPageIsClampedToTheInstanceMax(): void
     {
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1, ['maxPerPage' => 2]);
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $paginator->perPage());
     }
@@ -89,7 +106,12 @@ class LengthAwarePaginatorTest extends TestCase
     {
         LengthAwarePaginator::setDefaultMaxPerPage(5);
 
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1);
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+        );
 
         $this->assertSame(5, $paginator->perPage());
     }
@@ -98,7 +120,13 @@ class LengthAwarePaginatorTest extends TestCase
     {
         LengthAwarePaginator::setDefaultMaxPerPage(5);
 
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1, ['maxPerPage' => 2]);
+        $paginator = new LengthAwarePaginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            total: 3,
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $paginator->perPage());
     }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -26,6 +26,8 @@ class LengthAwarePaginatorTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->p);
+
+        LengthAwarePaginator::setDefaultMaxPerPage(null);
     }
 
     public function testLengthAwarePaginatorGetAndSetPageName()
@@ -61,7 +63,44 @@ class LengthAwarePaginatorTest extends TestCase
         $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0, 1);
 
         $this->assertSame(4, $paginator->lastPage());
-        $this->assertSame(0, $paginator->perPage());
+        $this->assertSame(1, $paginator->perPage());
+    }
+
+    public function testPerPageIsClampedToAMinimumOfOne(): void
+    {
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0, 1);
+        $this->assertSame(1, $paginator->perPage());
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0.5, 1);
+        $this->assertSame(1, $paginator->perPage());
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, -1, 1);
+        $this->assertSame(1, $paginator->perPage());
+    }
+
+    public function testPerPageIsClampedToTheInstanceMax(): void
+    {
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $paginator->perPage());
+    }
+
+    public function testPerPageIsClampedToTheDefaultMax(): void
+    {
+        LengthAwarePaginator::setDefaultMaxPerPage(5);
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1);
+
+        $this->assertSame(5, $paginator->perPage());
+    }
+
+    public function testInstanceMaxTakesPrecedenceOverDefaultMax(): void
+    {
+        LengthAwarePaginator::setDefaultMaxPerPage(5);
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 3, 10, 1, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $paginator->perPage());
     }
 
     public function testLengthAwarePaginatorOnFirstAndLastPage()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -180,7 +180,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(10, $p->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
     {
         $p = new Paginator(
@@ -193,7 +193,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(1, $p->perPage());
     }
 
-    #[DataProvider('invalidMaxProvider')]
+    #[DataProvider('dataProviderInvalidMax')]
     public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
     {
         Paginator::setDefaultMaxPerPage($max);
@@ -207,7 +207,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(1, $p->perPage());
     }
 
-    public static function invalidMaxProvider(): Generator
+    public static function dataProviderInvalidMax(): Generator
     {
         yield 'zero' => [0];
         yield 'float' => [0.5];

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Generator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PaginatorTest extends TestCase
@@ -106,21 +109,33 @@ class PaginatorTest extends TestCase
         $this->assertStringContainsString('item/1', $results);
     }
 
-    public function testPerPageIsClampedToAMinimumOfOne(): void
+    #[DataProvider('invalidPerPageProvider')]
+    public function testPerPageIsClampedToAMinimumOfOne($perPage): void
     {
-        $p = new Paginator(['item1', 'item2'], 0, 1);
-        $this->assertSame(1, $p->perPage());
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2']),
+            perPage: $perPage,
+            currentPage: 1,
+        );
 
-        $p = new Paginator(['item1', 'item2'], 0.5, 1);
         $this->assertSame(1, $p->perPage());
+    }
 
-        $p = new Paginator(['item1', 'item2'], -1, 1);
-        $this->assertSame(1, $p->perPage());
+    public static function invalidPerPageProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-1];
     }
 
     public function testPerPageIsClampedToTheInstanceMax(): void
     {
-        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1, ['maxPerPage' => 2]);
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $p->perPage());
     }
@@ -129,7 +144,11 @@ class PaginatorTest extends TestCase
     {
         Paginator::setDefaultMaxPerPage(5);
 
-        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1);
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+        );
 
         $this->assertSame(5, $p->perPage());
     }
@@ -138,14 +157,23 @@ class PaginatorTest extends TestCase
     {
         Paginator::setDefaultMaxPerPage(5);
 
-        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1, ['maxPerPage' => 2]);
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => 2],
+        );
 
         $this->assertSame(2, $p->perPage());
     }
 
     public function testPerPageIsNotClampedWhenNoMaxIsSet(): void
     {
-        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1);
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+        );
 
         $this->assertSame(10, $p->perPage());
     }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -119,6 +119,8 @@ class PaginatorTest extends TestCase
         );
 
         $this->assertSame(1, $p->perPage());
+        $this->assertCount(1, $p->items());
+        $this->assertTrue($p->hasMorePages());
     }
 
     public static function invalidPerPageProvider(): Generator
@@ -176,5 +178,51 @@ class PaginatorTest extends TestCase
         );
 
         $this->assertSame(10, $p->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testInstanceMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+            options: ['maxPerPage' => $max],
+        );
+
+        $this->assertSame(1, $p->perPage());
+    }
+
+    #[DataProvider('invalidMaxProvider')]
+    public function testDefaultMaxIsFlooredToOneWhenInvalid($max): void
+    {
+        Paginator::setDefaultMaxPerPage($max);
+
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 10,
+            currentPage: 1,
+        );
+
+        $this->assertSame(1, $p->perPage());
+    }
+
+    public static function invalidMaxProvider(): Generator
+    {
+        yield 'zero' => [0];
+        yield 'float' => [0.5];
+        yield 'negative' => [-5];
+    }
+
+    public function testMinimumAndMaximumClampsCanCollide(): void
+    {
+        $p = new Paginator(
+            items: new Collection(['item1', 'item2', 'item3']),
+            perPage: 0,
+            currentPage: 1,
+            options: ['maxPerPage' => 1],
+        );
+
+        $this->assertSame(1, $p->perPage());
     }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -7,6 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class PaginatorTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Paginator::setDefaultMaxPerPage(null);
+    }
+
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
         /** @var Paginator<int, string> $p */
@@ -99,5 +104,49 @@ class PaginatorTest extends TestCase
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
         $this->assertStringContainsString('item/1', $results);
+    }
+
+    public function testPerPageIsClampedToAMinimumOfOne(): void
+    {
+        $p = new Paginator(['item1', 'item2'], 0, 1);
+        $this->assertSame(1, $p->perPage());
+
+        $p = new Paginator(['item1', 'item2'], 0.5, 1);
+        $this->assertSame(1, $p->perPage());
+
+        $p = new Paginator(['item1', 'item2'], -1, 1);
+        $this->assertSame(1, $p->perPage());
+    }
+
+    public function testPerPageIsClampedToTheInstanceMax(): void
+    {
+        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $p->perPage());
+    }
+
+    public function testPerPageIsClampedToTheDefaultMax(): void
+    {
+        Paginator::setDefaultMaxPerPage(5);
+
+        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1);
+
+        $this->assertSame(5, $p->perPage());
+    }
+
+    public function testInstanceMaxTakesPrecedenceOverDefaultMax(): void
+    {
+        Paginator::setDefaultMaxPerPage(5);
+
+        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1, ['maxPerPage' => 2]);
+
+        $this->assertSame(2, $p->perPage());
+    }
+
+    public function testPerPageIsNotClampedWhenNoMaxIsSet(): void
+    {
+        $p = new Paginator(['item1', 'item2', 'item3'], 10, 1);
+
+        $this->assertSame(10, $p->perPage());
     }
 }


### PR DESCRIPTION
## What

`perPage` was never checked, so `0`, negative, or float values were passed straight through and could break pagination. This PR:

- Clamps `perPage` to a minimum of `1` on `Paginator`, `LengthAwarePaginator`, and `CursorPaginator`.
- Adds an optional maximum, so an app can cap how many items a request can ask for:
  - Per instance: `new Paginator($items, $perPage, $currentPage, ['maxPerPage' => 100])`.
  - Globally, e.g. in `AppServiceProvider::boot()`: `Paginator::setDefaultMaxPerPage(1000)`.

`LengthAwarePaginator` shares the global max with `Paginator` (they extend the same base class). `CursorPaginator` has its own, separate global max. Per-instance max always wins over the global one. Default is no max at all, so this is opt-in unless you set one.

## Possible BC break

The minimum clamp changes behavior: code that used to pass `perPage <= 0` on purpose (e.g. expecting `perPage() === 0` or always-empty results) will now get `1` instead. Unlikely to matter in practice, but wanted to flag it.

The max feature itself doesn't change anything unless you turn it on.

## Target branch

Opened against `13.x` — happy to move it to `master` if that's better.