### PR TITLE
[13.x] feat: add Image::fromStream method

### DIFF
--- a/src/Illuminate/Image/ImageManager.php
+++ b/src/Illuminate/Image/ImageManager.php
@@ -33,6 +33,18 @@ class ImageManager extends Manager
     }
 
     /**
+     * Create an image instance from a stream.
+     *
+     * @param  resource  $stream
+     */
+    public function fromStream(mixed $stream): Image
+    {
+        return new Image(
+            fn () => stream_get_contents($stream) ?: throw new ImageException('Invalid stream image data.'),
+        );
+    }
+
+    /**
      * Create an image instance from a base64 encoded string.
      */
     public function fromBase64(string $base64): Image

--- a/src/Illuminate/Support/Facades/Image.php
+++ b/src/Illuminate/Support/Facades/Image.php
@@ -7,6 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Image\Image fromBase64(string $base64)
  * @method static \Illuminate\Image\Image fromPath(string $path)
  * @method static \Illuminate\Image\Image fromStorage(string $path, \BackedEnum|string|null $disk = null)
+ * @method static \Illuminate\Image\Image fromStream(resource $stream)
  * @method static \Illuminate\Image\Image fromUpload(\Illuminate\Http\UploadedFile $file)
  * @method static \Illuminate\Image\Image fromUrl(string $url)
  * @method static \Illuminate\Image\ImageManager transformUsing(string $driver, string $transformation, callable $callback)

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -203,6 +203,54 @@ class ImageManagerTest extends TestCase
         $this->assertInstanceOf(Image::class, $image);
     }
 
+    public function test_from_stream_returns_image()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $this->assertInstanceOf(Image::class, $image);
+        $this->assertSame($contents, $image->toBytes());
+
+        fclose($stream);
+    }
+
+    public function test_from_stream_is_lazy()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $this->assertInstanceOf(Image::class, $image);
+        $this->assertSame(0, ftell($stream));
+
+        fclose($stream);
+    }
+
+    public function test_from_stream_throws_for_invalid_data()
+    {
+        $stream = fopen('php://memory', 'r+');
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+
+        $this->expectExceptionObject(new ImageException('Invalid stream image data.'));
+
+        $manager->fromStream($stream)->toBytes();
+
+        fclose($stream);
+    }
+
     public function test_from_upload_returns_image_from_uploaded_file()
     {
         $file = UploadedFile::fake()->image('avatar.jpg', 100, 100);


### PR DESCRIPTION
Hello!

Adds `ImageManager::fromStream()` to create an Image instance from a stream resource. The method lazily reads the stream via `stream_get_contents`, throwing an `ImageException` if the stream yields no data.

Thanks!