### PR TITLE
[13.x] Fix nullable return types on the route binding registrar

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -42,7 +42,7 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * The binding registrar instance.
      *
-     * @var \Illuminate\Contracts\Routing\BindingRegistrar
+     * @var \Illuminate\Contracts\Routing\BindingRegistrar|null
      */
     protected $bindingRegistrar;
 
@@ -293,7 +293,7 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * Get the model binding registrar instance.
      *
-     * @return \Illuminate\Contracts\Routing\BindingRegistrar
+     * @return \Illuminate\Contracts\Routing\BindingRegistrar|null
      */
     protected function binder()
     {

--- a/src/Illuminate/Contracts/Routing/BindingRegistrar.php
+++ b/src/Illuminate/Contracts/Routing/BindingRegistrar.php
@@ -17,7 +17,7 @@ interface BindingRegistrar
      * Get the binding callback for a given binding.
      *
      * @param  string  $key
-     * @return \Closure
+     * @return \Closure|null
      */
     public function getBindingCallback($key);
 }


### PR DESCRIPTION
`Illuminate\Contracts\Routing\BindingRegistrar::getBindingCallback()` documents `@return \Closure`, but its only implementation returns `null` whenever the given key has no registered binder:

```php
public function getBindingCallback($key)
{
    if (isset($this->binders[$key = str_replace('-', '_', $key)])) {
        return $this->binders[$key];
    }
}
```

`Broadcaster::binder()` has the same gap. It documents `@return \Illuminate\Contracts\Routing\BindingRegistrar`, but assigns `null` when no registrar is bound in the container:

```php
$this->bindingRegistrar = Container::getInstance()->bound(BindingRegistrar::class)
    ? Container::getInstance()->make(BindingRegistrar::class)
    : null;
```

Because both docblocks claim non-null, static analysis reports the framework's own null handling as dead code. Running PHPStan over the contract, the router and the broadcaster (level 6, `checkPhpDocMethodSignatures: true`):

```
Broadcaster.php:231: Left side of && is always true.
Broadcaster.php:231: Right side of && is always true.
Broadcaster.php:235: Unreachable statement - code above always terminates.
Broadcaster.php:300: Negated boolean expression is always false.
```

Those are the `if ($binder && $binder->getBindingCallback($key))` guard and the `return $value;` fallback in `resolveExplicitBindingIfPossible()`, plus the lazy initialization in `binder()`. Adding `|null` to the three docblocks clears all four.

The `Route` facade already documents the real type: `@method static \Closure|null getBindingCallback(string $key)`.

Docblocks only, no behavior change.