### PR TITLE
[14.x] Use spl_object_id over spl_object_hash

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1112,7 +1112,7 @@ class Container implements ArrayAccess, ContainerContract
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            $this->buildStack[] = spl_object_hash($concrete);
+            $this->buildStack[] = spl_object_id($concrete);
 
             try {
                 return $concrete($this, $this->getLastParameterOverride());

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -208,12 +208,12 @@ class Builder implements BuilderContract
     /**
      * Remove a registered global scope.
      *
-     * @param  \Illuminate\Database\Eloquent\Scope|string|int  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
      * @return $this
      */
     public function withoutGlobalScope($scope)
     {
-        if (! is_string($scope) && ! is_int($scope)) {
+        if (is_object($scope)) {
             $scope = get_class($scope);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -208,12 +208,12 @@ class Builder implements BuilderContract
     /**
      * Remove a registered global scope.
      *
-     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|string|int  $scope
      * @return $this
      */
     public function withoutGlobalScope($scope)
     {
-        if (! is_string($scope)) {
+        if (! is_string($scope) && ! is_int($scope)) {
             $scope = get_class($scope);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -65,7 +65,7 @@ trait HasGlobalScopes
         if (is_string($scope) && ($implementation instanceof Closure || $implementation instanceof Scope)) {
             return static::$globalScopes[static::class][$scope] = $implementation;
         } elseif ($scope instanceof Closure) {
-            return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
+            return static::$globalScopes[static::class][spl_object_id($scope)] = $scope;
         } elseif ($scope instanceof Scope) {
             return static::$globalScopes[static::class][get_class($scope)] = $scope;
         } elseif (is_string($scope) && class_exists($scope) && is_subclass_of($scope, Scope::class)) {

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -68,7 +68,7 @@ class Onceable
                 }
 
                 if (is_object($argument)) {
-                    return spl_object_hash($argument);
+                    return spl_object_id($argument);
                 }
 
                 return $argument;

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -24,9 +24,9 @@ class MultipleInstanceManagerTest extends TestCase
         $duplicateFooInstance = $manager->instance('foo');
         $duplicateBarInstance = $manager->instance('bar');
         $duplicateMysqlInstance = $manager->instance('mysql_database-connection');
-        $this->assertEquals(spl_object_hash($fooInstance), spl_object_hash($duplicateFooInstance));
-        $this->assertEquals(spl_object_hash($barInstance), spl_object_hash($duplicateBarInstance));
-        $this->assertEquals(spl_object_hash($mysqlInstance), spl_object_hash($duplicateMysqlInstance));
+        $this->assertEquals(spl_object_id($fooInstance), spl_object_id($duplicateFooInstance));
+        $this->assertEquals(spl_object_id($barInstance), spl_object_id($duplicateBarInstance));
+        $this->assertEquals(spl_object_id($mysqlInstance), spl_object_id($duplicateMysqlInstance));
     }
 
     public function test_unresolvable_instances_throw_errors()

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -17,7 +17,7 @@ class ViewEngineResolverTest extends TestCase
         });
         $result = $resolver->resolve('foo');
 
-        $this->assertEquals(spl_object_hash($result), spl_object_hash($resolver->resolve('foo')));
+        $this->assertEquals(spl_object_id($result), spl_object_id($resolver->resolve('foo')));
     }
 
     public function testResolverThrowsExceptionOnUnknownEngine()


### PR DESCRIPTION
Since it's being deprecated https://github.com/php/php-src/commit/2c1c61de07953f901d95fd93e3ce79b50032e65c in php 8.6

This PR replaces the framework's remaining usages so it's warning-free under 8.6.

Semantically equivalent.. and is what php suggests using in the "modern age"  
https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_spl_object_hash for more info..

Targetted 14.x incase anyone has funky logic using spl_object_hash to grab out the build stack or something, andI've tweaked the builder to check is_object, rather than just ! is_string as this new method returns int (reads better anyway imo) and this isnt technically deprecated in 13.x yet as thats 8.3-8.5 
