### PR TITLE
[13.x] Add Storage::preventStrayDiskUsage()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -56,6 +56,13 @@ class FilesystemManager implements FactoryContract
     protected $customCreators = [];
 
     /**
+     * Indicates if an exception should be thrown when a disk that has not been faked is resolved.
+     *
+     * @var bool
+     */
+    protected $preventStrayDiskUsage = false;
+
+    /**
      * Create a new filesystem manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -120,10 +127,20 @@ class FilesystemManager implements FactoryContract
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
+     *
+     * @throws \Illuminate\Filesystem\StrayDiskUsageException
      */
     protected function get($name)
     {
-        return $this->disks[$name] ?? $this->resolve($name);
+        if (isset($this->disks[$name])) {
+            return $this->disks[$name];
+        }
+
+        if ($this->preventStrayDiskUsage) {
+            throw new StrayDiskUsageException($name);
+        }
+
+        return $this->resolve($name);
     }
 
     /**
@@ -371,6 +388,29 @@ class FilesystemManager implements FactoryContract
         $this->disks[$name] = $disk;
 
         return $this;
+    }
+
+    /**
+     * Indicate that an exception should be thrown if a disk that has not been faked is used.
+     *
+     * @param  bool  $prevent
+     * @return $this
+     */
+    public function preventStrayDiskUsage(bool $prevent = true)
+    {
+        $this->preventStrayDiskUsage = $prevent;
+
+        return $this;
+    }
+
+    /**
+     * Determine if stray disk usage is being prevented.
+     *
+     * @return bool
+     */
+    public function preventingStrayDiskUsage()
+    {
+        return $this->preventStrayDiskUsage;
     }
 
     /**

--- a/src/Illuminate/Filesystem/StrayDiskUsageException.php
+++ b/src/Illuminate/Filesystem/StrayDiskUsageException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use RuntimeException;
+
+class StrayDiskUsageException extends RuntimeException
+{
+    public function __construct(string $disk)
+    {
+        parent::__construct('Attempted to use disk ['.$disk.'] without a matching fake.');
+    }
+}

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -17,6 +17,8 @@ use function Illuminate\Support\enum_value;
  * @method static \Illuminate\Contracts\Filesystem\Cloud createS3Driver(array $config)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem createScopedDriver(array $config)
  * @method static \Illuminate\Filesystem\FilesystemManager set(string $name, mixed $disk)
+ * @method static \Illuminate\Filesystem\FilesystemManager preventStrayDiskUsage(bool $prevent = true)
+ * @method static bool preventingStrayDiskUsage()
  * @method static string getDefaultDriver()
  * @method static string getDefaultCloudDriver()
  * @method static \Illuminate\Filesystem\FilesystemManager forgetDisk(array|string $disk)

--- a/tests/Integration/Filesystem/FilesystemStrayDiskUsageTest.php
+++ b/tests/Integration/Filesystem/FilesystemStrayDiskUsageTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Filesystem;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\StrayDiskUsageException;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\TestCase;
+
+class FilesystemStrayDiskUsageTest extends TestCase
+{
+    /**
+     * The root directory of the "temp" disk used throughout the test.
+     *
+     * @var string
+     */
+    protected $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir().'/laravel-stray-disk-usage';
+
+        Config::set('filesystems.disks.temp', [
+            'driver' => 'local',
+            'root' => $this->root,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem)->deleteDirectory($this->root);
+        (new Filesystem)->deleteDirectory(storage_path('framework/testing/disks/temp'));
+        (new Filesystem)->deleteDirectory(storage_path('framework/testing/disks/public'));
+
+        parent::tearDown();
+    }
+
+    public function testStrayDiskUsageIsNotPreventedByDefault()
+    {
+        $this->assertFalse(Storage::preventingStrayDiskUsage());
+
+        Storage::disk('temp')->put('file.txt', 'contents');
+
+        $this->assertSame('contents', file_get_contents($this->root.'/file.txt'));
+    }
+
+    public function testPreventingStrayDiskUsageMayBeTurnedBackOff()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->assertTrue(Storage::preventingStrayDiskUsage());
+
+        Storage::preventStrayDiskUsage(false);
+
+        $this->assertFalse(Storage::preventingStrayDiskUsage());
+
+        Storage::disk('temp')->put('file.txt', 'contents');
+
+        $this->assertSame('contents', file_get_contents($this->root.'/file.txt'));
+    }
+
+    public function testResolvingAnUnfakedDiskThrows()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->expectExceptionObject(new StrayDiskUsageException('temp'));
+
+        Storage::disk('temp');
+    }
+
+    public function testUsingAnUnfakedDiskDoesNotTouchTheFilesystem()
+    {
+        Storage::preventStrayDiskUsage();
+
+        try {
+            Storage::disk('temp')->put('file.txt', 'contents');
+        } catch (StrayDiskUsageException) {
+            //
+        }
+
+        $this->assertDirectoryDoesNotExist($this->root);
+    }
+
+    public function testReadingFromAnUnfakedDiskThrows()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->expectException(StrayDiskUsageException::class);
+
+        Storage::disk('temp')->get('file.txt');
+    }
+
+    public function testTheDefaultDiskIsGuardedThroughTheFacade()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->expectExceptionObject(new StrayDiskUsageException('local'));
+
+        Storage::put('file.txt', 'contents');
+    }
+
+    public function testTheCloudDiskIsGuarded()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->expectExceptionObject(new StrayDiskUsageException('s3'));
+
+        Storage::cloud();
+    }
+
+    public function testResolvingADiskThroughTheContainerThrows()
+    {
+        Storage::preventStrayDiskUsage();
+
+        $this->expectException(StrayDiskUsageException::class);
+
+        $this->app->make('filesystem.disk');
+    }
+
+    public function testUsingAFakedDiskIsAllowed()
+    {
+        Storage::preventStrayDiskUsage();
+        $fake = Storage::fake('temp');
+
+        Storage::disk('temp')->put('file.txt', 'contents');
+
+        $this->assertSame('contents', Storage::disk('temp')->get('file.txt'));
+        $this->assertFileExists($fake->path('file.txt'));
+        $this->assertFileDoesNotExist($this->root.'/file.txt');
+    }
+
+    public function testUsingAPersistentlyFakedDiskIsAllowed()
+    {
+        Storage::preventStrayDiskUsage();
+        $fake = Storage::persistentFake('temp');
+
+        Storage::disk('temp')->put('file.txt', 'contents');
+
+        $this->assertFileExists($fake->path('file.txt'));
+        $this->assertFileDoesNotExist($this->root.'/file.txt');
+    }
+
+    public function testFakingOneDiskLeavesTheOtherDisksGuarded()
+    {
+        Storage::preventStrayDiskUsage();
+        Storage::fake('public');
+
+        Storage::disk('public')->put('file.txt', 'contents');
+
+        $this->expectExceptionObject(new StrayDiskUsageException('temp'));
+
+        Storage::disk('temp');
+    }
+
+    public function testOnDemandDisksAreNotGuarded()
+    {
+        Storage::preventStrayDiskUsage();
+
+        Storage::build(['driver' => 'local', 'root' => $this->root])->put('file.txt', 'contents');
+
+        $this->assertSame('contents', file_get_contents($this->root.'/file.txt'));
+    }
+}


### PR DESCRIPTION
Adds an opt-in guard that fails a test when it uses a disk that hasn't been faked. Same idea as `Http::preventStrayRequests()` and `Process::preventStrayProcesses()`.

```php
Storage::preventStrayDiskUsage();      // enable; off by default
Storage::preventStrayDiskUsage(false); // disable again
Storage::preventingStrayDiskUsage();   // bool
```

With it on, asking for a disk that hasn't been replaced by `Storage::fake()` or `Storage::persistentFake()` throws `Illuminate\Filesystem\StrayDiskUsageException`, so the code under test never gets hold of a disk backed by real storage.

## Why

`Storage::fake()` already exists, so the fair question is why this is needed. The problem is that faking the wrong disk looks exactly like faking the right one. You call `Storage::fake()` with no argument, which only fakes the default disk, but the code writes to `public`. Or you fake `public`, and the code `move()`s the file to the default disk. Either way the test passes, the file still ends up on real storage, and nothing tells you about it.

Someone asked for the same thing back in 2022 in [Discussion #42580](https://github.com/laravel/framework/discussions/42580), after noticing their test suite had been uploading files to a real S3 bucket for months, 341 of them by the time they checked.

## How it works

One `if` in `FilesystemManager::get()`, which both `disk()` and `cloud()` go through:

```php
protected function get($name)
{
    if (isset($this->disks[$name])) {
        return $this->disks[$name];
    }

    if ($this->preventStrayDiskUsage) {
        throw new StrayDiskUsageException($name);
    }

    return $this->resolve($name);
}
```

`FilesystemAdapter` isn't touched. Faked disks don't need any special handling either. `Storage::fake()` installs its disk with `set()`, which writes straight into `FilesystemManager::$disks`, and cached disks are returned before the check runs. So faking one disk still leaves every other disk guarded, which is what catches the two cases above.

## Notes

- Reads are covered as well as writes, since you can't do either without getting the disk first.
- On-demand disks from `Storage::build()` aren't guarded. You pass the root path yourself there, so it isn't stray.