### PR TITLE
[13.x] Preserve queue resolution on queued mailables in MailFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Mail\Factory;
 use Illuminate\Contracts\Mail\Mailable;
@@ -540,7 +541,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * Queue a new message for sending.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return mixed
      */
     public function queue($view, $queue = null)
@@ -549,11 +550,39 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             return;
         }
 
+        if (is_string($queue) || $queue instanceof BackedEnum) {
+            $view->onQueue($queue);
+        }
+
         $view->mailer($this->currentMailer);
 
         $this->currentMailer = null;
 
         $this->queuedMailables[] = $view;
+    }
+
+    /**
+     * Queue a new mail message for sending on the given queue.
+     *
+     * @param  \BackedEnum|string|null  $queue
+     * @param  \Illuminate\Contracts\Mail\Mailable  $view
+     * @return mixed
+     */
+    public function onQueue($queue, $view)
+    {
+        return $this->queue($view, $queue);
+    }
+
+    /**
+     * Queue a new mail message for sending on the given queue.
+     *
+     * @param  \BackedEnum|string|null  $queue
+     * @param  \Illuminate\Contracts\Mail\Mailable  $view
+     * @return mixed
+     */
+    public function queueOn($queue, $view)
+    {
+        return $this->onQueue($queue, $view);
     }
 
     /**
@@ -566,7 +595,24 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function later($delay, $view, $queue = null)
     {
-        $this->queue($view, $queue);
+        if ($view instanceof Mailable && ! is_null($queue)) {
+            $view->onQueue($queue);
+        }
+
+        $this->queue($view);
+    }
+
+    /**
+     * Queue a new e-mail message for sending after (n) seconds on the given queue.
+     *
+     * @param  string|null  $queue
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  \Illuminate\Contracts\Mail\Mailable  $view
+     * @return mixed
+     */
+    public function laterOn($queue, $delay, $view)
+    {
+        return $this->later($delay, $view, $queue);
     }
 
     /**

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
@@ -444,6 +445,59 @@ class SupportTestingMailFakeTest extends TestCase
                 $mail->usesMailer('mailjet');
         });
     }
+
+    public function testQueueSetsQueueOnMailable()
+    {
+        $mailable1 = new QueueableMailableStub;
+        $this->fake->queue($mailable1, 'podcasts');
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'podcasts';
+        });
+
+        $mailable2 = new QueueableMailableStub;
+        $this->fake->queue($mailable2, MailTestQueueEnum::Emails);
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'emails';
+        });
+
+        $mailable3 = new QueueableMailableStub;
+        $this->fake->onQueue('podcasts', $mailable3);
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'podcasts';
+        });
+
+        $mailable4 = new QueueableMailableStub;
+        $this->fake->queueOn('videos', $mailable4);
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'videos';
+        });
+    }
+
+    public function testLaterSetsQueueOnMailable()
+    {
+        $mailable1 = new QueueableMailableStub;
+        $this->fake->later(15, $mailable1, 'podcasts');
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'podcasts';
+        });
+
+        $mailable2 = new QueueableMailableStub;
+        $this->fake->laterOn('videos', 45, $mailable2);
+
+        $this->fake->assertQueued(QueueableMailableStub::class, function ($mail) {
+            return $mail->queue === 'videos';
+        });
+    }
+}
+
+enum MailTestQueueEnum: string
+{
+    case Emails = 'emails';
 }
 
 class MailableStub extends Mailable
@@ -466,6 +520,8 @@ class MailableStub extends Mailable
 
 class QueueableMailableStub extends Mailable implements ShouldQueue
 {
+    use Queueable;
+
     public $framework = 'Laravel';
 
     protected $version = '6.0';


### PR DESCRIPTION
### Description
When queueing mailables via `Mail::queue()`, `Mail::later()`, `Mail::onQueue()`, `Mail::queueOn()`, or `Mail::laterOn()` while using `Mail::fake()`, the `$queue` parameter was ignored and `$mailable->queue` remained `null`.

This PR updates `MailFake` to call `$view->onQueue($queue)` matching `Mailer::queue()` in production, and implements missing `onQueue`, `queueOn`, and `laterOn` helper methods on `MailFake`.