### PR TITLE
[13.x] feat: make Image::toFormat() public

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -303,7 +303,7 @@ class Image implements Stringable
      *
      * @throws ImageException
      */
-    protected function toFormat(string $format): static
+    public function toFormat(string $format): static
     {
         if (! in_array($format, ['webp', 'jpg', 'jpeg', 'png', 'gif', 'avif', 'heic', 'heif', 'bmp'])) {
             throw new ImageException("The [{$format}] format is not supported.");


### PR DESCRIPTION
Hello!

When dealing with dynamic formats, it would be nice to just be able to pass the format directly rather than having to use a match statement like the following...there's really no harm in just making the method public:

```php
return (match ($format) {
    'jpg', 'jpeg' => $image->toJpeg(),
    'png'         => $image->toPng(),
    'gif'         => $image->toGif(),
    'webp'        => $image->toWebp(),
    'avif'        => $image->toAvif(),
    'bmp'         => $image->toBmp(),
    default       => $image,
})->toBytes();

// would be nicer to just use
return $image->toFormat($format)->toBytes();
```

Thanks!