### PR TITLE
[13.x] Ensure Queue drivers work for enums matching the Fake

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -12,6 +12,8 @@ use Pheanstalk\Values\Job;
 use Pheanstalk\Values\JobId;
 use Pheanstalk\Values\TubeName;
 
+use function Illuminate\Support\enum_value;
+
 class BeanstalkdQueue extends Queue implements QueueContract
 {
     /**
@@ -68,7 +70,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
@@ -83,7 +85,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -94,7 +96,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -105,7 +107,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -116,7 +118,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function pendingJobs($queue = null): Collection
@@ -127,7 +129,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function delayedJobs($queue = null): Collection
@@ -138,7 +140,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function reservedJobs($queue = null): Collection
@@ -179,7 +181,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -193,7 +195,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -213,7 +215,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  array  $options
      * @return mixed
      */
@@ -232,7 +234,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -260,7 +262,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -279,7 +281,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null)
@@ -306,7 +308,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Delete a message from the Beanstalk queue.
      *
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $queue
      * @param  string|int  $id
      * @return void
      */
@@ -320,12 +322,12 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Get the queue or return the default.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return string
      */
     public function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        return enum_value($queue) ?: $this->default;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Stringable;
 use PDO;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
 {
     /**
@@ -79,7 +81,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
@@ -92,7 +94,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -107,7 +109,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -122,7 +124,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -136,7 +138,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function pendingJobs($queue = null): Collection
@@ -152,7 +154,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function delayedJobs($queue = null): Collection
@@ -168,7 +170,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function reservedJobs($queue = null): Collection
@@ -224,7 +226,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -242,7 +244,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -262,7 +264,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  array  $options
      * @return mixed
      */
@@ -277,7 +279,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -298,7 +300,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -371,7 +373,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a raw payload to the database with a given delay of (n) seconds.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  string  $payload
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  int  $attempts
@@ -411,7 +413,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      *
      * @throws \Throwable
@@ -605,7 +607,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Delete all of the jobs from the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function clear($queue = null)
@@ -618,12 +620,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the queue or return the default.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return string
      */
     public function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        return enum_value($queue) ?: $this->default;
     }
 
     /**

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -32,7 +32,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
@@ -43,7 +43,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -54,7 +54,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -65,7 +65,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -76,7 +76,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function pendingJobs($queue = null): Collection
@@ -87,7 +87,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function delayedJobs($queue = null): Collection
@@ -98,7 +98,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function reservedJobs($queue = null): Collection
@@ -139,7 +139,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -154,7 +154,7 @@ class FailoverQueue extends Queue implements QueueContract
      *
      * @param  object|string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -166,7 +166,7 @@ class FailoverQueue extends Queue implements QueueContract
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -180,7 +180,7 @@ class FailoverQueue extends Queue implements QueueContract
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -193,7 +193,7 @@ class FailoverQueue extends Queue implements QueueContract
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -212,7 +212,7 @@ class FailoverQueue extends Queue implements QueueContract
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null)

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -14,6 +14,8 @@ use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\enum_value;
+
 class RedisQueue extends Queue implements QueueContract, ClearableQueue
 {
     /**
@@ -108,7 +110,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
@@ -123,7 +125,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -134,7 +136,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -145,7 +147,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -156,12 +158,12 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function pendingJobs($queue = null): Collection
     {
-        $name = $queue ?: $this->default;
+        $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->lrange($this->getQueueRedisKey($queue), 0, -1)))
             ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
@@ -170,12 +172,12 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function delayedJobs($queue = null): Collection
     {
-        $name = $queue ?: $this->default;
+        $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':delayed', 0, -1)))
             ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
@@ -184,12 +186,12 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function reservedJobs($queue = null): Collection
     {
-        $name = $queue ?: $this->default;
+        $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':reserved', 0, -1)))
             ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
@@ -242,7 +244,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -263,7 +265,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -296,7 +298,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  object|string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -316,7 +318,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  array  $options
      * @return mixed
      */
@@ -338,7 +340,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  object|string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -391,7 +393,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  int  $index
      * @return \Illuminate\Contracts\Queue\Job|null
      */
@@ -414,7 +416,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
 
             return new RedisJob(
                 $this->container, $this, $job,
-                $reserved, $this->connectionName, $queue ?: $this->default
+                $reserved, $this->connectionName, enum_value($queue) ?: $this->default
             );
         }
     }
@@ -509,7 +511,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Delete all of the jobs from the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function clear($queue = null)
@@ -535,23 +537,23 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the queue or return the default.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return string
      */
     public function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return 'queues:'.(enum_value($queue) ?: $this->default);
     }
 
     /**
      * Get the cluster-safe Redis key for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return string
      */
     protected function getQueueRedisKey($queue = null)
     {
-        $queue = $queue ?: $this->default;
+        $queue = enum_value($queue) ?: $this->default;
 
         return $this->isClusterConnection() && ! Connection::hasHashTag($queue)
             ? $this->getQueue('{'.$queue.'}')

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\enum_value;
+
 class SqsQueue extends Queue implements QueueContract, ClearableQueue
 {
     /**
@@ -100,7 +102,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
@@ -124,7 +126,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -140,7 +142,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -156,7 +158,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -172,7 +174,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function pendingJobs($queue = null): Collection
@@ -183,7 +185,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function delayedJobs($queue = null): Collection
@@ -194,7 +196,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function reservedJobs($queue = null): Collection
@@ -237,7 +239,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * Not supported by SQS, returns null.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -251,14 +253,14 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
     {
         return $this->enqueueUsing(
             $job,
-            $this->createPayload($job, $queue ?: $this->default, $data),
+            $this->createPayload($job, enum_value($queue) ?: $this->default, $data),
             $queue,
             null,
             function ($payload, $queue) use ($job) {
@@ -271,7 +273,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  array  $options
      * @return mixed
      */
@@ -292,14 +294,14 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
         return $this->enqueueUsing(
             $job,
-            $this->createPayload($job, $queue ?: $this->default, $data, $delay),
+            $this->createPayload($job, enum_value($queue) ?: $this->default, $data, $delay),
             $queue,
             $delay,
             function ($payload, $queue, $delay) use ($job) {
@@ -313,7 +315,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -362,7 +364,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
                 return [
                     'job' => $job,
                     'delay' => $delay,
-                    'payload' => $this->createPayload($job, $queue ?: $this->default, $data, $delay),
+                    'payload' => $this->createPayload($job, enum_value($queue) ?: $this->default, $data, $delay),
                 ];
             })
             ->all();
@@ -537,7 +539,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function getQueueableOptions($job, $queue, $payload, $delay = null): array
     {
         // Make sure we have a queue name to properly determine if it's a FIFO queue...
-        $queue ??= $this->default;
+        $queue = enum_value($queue) ?? $this->default;
 
         $isObject = is_object($job);
         $isFifo = str_ends_with((string) $queue, '.fifo');
@@ -594,7 +596,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null)
@@ -637,12 +639,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Get the queue or return the default.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return string
      */
     public function getQueue($queue)
     {
-        $queue = $queue ?: $this->default;
+        $queue = enum_value($queue) ?: $this->default;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
             ? $this->suffixQueue($queue, $this->suffix)

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -428,6 +428,35 @@ class QueueRedisQueueTest extends TestCase
 
         $this->assertSame(['default', 'emails'], $queue->testAllQueueNames()->all());
     }
+
+    public function testSizeResolvesTheQueueNameFromAnEnum()
+    {
+        $queue = new RedisQueue($redis = m::mock(Factory::class), 'default');
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('eval')->once()->with(
+            LuaScripts::size(), 3, 'queues:emails', 'queues:emails:delayed', 'queues:emails:reserved'
+        )->andReturn(5);
+
+        $this->assertSame(5, $queue->size(RedisQueueName::Emails));
+    }
+
+    public function testPendingJobsResolvesTheQueueNameFromAnEnum()
+    {
+        $queue = new RedisQueue($redis = m::mock(Factory::class), 'default');
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('lrange')->once()->with('queues:emails', 0, -1)->andReturn([
+            json_encode(['uuid' => 'uuid', 'displayName' => 'foo']),
+        ]);
+
+        $this->assertSame('emails', $queue->pendingJobs(RedisQueueName::Emails)->first()->queue);
+    }
+}
+
+enum RedisQueueName: string
+{
+    case Emails = 'emails';
 }
 
 class TestableRedisQueue extends RedisQueue


### PR DESCRIPTION
First off, I know you hate enum PRS, but I bring this for good reason!

The Queue fake accepts enums for `size()`, `pendingJobs()`, `push()`, `bulk()` etc. 

The real drivers don't, so the type hints and the actual behavior disagree. 


That means this:
```php
  Queue::fake()->size(Queues::Rules); // IDE says it's fine  and it works..
```

It works in tests but when using a real  Redis driver:
```
  > Queue::size(Queues::Rules);

     Error  Object of class App\Enums\Queues could not be converted to string.
```


My gut is telling me it should be the same, as feels weird using enums only in the fake, and not the real facade calls, so this PR makes them in line by using `enum_value()` in the `getQueue` method and updated the docblocks.. 

I've left the queue and null driver docblocks as is cos we dont use any enum_value shenanigans   

There could be methods I've missed with the docblock changes, but i think i've covered all the faked ones.
  
I haven't changed the contracts to avoid a b/c, but probably not worth updating them tbh