### PR TITLE
[13.x] Fix QueueWorkerTest

### DIFF
--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -479,7 +479,7 @@ class QueueWorkerTest extends TestCase
 
         $this->assertTrue($job->isReleased());
         $this->assertFalse($job->isDeleted());
-        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobReleased::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobReleased::class))->once();
     }
 
     public function testWorkerPicksJobUsingCustomCallbacks()


### PR DESCRIPTION
This got changed to Mockery::, the m alias got dropped by Jmac this PR changes it to match elsewhere 🥁  

