### PR TITLE
[13.x] Add pluckModelKeys() to Eloquent builder and collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1108,13 +1108,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a collection of primary keys from the query result.
+     *
+     * @return \Illuminate\Support\Collection<int, array-key>
+     */
+    public function pluckModelKeys()
+    {
+        return $this->pluck($this->model->getQualifiedKeyName());
+    }
+
+    /**
      * Get an array of primary keys from the query result.
      *
      * @return array<int, array-key>
      */
     public function modelKeys()
     {
-        return $this->pluck($this->model->getQualifiedKeyName())->all();
+        return $this->pluckModelKeys()->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -378,13 +378,23 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get a collection of primary keys.
+     *
+     * @return \Illuminate\Support\Collection<int, array-key>
+     */
+    public function pluckModelKeys()
+    {
+        return new BaseCollection(array_map(fn ($model) => $model->getKey(), $this->items));
+    }
+
+    /**
      * Get the array of primary keys.
      *
      * @return array<int, array-key>
      */
     public function modelKeys()
     {
-        return array_map(fn ($model) => $model->getKey(), $this->items);
+        return $this->pluckModelKeys()->all();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -307,6 +307,8 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection([$one, $two, $three]);
 
         $this->assertEquals([1, 2, 3], $c->modelKeys());
+        $this->assertInstanceOf(BaseCollection::class, $c->pluckModelKeys());
+        $this->assertEquals([1, 2, 3], $c->pluckModelKeys()->all());
     }
 
     public function testCollectionMergesWithGivenCollection()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -24,6 +24,7 @@ use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
@@ -1031,6 +1032,19 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame([1, 2], EloquentTestUser::oldest('id')->modelKeys());
     }
 
+    public function testPluckModelKeys()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+        ]);
+
+        $keys = EloquentTestUser::oldest('id')->pluckModelKeys();
+
+        $this->assertInstanceOf(BaseCollection::class, $keys);
+        $this->assertSame([1, 2], $keys->all());
+    }
+
     public function testModelKeysWithCastPrimaryKey()
     {
         EloquentTestUserWithStringCastId::insert([
@@ -1039,6 +1053,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertSame(['1', '2'], EloquentTestUserWithStringCastId::oldest('id')->modelKeys());
+        $this->assertSame(['1', '2'], EloquentTestUserWithStringCastId::oldest('id')->pluckModelKeys()->all());
     }
 
     public function testModelKeysWithCustomPrimaryKey()
@@ -1049,6 +1064,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertSame(['first', 'second'], EloquentTestUniqueUserWithCustomKey::orderBy('screen_name')->modelKeys());
+        $this->assertSame(['first', 'second'], EloquentTestUniqueUserWithCustomKey::orderBy('screen_name')->pluckModelKeys()->all());
     }
 
     public function testModelKeysWithQueryConstraints()
@@ -1061,6 +1077,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertSame([2, 3], EloquentTestUser::where('id', '>', 1)->oldest('id')->modelKeys());
         $this->assertSame([1], EloquentTestUser::oldest('id')->take(1)->modelKeys());
+        $this->assertSame([2, 3], EloquentTestUser::where('id', '>', 1)->oldest('id')->pluckModelKeys()->all());
+        $this->assertSame([1], EloquentTestUser::oldest('id')->take(1)->pluckModelKeys()->all());
     }
 
     public function testModelKeysWithRelationshipAndJoin()
@@ -1073,10 +1091,12 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user2->posts()->create(['id' => 3, 'name' => 'Third post']);
 
         $this->assertEquals([1, 2], $user1->posts()->oldest('id')->modelKeys());
+        $this->assertEquals([1, 2], $user1->posts()->oldest('id')->pluckModelKeys()->all());
 
         $join = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')->where('users.id', 1);
 
         $this->assertEquals([1, 1], $join->modelKeys());
+        $this->assertEquals([1, 1], $join->pluckModelKeys()->all());
     }
 
     public function testFindOrFail()

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -71,6 +71,8 @@ function test(
     assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->lazyById());
     assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->lazyByIdDesc());
     assertType('Illuminate\Support\Collection<(int|string), mixed>', $query->pluck('foo'));
+    assertType('Illuminate\Support\Collection<int, (int|string)>', $query->pluckModelKeys());
+    assertType('array<int, (int|string)>', $query->modelKeys());
     assertType('Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model, Illuminate\Types\Builder\User, *>', $query->getRelation('foo'));
     assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query->setModel(new Post()));
 

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -93,6 +93,7 @@ assertType('bool', $collection->contains(function ($user) {
 assertType('bool', $collection->contains('string', '=', 'string'));
 
 assertType('array<int, (int|string)>', $collection->modelKeys());
+assertType('Illuminate\Support\Collection<int, (int|string)>', $collection->pluckModelKeys());
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge($collection));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge([new User]));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `pluckModelKeys()` method to the Eloquent query builder and Eloquent collection. It returns the same primary keys as `modelKeys()`, but as a `Support\Collection` instead of an array:

```php
Post::query()->where('published', true)->pluckModelKeys();
// Illuminate\Support\Collection containing [1, 2, 3]

$posts->pluckModelKeys();
// Illuminate\Support\Collection containing [1, 2, 3]
```

`modelKeys()` already exists and must keep returning an array for backward compatibility. A Collection-returning counterpart is useful when you want to keep chaining Collection methods (`unique()`, `map()`, `diff()`, etc.) without wrapping the array yourself via `collect($query->modelKeys())`.

`modelKeys()` now delegates to `pluckModelKeys()->all()`, so both stay in sync. Existing `modelKeys()` behavior is unchanged.

Note: personally, I think `->modelKeys()` should return a collection, which would be matching the convention of other methods on the collection/builder. but given that this is a breaking change, this is an alternative solution. I choose the name `pluckModelKeys` because I believe it is the best Laravel fit. `modelKeys()` is basically a PK-aware `pluck`; `pluck*` already means “Collection of values.”