### PR TITLE
[13.x] Avoid cross-slot reads when checking paused queues

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -313,12 +313,10 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function isPaused($connection, $queue)
     {
-        $states = $this->app['cache']->store()->many([
-            'illuminate:queues:paused',
-            "illuminate:queue:paused:{$connection}:{$queue}",
-        ]);
+        $cache = $this->app['cache']->store();
 
-        return (bool) array_filter($states);
+        return (bool) ($cache->get('illuminate:queues:paused')
+            ?: $cache->get("illuminate:queue:paused:{$connection}:{$queue}"));
     }
 
     /**
@@ -330,15 +328,15 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function getPausedQueues($connection, $queues)
     {
-        $keys = array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues);
+        $cache = $this->app['cache']->store();
 
-        $states = $this->app['cache']->store()->many(
-            array_merge(['illuminate:queues:paused'], $keys)
-        );
-
-        if ($states['illuminate:queues:paused'] ?? false) {
+        if ($cache->get('illuminate:queues:paused')) {
             return array_values($queues);
         }
+
+        $states = $cache->many(
+            array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues)
+        );
 
         return array_values(array_filter(
             $queues, fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -195,6 +195,7 @@ class WorkCommandTest extends QueueTestCase
 
         $cache = Mockery::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
+        $cache->expects('get')->with('illuminate:queues:paused')->andReturn(null);
         $cache->expects('many')->andReturn([]);
 
         $cacheManager = Mockery::mock(CacheManager::class);

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Carbon;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class QueuePauseResumeTest extends TestCase
 {
@@ -23,9 +24,14 @@ class QueuePauseResumeTest extends TestCase
     {
         $this->cache = new Repository(new ArrayStore);
 
+        $this->manager = $this->createManager($this->cache);
+    }
+
+    protected function createManager($cache)
+    {
         // Mock the cache facade to return our cache repository
         $cacheMock = Mockery::mock();
-        $cacheMock->shouldReceive('store')->andReturn($this->cache);
+        $cacheMock->shouldReceive('store')->andReturn($cache);
 
         $app = [
             'config' => [
@@ -37,7 +43,7 @@ class QueuePauseResumeTest extends TestCase
             'events' => new Dispatcher(),
         ];
 
-        $this->manager = new QueueManager($app);
+        return new QueueManager($app);
     }
 
     public function testPauseQueueWithConnection()
@@ -186,6 +192,31 @@ class QueuePauseResumeTest extends TestCase
 
         $this->assertFalse($this->manager->isPaused('redis', 'default'));
         $this->assertSame([], $this->manager->getPausedQueues('redis', ['default', 'emails']));
+    }
+
+    public function testPauseChecksDoNotBatchTheGlobalKeyWithQueueKeys()
+    {
+        $store = new class extends ArrayStore
+        {
+            public function many(array $keys)
+            {
+                if (count($keys) > 1 && in_array('illuminate:queues:paused', $keys)) {
+                    throw new RuntimeException("CROSSSLOT Keys in request don't hash to the same slot");
+                }
+
+                return parent::many($keys);
+            }
+        };
+
+        $manager = $this->createManager(new Repository($store));
+
+        $this->assertFalse($manager->isPaused('redis', 'default'));
+        $this->assertSame([], $manager->getPausedQueues('redis', ['default']));
+
+        $manager->pauseAll();
+
+        $this->assertTrue($manager->isPaused('redis', 'default'));
+        $this->assertSame(['default'], $manager->getPausedQueues('redis', ['default']));
     }
 
     public function testPauseAllDispatchesQueuesPausedEvent()


### PR DESCRIPTION
Since #61126, `getPausedQueues()` fetches the global pause key in the same `many()` call as the per-queue pause keys. On a Redis cache store that becomes a single `MGET` over keys that hash to different slots, so any backend with cluster semantics (Redis Cluster, ElastiCache Serverless) replies with `CROSSSLOT Keys in request don't hash to the same slot`. phpredis signals that by returning `false`, which `PhpRedisConnection::mget()` then passes to `array_map()`, so the worker sees a `TypeError` on every poll and stops consuming jobs. `isPaused()` batches the two kinds of keys the same way.

This reads the global key on its own and batches only the per-queue keys, so a worker polling a single queue is back to reading one key at a time and queues keep running on those backends.

Fixes #61138