### PR TITLE
Clarify `SESSION_EXPIRE_ON_CLOSE` is only cookie driver

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -25,10 +25,9 @@ return [
     | Session Lifetime
     |--------------------------------------------------------------------------
     |
-    | Here you may specify the number of minutes that you wish the session
-    | to be allowed to remain idle before it expires. If you want them
-    | to expire immediately when the browser is closed then you may
-    | indicate that via the expire_on_close configuration option.
+    | Here you may specify the number of minutes that you wish the session to
+    | remain idle before it expires. The "cookie" driver supports expiring
+    | a session immediately when the browser window (not tab) is closed.
     |
     */
 


### PR DESCRIPTION
This man spent so long playing with the 3-char comment (kinda fun tbh!) that he's entirely lost track of how he ended up here.
