### PR TITLE
[13.x] feat: implement Responsable on Image class

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -426,18 +426,6 @@ class Image implements Responsable, Stringable
     }
 
     /**
-     * Create an HTTP response that represents the image.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     */
-    public function toResponse($request): Response
-    {
-        return new Response($this->toBytes(), 200, [
-            'Content-Type' => $this->mimeType(),
-        ]);
-    }
-
-    /**
      * Get the file extension based on the MIME type.
      */
     public function extension(): string
@@ -606,6 +594,18 @@ class Image implements Responsable, Stringable
         $callback($clone);
 
         return $clone;
+    }
+
+    /**
+     * Create an HTTP response that represents the image.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        return new Response($this->toBytes(), 200, [
+            'Content-Type' => $this->mimeType(),
+        ]);
     }
 
     /**

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -8,6 +8,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Image\Driver;
 use Illuminate\Contracts\Image\Transformation;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Transformations\Blur;
 use Illuminate\Image\Transformations\Contain;
@@ -27,7 +29,7 @@ use Illuminate\Support\Traits\Macroable;
 use Stringable;
 use Throwable;
 
-class Image implements Stringable
+class Image implements Responsable, Stringable
 {
     use Conditionable, Macroable;
 
@@ -421,6 +423,18 @@ class Image implements Stringable
     public function toDataUri(): string
     {
         return 'data:'.$this->mimeType().';base64,'.$this->toBase64();
+    }
+
+    /**
+     * Create an HTTP response that represents the image.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        return new Response($this->toBytes(), 200, [
+            'Content-Type' => $this->mimeType(),
+        ]);
     }
 
     /**

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -1148,6 +1148,34 @@ class ImageTest extends TestCase
         $this->assertInstanceOf(\RuntimeException::class, $exception);
     }
 
+    public function test_implements_responsable()
+    {
+        $image = new Image($this->fakeImageContents());
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Support\Responsable::class, $image);
+    }
+
+    public function test_to_response_returns_response_with_image_bytes()
+    {
+        $contents = $this->fakeImageContents();
+        $image = new Image($contents);
+
+        $response = $image->toResponse(new \Illuminate\Http\Request);
+
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
+        $this->assertSame($contents, $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_to_response_sets_content_type_header()
+    {
+        $image = new Image($this->fakeImageContents());
+
+        $response = $image->toResponse(new \Illuminate\Http\Request);
+
+        $this->assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
     protected function makeImage(): Image
     {
         return new Image($this->fakeImageContents());


### PR DESCRIPTION
Allow Image instances to be returned directly from routes and controllers by implementing the `Responsable` contract. The `toResponse` method returns an HTTP response with the processed image bytes and the appropriate Content-Type header, matching the pattern established by Intervention Image's Laravel package.

Thanks!