### PR TITLE
[13.x] Preserve the default mailer between fake sends

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -29,6 +29,13 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public $manager;
 
     /**
+     * The default mailer name.
+     *
+     * @var string
+     */
+    protected $defaultMailer;
+
+    /**
      * The mailer currently being used to send a message.
      *
      * @var string
@@ -57,7 +64,8 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function __construct(MailManager $manager)
     {
         $this->manager = $manager;
-        $this->currentMailer = $manager->getDefaultDriver();
+        $this->defaultMailer = $manager->getDefaultDriver();
+        $this->currentMailer = $this->defaultMailer;
     }
 
     /**
@@ -526,7 +534,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             return;
         }
 
-        $view->mailer($this->currentMailer);
+        $view->mailer($this->currentMailer ?? $this->defaultMailer);
 
         if ($shouldQueue) {
             return $this->queue($view);
@@ -554,7 +562,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             $view->onQueue($queue);
         }
 
-        $view->mailer($this->currentMailer);
+        $view->mailer($this->currentMailer ?? $this->defaultMailer);
 
         $this->currentMailer = null;
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -422,6 +422,24 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
+    public function testDefaultMailerIsAppliedToEachMailable()
+    {
+        $firstSentMailable = new MailableStub;
+        $secondSentMailable = new MailableStub;
+        $firstQueuedMailable = new MailableStub;
+        $secondQueuedMailable = new MailableStub;
+
+        $this->fake->send($firstSentMailable);
+        $this->fake->send($secondSentMailable);
+        $this->fake->queue($firstQueuedMailable);
+        $this->fake->queue($secondQueuedMailable);
+
+        $this->assertTrue($firstSentMailable->usesMailer('smtp'));
+        $this->assertTrue($secondSentMailable->usesMailer('smtp'));
+        $this->assertTrue($firstQueuedMailable->usesMailer('smtp'));
+        $this->assertTrue($secondQueuedMailable->usesMailer('smtp'));
+    }
+
     public function testDriverMethod()
     {
         $this->fake->driver('ses')->to('taylor@laravel.com')->send($this->mailable);


### PR DESCRIPTION
When multiple mailables are sent through `MailFake` without explicitly selecting a mailer, only the first mailable records the configured default mailer.

After each send or queue operation, the fake clears its current mailer. Subsequent mailables therefore receive `null`, causing `usesMailer()` assertions for the default mailer to fail even though the real mail manager would resolve the configured default.

This PR captures the default mailer when the fake is created and reuses it whenever no explicit mailer is selected.

Explicitly selected mailers remain scoped to their intended message, and existing queue selection behavior remains unchanged.

A regression test has been added for consecutive sent and queued mailables.