### PR TITLE
[13.x] Handle cache maintenance mode deactivation races

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
 use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Illuminate\Support\Arr;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use TypeError;
 
 class PreventRequestsDuringMaintenance
 {
@@ -64,7 +65,7 @@ class PreventRequestsDuringMaintenance
         if ($this->app->maintenanceMode()->active()) {
             try {
                 $data = $this->app->maintenanceMode()->data();
-            } catch (ErrorException $exception) {
+            } catch (ErrorException|TypeError $exception) {
                 if (! $this->app->maintenanceMode()->active()) {
                     return $next($request);
                 }

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -3,6 +3,10 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use DateTimeInterface;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+use Illuminate\Foundation\CacheBasedMaintenanceMode;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Events\MaintenanceModeDisabled;
@@ -12,6 +16,7 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -44,6 +49,24 @@ class MaintenanceModeTest extends TestCase
         $response->assertStatus(503);
         $response->assertHeader('Retry-After', '60');
         $response->assertHeader('Refresh', '60');
+    }
+
+    public function testCacheMaintenanceModeAllowsRequestWhenDeactivatedWhileReadingPayload()
+    {
+        $cache = m::mock(Factory::class, Repository::class);
+        $cache->shouldReceive('store')->with('maintenance')->andReturnSelf();
+        $cache->shouldReceive('has')->with('framework:down')->andReturn(true, false);
+        $cache->shouldReceive('get')->once()->with('framework:down')->andReturnNull();
+
+        $this->app->instance(MaintenanceMode::class, new CacheBasedMaintenanceMode(
+            $cache, 'maintenance', 'framework:down'
+        ));
+
+        Route::get('/foo', fn () => 'Hello World')->middleware(PreventRequestsDuringMaintenance::class);
+
+        $this->get('/foo')
+            ->assertOk()
+            ->assertSeeText('Hello World');
     }
 
     public function testMaintenanceModeCanHaveCustomStatus()


### PR DESCRIPTION
When cache-backed maintenance mode is deactivated between the middleware's active-state and payload checks, the second cache lookup returns null.

This causes `CacheBasedMaintenanceMode::data()` to throw a `TypeError` instead of allowing the request to continue after maintenance mode has been disabled.

The middleware already handles the equivalent file-based race by checking the maintenance state again after an `ErrorException`. This PR applies the same state check when the cache driver throws a `TypeError`.

If maintenance mode has been disabled, the request continues normally. If it remains active, the original exception is still thrown.

A regression test has been added for a request concurrent with cache-backed maintenance mode deactivation.