### PR TITLE
Align framework and skeleton app config for session cookie name: use slug not snake for fallback

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug((string) env('APP_NAME', 'laravel')).'-session'
     ),
 
     /*


### PR DESCRIPTION
This PR mirrors the [skeleton app config file](https://github.com/laravel/laravel/blob/c926b8ca7fa01e71852e19141f2bdd7fabfb6ade/config/session.php#L132), which changed `slug()`→`snake()` in https://github.com/laravel/laravel/commit/dd473eaddc824aeada037f0dc702a3b68a51946c, but was reverted a few weeks later in https://github.com/laravel/laravel/commit/902200e7aac4af7efff60ed7ee958932b83ff2e4.

The skeleton app config and framework config should show similar behaviour because they are merged; removing a default skeleton app config should not change the behaviour. The framework should move to use `slug()` to derive the session cookie name (when `SESSION_COOKIE` is not set), not `snake()`, because the latter does not fully strip punctuation that are not valid cookie names (`:`, `.`, etc). The [Laravel 13.x upgrade documentation](https://laravel.com/docs/13.x/upgrade#cache-prefixes-and-session-cookie-names) also shows `slug()` to be in use here.

Note, the framework `slug()`→`snake()` change was introduced in #56172, with the commit message "Use `Str::snake()` as intended". Issue #60569 was opened about this very same discrepancy but was closed without a PR, with rationale that changes to the framework could be breaking, whereas changes to the skeleton only affect new installations.

So, feel free to reject this PR if you see fit, but my reading is that the adoption of `snake()` **is** the breaking change — prior to mid-2025, the framework (and skeleton) used `slug()` here. In 2025, this was changed to `snake()` in both framework and skeleton, arguably breaking the framework (due to the afore-mentioned potential for illegal cookie names to result), before being reverted in the skeleton only a few weeks later.

I hit this issue while trying to slim down my app configs — I removed a local `config/session.php` (which had `slug()`), thinking I was repeating the framework config.
Essentially, if you created a new app using the skeleton before July 2025, it wouldn't have mattered if you kept the app's `config/session.php` or adopted the framework. For three weeks in July, if you created a new app from the skeleton, removing the app's `config/session.php` could was also fine, even though both could result in illegal cookie names. Since then, creating an app from the skeleton gives valid cookie names (uses `slug()`), but removing the app's `config/session.php` could break the behaviour (and could result in illegal cookie names).

Given the docs describe using `slug()`, and the fact that, essentially, carrying `snake()`  forward in the framework forever means apps should (must) always maintain their local definition (in order to use `slug()`), which stands in contrary to the [streamlined config merging introduced with Laravel 11](https://laravel-news.com/laravel11-streamlined-configs) (at least, to my thinking, but again, willing to accept rejection on this).