### PR TITLE
[13.x] Fix `firstOrNew` query state leakage

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -693,7 +693,7 @@ class Builder implements BuilderContract
      */
     public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (! is_null($instance = (clone $this)->where($attributes)->first())) {
             return $instance;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -245,7 +245,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (is_null($instance = (clone $this)->where($attributes)->first())) {
             $instance = $this->related->newInstance(array_merge($attributes, value($values)));
 
             $this->setForeignAttributesForCreate($instance);

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -204,16 +204,16 @@ abstract class HasOneOrManyThrough extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (! is_null($instance = (clone $this)->where($attributes)->first())) {
             return $instance;
         }
 
-        return $this->related->newInstance(array_merge($attributes, $values));
+        return $this->related->newInstance(array_merge($attributes, value($values)));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -638,6 +638,30 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $this->assertSame('bar', $result->val);
     }
 
+    public function testFirstOrNewDoesNotModifyExistingQuery(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([]);
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table"', [], true, [])
+            ->andReturn([]);
+
+        $query = $model->newQuery();
+
+        $query->firstOrNew(['attr' => 'foo']);
+
+        $this->assertCount(0, $query->get());
+    }
+
     public static function createOrFirstValues(): array
     {
         return [

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -399,6 +399,31 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $this->assertSame('bar', $result->val);
     }
 
+    public function testFirstOrNewDoesNotModifyExistingRelationQuery(): void
+    {
+        $model = new HasManyCreateOrFirstTestParentModel();
+        $model->id = 123;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "child_table" where "child_table"."parent_id" = ? and "child_table"."parent_id" is not null and ("attr" = ?) limit 1', [123, 'foo'], true, [])
+            ->andReturn([]);
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "child_table" where "child_table"."parent_id" = ? and "child_table"."parent_id" is not null', [123], true, [])
+            ->andReturn([]);
+
+        $relation = $model->children();
+
+        $relation->firstOrNew(['attr' => 'foo']);
+
+        $this->assertCount(0, $relation->get());
+    }
+
     public static function createOrFirstValues(): array
     {
         return [

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -166,6 +166,25 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertSame('Tony', $user1->name);
     }
 
+    public function testFirstOrNewAcceptsClosureValuesOnMissingRecord()
+    {
+        $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
+        $team = Team::create(['owner_id' => $taylor->id]);
+        $callCount = 0;
+
+        $user = $taylor->teamMates()->firstOrNew(['slug' => 'tony'], function () use (&$callCount, $team) {
+            $callCount++;
+
+            return ['name' => 'Tony', 'team_id' => $team->id];
+        });
+
+        $this->assertSame(1, $callCount);
+        $this->assertFalse($user->exists);
+        $this->assertEquals($team->id, $user->team_id);
+        $this->assertSame('tony', $user->slug);
+        $this->assertSame('Tony', $user->name);
+    }
+
     public function testFirstOrNewWhenRecordExists()
     {
         $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
@@ -185,6 +204,37 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertTrue($existingTony->is($newTony));
         $this->assertSame('tony', $existingTony->refresh()->slug);
         $this->assertSame('Tony Messias', $existingTony->name);
+    }
+
+    public function testFirstOrNewDoesNotInvokeClosureValuesWhenRecordExists()
+    {
+        $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
+        $team = Team::create(['owner_id' => $taylor->id]);
+        $existingTony = $team->members()->create(['name' => 'Tony Messias', 'slug' => 'tony']);
+        $callCount = 0;
+
+        $user = $taylor->teamMates()->firstOrNew(['slug' => 'tony'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['name' => 'Tony'];
+        });
+
+        $this->assertSame(0, $callCount);
+        $this->assertTrue($existingTony->is($user));
+        $this->assertSame('Tony Messias', $user->name);
+    }
+
+    public function testFirstOrNewDoesNotModifyExistingRelationQuery()
+    {
+        $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
+        $team = Team::create(['owner_id' => $taylor->id]);
+        $john = $team->members()->create(['name' => 'John', 'slug' => 'john']);
+
+        $relation = $taylor->teamMates();
+
+        $relation->firstOrNew(['slug' => 'tony']);
+
+        $this->assertTrue($john->is($relation->sole()));
     }
 
     public function testFirstOrCreateWhenModelDoesntExist()


### PR DESCRIPTION
This PR clones the builder/relation before applying `firstOrNew` lookup attributes so temporary where clauses do not persist on reused query instances.

It also aligns `HasOneOrManyThrough::firstOrNew` with sibling methods by accepting closure values and evaluating them only when a new model is instantiated.
