### PR TITLE
[12.x] ColumnDefinition::unsigned takes a parameter, which should be documented

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Fluent;
  * @method $this storedAs(string|\Illuminate\Contracts\Database\Query\Expression $expression) Create a stored generated column (MySQL/PostgreSQL/SQLite)
  * @method $this type(string $type) Specify a type for the column
  * @method $this unique(bool|string $indexName = null) Add a unique index
- * @method $this unsigned() Set the INTEGER column as UNSIGNED (MySQL)
+ * @method $this unsigned(bool $value = true) Set the INTEGER column as UNSIGNED if value is true (MySQL)
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method $this useCurrentOnUpdate() Set the TIMESTAMP column to use CURRENT_TIMESTAMP when updating (MySQL)
  * @method $this virtualAs(string|\Illuminate\Contracts\Database\Query\Expression $expression) Create a virtual generated column (MySQL/PostgreSQL/SQLite)


### PR DESCRIPTION
The phpdoc for the `unsigned` method on `ColumnDefinition` doesn't mention that it takes a parameter that has a side effect. 

Github has some public usages [in search for `->unsigned(false)`](https://github.com/search?q=-%3Eunsigned%28false%29&type=code)

Just backporting https://github.com/laravel/framework/pull/60875 from 13.x to 12.x

(Closed and reopened to re-trigger tests, one container had initially failed to boot for an unknown reason)