### PR TITLE
fix: namespace Redis throttle keys

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -93,7 +93,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->getRedisConnection(), $key, $maxAttempts, $decaySeconds
+            $this->getRedisConnection(), $this->redisPrefix().$key, $maxAttempts, $decaySeconds
         );
 
         return tap($limiter->tooManyAttempts(), function () use ($key, $limiter) {
@@ -114,7 +114,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function hit($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->getRedisConnection(), $key, $maxAttempts, $decaySeconds
+            $this->getRedisConnection(), $this->redisPrefix().$key, $maxAttempts, $decaySeconds
         );
 
         $limiter->acquire();
@@ -156,5 +156,15 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function getRedisConnection()
     {
         return $this->redis->connection();
+    }
+
+    /**
+     * Get the prefix that should be used for the Redis rate limiter keys.
+     *
+     * @return string
+     */
+    protected function redisPrefix()
+    {
+        return '';
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -92,4 +92,37 @@ class ThrottleRequestsWithRedisTest extends TestCase
             $this->get('/')->assertTooManyRequests()->assertContent('ah ah ah');
         });
     }
+
+    public function testRedisPrefixIsAppliedToLimiterKeys()
+    {
+        $this->ifRedisAvailable(function () {
+            $now = Carbon::now();
+            Carbon::setTestNow($now);
+
+            Route::get('/namespaced', function () {
+                return 'yes';
+            })->middleware(NamespacedThrottleRequestsWithRedis::class.':2,1');
+
+            $this->withoutExceptionHandling()->get('/namespaced');
+            $this->withoutExceptionHandling()->get('/namespaced');
+
+            try {
+                $this->withoutExceptionHandling()->get('/namespaced');
+            } catch (Throwable $e) {
+                $this->assertEquals(429, $e->getStatusCode());
+            }
+
+            $redis = $this->app->make('redis')->connection();
+            $keys = $redis->keys('throttle:*');
+            $this->assertNotEmpty($keys);
+        });
+    }
+}
+
+class NamespacedThrottleRequestsWithRedis extends ThrottleRequestsWithRedis
+{
+    protected function redisPrefix()
+    {
+        return 'throttle:';
+    }
 }


### PR DESCRIPTION
## Summary

Fix Redis throttle limiter keys so applications can provide a stable Redis key namespace when using `ThrottleRequestsWithRedis`.

## Changes

* Added a protected `redisPrefix()` extension point to `ThrottleRequestsWithRedis`.
* Applied the prefix when constructing the Redis `DurationLimiter`.
* Added a regression test verifying that the configured prefix is applied to the generated limiter keys.

## Why

Redis rate limiter keys may need to be namespaced when Redis is shared across applications or when infrastructure-level Redis ACL/key-prefix requirements are in place. This change provides an explicit extension point for applications to supply that namespace without changing the existing default behavior.

## Testing

A targeted regression test was added in:

`tests/Integration/Http/ThrottleRequestsWithRedisTest.php`

The test verifies that the Redis prefix is correctly applied to the limiter keys.

**Local test execution:** Not run because Composer/vendor dependencies were unavailable in the development environment.

## Issue

Closes #58279
