### PR TITLE
[13.x] Fix paginate() total count when using distinct with join

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1133,7 +1133,25 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->toBase()->getCountForPagination();
+        $countColumns = ['*'];
+
+        if ($this->query->distinct && ! $this->query->unions) {
+            if (is_array($this->query->distinct)) {
+                $countColumns = $this->query->distinct;
+            } else {
+                $resolvedColumns = Arr::wrap($columns === ['*'] ? ($this->query->columns ?? ['*']) : $columns);
+
+                if ($resolvedColumns !== ['*']) {
+                    $countColumns = collect($resolvedColumns)->contains(
+                        fn ($column) => is_string($column)
+                            && str_contains($column, '*')
+                            && ! str_starts_with($column, $this->model->getTable().'.')
+                    ) ? $resolvedColumns : [$this->model->getQualifiedKeyName()];
+                }
+            }
+        }
+
+        $total = value($total) ?? $this->toBase()->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total) ?: $this->model->getPerPage();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3615,7 +3615,17 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->getCountForPagination();
+        $countColumns = ['*'];
+
+        if ($this->distinct) {
+            $resolvedColumns = Arr::wrap($columns === ['*'] ? ($this->columns ?? ['*']) : $columns);
+
+            if ($resolvedColumns !== ['*']) {
+                $countColumns = $resolvedColumns;
+            }
+        }
+
+        $total = value($total) ?? $this->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total);
 
@@ -3741,6 +3751,16 @@ class Builder implements BuilderContract
                 ->from(new Expression('('.$clone->toSql().') as '.$this->grammar->wrap('aggregate_table')))
                 ->mergeBindings($clone)
                 ->setAggregate('count', $this->withoutSelectAliases($columns))
+                ->get()->all();
+        }
+
+        if ($this->distinct && ! $this->unions && $columns !== ['*']) {
+            $clone = $this->cloneForPaginationCount();
+
+            return $this->newQuery()
+                ->from(new Expression('('.$clone->select($this->withoutSelectAliases($columns))->toSql().') as '.$this->grammar->wrap('aggregate_table')))
+                ->mergeBindings($clone)
+                ->setAggregate('count', ['*'])
                 ->get()->all();
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -398,6 +398,190 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
     }
 
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinct()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10, ['users.*']);
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndSelect()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::select('users.*')
+            ->join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10);
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndMultipleColumns()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10, ['users.id', 'users.email']);
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndStringColumn()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10, 'users.*');
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndNullableColumn()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'name' => null, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'name' => null, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'name' => 'foo', 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::select('users.*')
+            ->join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10);
+
+        $this->assertCount(2, $models);
+        $this->assertSame(2, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndForeignWildcard()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        EloquentTestPost::insert([
+            ['id' => 1, 'user_id' => 1, 'parent_id' => null, 'name' => 'First Post'],
+            ['id' => 2, 'user_id' => 1, 'parent_id' => null, 'name' => 'Second Post'],
+            ['id' => 3, 'user_id' => 2, 'parent_id' => null, 'name' => 'Third Post'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')
+            ->distinct()
+            ->oldest('users.id')
+            ->paginate(10, ['posts.*']);
+
+        $this->assertCount(3, $models);
+        $this->assertSame(3, $models->total());
+    }
+
+    public function testPaginatedModelCollectionRetrievalWithDistinctAndUnionAll()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+        ]);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $duplicate = EloquentTestUser::select('users.*')->distinct();
+        $models = EloquentTestUser::select('users.*')->distinct()
+            ->unionAll($duplicate)
+            ->paginate(10);
+
+        $this->assertCount(4, $models);
+        $this->assertSame(4, $models->total());
+    }
+
     public function testCountForPaginationWithGrouping()
     {
         EloquentTestUser::insert([


### PR DESCRIPTION
This is a re-submission of [#61070](https://github.com/laravel/framework/pull/61070), Thank you for the thorough review — all six comments have been addressed.

## Changes from #61070

> inspecting only paginate()'s $columns ignores select('users.'), so the PR's documented reproduction still generates COUNT().

When `$columns` is `['*']`, `$this->query->columns` is now used as a fallback.

> multiple columns generate COUNT(DISTINCT a, b), which is invalid on SQLite, PostgreSQL, and SQL Server.

In `Query\Builder`, the `SELECT DISTINCT` is now wrapped in a subquery and counted with an outer `COUNT(*)`.

> documented string columns now cause array_map/array_filter type errors during distinct pagination, while Query Builder expression columns also fail in str_contains.

`Arr::wrap()` and `is_string()` guards have been added.

> COUNT(DISTINCT nullable_column) excludes NULL, so distinct results containing NULL report an incorrect total.

To prevent `COUNT(DISTINCT col)` from silently excluding `NULL` rows, `Eloquent\Builder` now always uses the primary key (`NOT NULL`) instead of the specified columns.

> replacing every wildcard with the model key makes selections such as posts.* count distinct users rather than distinct posts.

`posts.*` was being replaced with `users.id`, causing posts to be counted by distinct users instead. Now only wildcards matching the model's own table are replaced with the primary key; other wildcards are passed to the subquery as-is.

> applying an outer distinct count to a unionAll() query removes duplicates that the result set intentionally retains.

When `$this->unions` is set, both builders now skip the distinct count path entirely.

## Tests

Added the following integration tests to `DatabaseEloquentIntegrationTest`:

- `testPaginatedModelCollectionRetrievalWithJoinAndDistinct`: basic case
- `testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndSelect`: columns specified via `select()`
- `testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndMultipleColumns`: multiple qualified columns
- `testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndStringColumn`: string passed as `$columns`
- `testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndNullableColumn`: nullable columns do not skew total
- `testPaginatedModelCollectionRetrievalWithJoinAndDistinctAndForeignWildcard`: wildcard referencing a joined table
- `testPaginatedModelCollectionRetrievalWithDistinctAndUnionAll`: `unionAll` retains duplicate rows
