### PR TITLE
[13.x] Add `withoutCookies` method

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -176,6 +176,23 @@ trait ResponseTrait
     }
 
     /**
+     * Expire multiple cookies when sending the response.
+     *
+     * @param  array  $cookies
+     * @param  string|null  $path
+     * @param  string|null  $domain
+     * @return $this
+     */
+    public function withoutCookies(array $cookies, $path = null, $domain = null)
+    {
+        foreach ($cookies as $cookie) {
+            $this->withoutCookie($cookie, $path, $domain);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the callback of the response.
      *
      * @return string|null

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -101,6 +101,30 @@ class HttpResponseTest extends TestCase
         $this->assertSame('qux', $cookies[1]->getValue());
     }
 
+    public function testWithoutCookie()
+    {
+        $response = new Response;
+        $this->assertCount(0, $response->headers->getCookies());
+        $this->assertEquals($response, $response->withoutCookie(new Cookie('foo', 'bar')));
+        $cookies = $response->headers->getCookies();
+        $this->assertCount(1, $cookies);
+        $this->assertSame('foo', $cookies[0]->getName());
+    }
+
+    public function testWithoutCookies()
+    {
+        $response = new Response;
+        $this->assertCount(0, $response->headers->getCookies());
+        $this->assertEquals($response, $response->withoutCookies([
+            new Cookie('foo', 'bar'),
+            new Cookie('baz', 'qux'),
+        ]));
+        $cookies = $response->headers->getCookies();
+        $this->assertCount(2, $cookies);
+        $this->assertSame('foo', $cookies[0]->getName());
+        $this->assertSame('baz', $cookies[1]->getName());
+    }
+
     public function testResponseCookiesInheritRequestSecureState()
     {
         $cookie = Cookie::create('foo', 'bar');


### PR DESCRIPTION
This adds `withoutCookies()`:

```php
// Before
return response('OK')
    ->withoutCookie('session')
    ->withoutCookie('tracking')
    ->withoutCookie('preferences');

// After
return response('OK')->withoutCookies(['session', 'tracking', 'preferences']);
```