### PR TITLE
[13.x] Add JobReleased event to Worker

### DIFF
--- a/src/Illuminate/Queue/Events/JobReleased.php
+++ b/src/Illuminate/Queue/Events/JobReleased.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobReleased
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName  The connection name.
+     * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
+     */
+    public function __construct(
+        public $connectionName,
+        public $job,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
@@ -559,6 +560,12 @@ class Worker
             $job->fire();
 
             $this->raiseAfterJobEvent($connectionName, $job);
+
+            if ($job->isReleased() && ! $job->isDeleted()) {
+                $this->events->dispatch(new JobReleased(
+                    $connectionName, $job
+                ));
+            }
         } catch (Throwable $e) {
             $exceptionOccurred = $e;
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -482,19 +482,6 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleased::class))->once();
     }
 
-    public function testJobReleasedEventIsNotRaisedWhenJobIsReleasedAfterException()
-    {
-        $job = new WorkerFakeJob(function () {
-            throw new RuntimeException;
-        });
-
-        $worker = $this->getWorker('default', ['queue' => [$job]]);
-        $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
-
-        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleasedAfterException::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobReleased::class)]);
-    }
-
     public function testWorkerPicksJobUsingCustomCallbacks()
     {
         $worker = $this->getWorker('default', [

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -482,7 +482,6 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleased::class))->once();
     }
 
-
     public function testJobReleasedEventIsNotRaisedWhenJobIsReleasedAfterException()
     {
         $job = new WorkerFakeJob(function () {

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerStarting;
@@ -465,6 +466,34 @@ class QueueWorkerTest extends TestCase
         $this->assertFalse($job->hasFailed());
         $this->assertFalse($job->isReleased());
         $this->assertTrue($job->isDeleted());
+    }
+
+    public function testJobReleasedEventIsRaisedWhenJobReleasesItself()
+    {
+        $job = new WorkerFakeJob(function ($job) {
+            $job->release(10);
+        });
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->assertTrue($job->isReleased());
+        $this->assertFalse($job->isDeleted());
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleased::class))->once();
+    }
+
+
+    public function testJobReleasedEventIsNotRaisedWhenJobIsReleasedAfterException()
+    {
+        $job = new WorkerFakeJob(function () {
+            throw new RuntimeException;
+        });
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleasedAfterException::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobReleased::class)]);
     }
 
     public function testWorkerPicksJobUsingCustomCallbacks()


### PR DESCRIPTION
This PR adds a `JobReleased` event that is dispatched when a job releases itself back onto the queue from within its own handler.  

We have a `JobReleasedAfterException` event, but the difference is this event fires when a release happens such as from the middleware ie `WithoutOverlapping`.. or in job handle in userland when using `->release();` 

Context is we're freshly using managed queues and I wanna know when its overlapped

Open to renaming it 🫡  but this is all I could think of

Thanks Brother T