### PR TITLE
Read-through filesystem

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -300,10 +300,12 @@ class FilesystemManager implements FactoryContract
             $config['throw_on_promotion_failure'] ?? false,
         );
 
-        return new FilesystemAdapter(
+        return new ReadThroughFilesystem(
             $this->createFlysystem($adapter, $config),
             $primary->getAdapter(),
             array_replace($primary->getConfig(), $config),
+            $primary,
+            $fallback,
         );
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Contracts\Filesystem\Factory as FactoryContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\RebindsCallbacksToSelf;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter as S3Adapter;
 use League\Flysystem\AwsS3V3\PortableVisibilityConverter as AwsS3PortableVisibilityConverter;
@@ -149,7 +150,7 @@ class FilesystemManager implements FactoryContract
             return $this->callCustomCreator($config);
         }
 
-        $driverMethod = 'create'.ucfirst($driver).'Driver';
+        $driverMethod = 'create'.Str::studly($driver).'Driver';
 
         if (! method_exists($this, $driverMethod)) {
             throw new InvalidArgumentException("Driver [{$driver}] is not supported.");
@@ -263,6 +264,46 @@ class FilesystemManager implements FactoryContract
 
         return new AwsS3V3Adapter(
             $this->createFlysystem($adapter, $config), $adapter, $s3Config, $client
+        );
+    }
+
+    /**
+     * Create a read-through filesystem driver.
+     *
+     * @param  array  $config
+     * @param  string  $name
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public function createReadThroughDriver(array $config, string $name = 'read-through')
+    {
+        if (empty($config['primary'])) {
+            throw new InvalidArgumentException('Read-through disk is missing "primary" configuration option.');
+        } elseif (empty($config['fallback'])) {
+            throw new InvalidArgumentException('Read-through disk is missing "fallback" configuration option.');
+        } elseif ($config['primary'] === $config['fallback']) {
+            throw new InvalidArgumentException('Read-through disk requires distinct "primary" and "fallback" disks.');
+        } elseif ($config['primary'] === $name || $config['fallback'] === $name) {
+            throw new InvalidArgumentException("Read-through disk [{$name}] cannot reference itself.");
+        }
+
+        $primary = is_array($config['primary'])
+            ? $this->build($config['primary'])
+            : $this->disk($config['primary']);
+
+        $fallback = is_array($config['fallback'])
+            ? $this->build($config['fallback'])
+            : $this->disk($config['fallback']);
+
+        $adapter = new ReadThroughFilesystemAdapter(
+            $primary->getDriver(),
+            $fallback->getDriver(),
+            $config['throw_on_promotion_failure'] ?? false,
+        );
+
+        return new FilesystemAdapter(
+            $this->createFlysystem($adapter, $config),
+            $primary->getAdapter(),
+            array_replace($primary->getConfig(), $config),
         );
     }
 

--- a/src/Illuminate/Filesystem/ReadThroughFilesystem.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystem.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
+use League\Flysystem\FilesystemOperator;
+
+class ReadThroughFilesystem extends FilesystemAdapter
+{
+    /**
+     * Create a new read-through filesystem instance.
+     */
+    public function __construct(
+        FilesystemOperator $driver,
+        FlysystemAdapter $adapter,
+        array $config,
+        protected FilesystemAdapter $primary,
+        protected FilesystemAdapter $fallback,
+    ) {
+        parent::__construct($driver, $adapter, $config);
+    }
+
+    /**
+     * Get the URL for the file at the given path.
+     */
+    public function url($path)
+    {
+        return $this->readerFor($path)->url($path);
+    }
+
+    /**
+     * Get a temporary URL for the file at the given path.
+     */
+    public function temporaryUrl($path, $expiration, array $options = [])
+    {
+        return isset($this->temporaryUrlCallback)
+            ? parent::temporaryUrl($path, $expiration, $options)
+            : $this->readerFor($path)->temporaryUrl($path, $expiration, $options);
+    }
+
+    /**
+     * Determine if temporary upload URLs can be generated.
+     */
+    public function providesTemporaryUploadUrls()
+    {
+        return isset($this->temporaryUploadUrlCallback) || $this->primary->providesTemporaryUploadUrls();
+    }
+
+    /**
+     * Get a temporary upload URL for the file at the given path.
+     */
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    {
+        return isset($this->temporaryUploadUrlCallback)
+            ? parent::temporaryUploadUrl($path, $expiration, $options)
+            : $this->primary->temporaryUploadUrl($path, $expiration, $options);
+    }
+
+    /**
+     * Determine if temporary URLs can be generated.
+     */
+    public function providesTemporaryUrls()
+    {
+        return isset($this->temporaryUrlCallback)
+            || $this->primary->providesTemporaryUrls()
+            || $this->fallback->providesTemporaryUrls();
+    }
+
+    /**
+     * Get the filesystem that contains the given path.
+     */
+    protected function readerFor($path)
+    {
+        return $this->primary->fileExists($path) ? $this->primary : $this->fallback;
+    }
+}

--- a/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToReadFile;
+
+class ReadThroughFilesystemAdapter implements FilesystemAdapter
+{
+    /**
+     * Create a new read-through filesystem adapter instance.
+     */
+    public function __construct(
+        protected FilesystemOperator $primary,
+        protected FilesystemOperator $fallback,
+        protected bool $throwOnPromotionFailure = false,
+    ) {
+    }
+
+    /**
+     * Determine if a file exists.
+     */
+    public function fileExists(string $path): bool
+    {
+        return $this->primary->fileExists($path) || $this->fallback->fileExists($path);
+    }
+
+    /**
+     * Determine if a directory exists.
+     */
+    public function directoryExists(string $path): bool
+    {
+        return $this->primary->directoryExists($path) || $this->fallback->directoryExists($path);
+    }
+
+    /**
+     * Write a file to the primary filesystem.
+     */
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->primary->write($path, $contents, $config->toArray());
+    }
+
+    /**
+     * Write a file stream to the primary filesystem.
+     */
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->primary->writeStream($path, $contents, $config->toArray());
+    }
+
+    /**
+     * Read a file, promoting it from the fallback filesystem when necessary.
+     */
+    public function read(string $path): string
+    {
+        if ($this->primary->fileExists($path)) {
+            return $this->primary->read($path);
+        }
+
+        $contents = $this->fallback->read($path);
+
+        if ($this->primary->fileExists($path)) {
+            return $this->primary->read($path);
+        }
+
+        try {
+            $this->primary->write($path, $contents);
+        } catch (FilesystemException $exception) {
+            $this->handlePromotionFailure($path, $exception);
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Read a file stream, promoting it from the fallback filesystem when necessary.
+     */
+    public function readStream(string $path)
+    {
+        if ($this->primary->fileExists($path)) {
+            return $this->primary->readStream($path);
+        }
+
+        $source = $this->fallback->readStream($path);
+
+        $temporary = fopen('php://temp', 'w+b');
+
+        try {
+            if ($temporary === false || stream_copy_to_stream($source, $temporary) === false) {
+                throw UnableToReadFile::fromLocation($path);
+            }
+        } finally {
+            fclose($source);
+        }
+
+        rewind($temporary);
+
+        if ($this->primary->fileExists($path)) {
+            fclose($temporary);
+
+            return $this->primary->readStream($path);
+        }
+
+        try {
+            $this->primary->writeStream($path, $temporary);
+        } catch (FilesystemException $exception) {
+            if ($this->throwOnPromotionFailure) {
+                fclose($temporary);
+            }
+
+            $this->handlePromotionFailure($path, $exception);
+        }
+
+        rewind($temporary);
+
+        return $temporary;
+    }
+
+    /**
+     * Delete a file from the primary filesystem.
+     */
+    public function delete(string $path): void
+    {
+        $this->primary->delete($path);
+    }
+
+    /**
+     * Delete a directory from the primary filesystem.
+     */
+    public function deleteDirectory(string $path): void
+    {
+        $this->primary->deleteDirectory($path);
+    }
+
+    /**
+     * Create a directory on the primary filesystem.
+     */
+    public function createDirectory(string $path, Config $config): void
+    {
+        $this->primary->createDirectory($path, $config->toArray());
+    }
+
+    /**
+     * Set a file's visibility on the primary filesystem.
+     */
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->primary->setVisibility($path, $visibility);
+    }
+
+    /**
+     * Retrieve a file's visibility.
+     */
+    public function visibility(string $path): FileAttributes
+    {
+        return new FileAttributes($path, visibility: $this->readerFor($path)->visibility($path));
+    }
+
+    /**
+     * Retrieve a file's MIME type.
+     */
+    public function mimeType(string $path): FileAttributes
+    {
+        return new FileAttributes($path, mimeType: $this->readerFor($path)->mimeType($path));
+    }
+
+    /**
+     * Retrieve a file's last modified time.
+     */
+    public function lastModified(string $path): FileAttributes
+    {
+        return new FileAttributes($path, lastModified: $this->readerFor($path)->lastModified($path));
+    }
+
+    /**
+     * Retrieve a file's size.
+     */
+    public function fileSize(string $path): FileAttributes
+    {
+        return new FileAttributes($path, fileSize: $this->readerFor($path)->fileSize($path));
+    }
+
+    /**
+     * List the contents of the primary filesystem.
+     */
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->primary->listContents($path, $deep);
+    }
+
+    /**
+     * Move a file on the primary filesystem.
+     */
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->primary->move($source, $destination, $config->toArray());
+    }
+
+    /**
+     * Copy a file on the primary filesystem.
+     */
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->primary->copy($source, $destination, $config->toArray());
+    }
+
+    /**
+     * Get the filesystem that contains the given path.
+     */
+    protected function readerFor(string $path): FilesystemOperator
+    {
+        return $this->primary->fileExists($path) ? $this->primary : $this->fallback;
+    }
+
+    /**
+     * Handle an exception encountered while promoting a file.
+     */
+    protected function handlePromotionFailure(string $path, FilesystemException $exception): void
+    {
+        if ($this->throwOnPromotionFailure) {
+            throw UnableToReadFile::fromLocation($path, 'Unable to promote file to the primary filesystem.', $exception);
+        }
+    }
+}

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,7 +2,8 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
@@ -14,6 +15,17 @@ use stdClass;
 
 class FilesystemManagerTest extends TestCase
 {
+    protected array $temporaryDirectories = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryDirectories as $directory) {
+            (new Filesystem)->deleteDirectory($directory);
+        }
+
+        parent::tearDown();
+    }
+
     public function testExceptionThrownOnUnsupportedDriver()
     {
         $this->expectExceptionObject(new InvalidArgumentException('Disk [local] does not have a configured driver.'));
@@ -29,9 +41,9 @@ class FilesystemManagerTest extends TestCase
     {
         $filesystem = new FilesystemManager(new Application);
 
-        $this->assertInstanceOf(Filesystem::class, $filesystem->build('my-custom-path'));
+        $this->assertInstanceOf(FilesystemContract::class, $filesystem->build('my-custom-path'));
 
-        $this->assertInstanceOf(Filesystem::class, $filesystem->build([
+        $this->assertInstanceOf(FilesystemContract::class, $filesystem->build([
             'driver' => 'local',
             'root' => 'my-custom-path',
             'url' => 'my-custom-url',
@@ -217,6 +229,85 @@ class FilesystemManagerTest extends TestCase
         }
     }
 
+    public function testCanBuildReadThroughDisks()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('fallback.txt', 'fallback contents');
+        $fallback->put('hidden-from-listing.txt', 'contents');
+        $primary->put('primary.txt', 'primary contents');
+        $primary->put('preferred.txt', 'primary version');
+        $fallback->put('preferred.txt', 'fallback version');
+
+        $this->assertTrue($readThrough->exists('fallback.txt'));
+        $this->assertSame(strlen('fallback contents'), $readThrough->size('fallback.txt'));
+        $this->assertTrue($primary->missing('fallback.txt'));
+        $this->assertSame(['preferred.txt', 'primary.txt'], $readThrough->files());
+
+        $this->assertSame('fallback contents', $readThrough->get('fallback.txt'));
+        $this->assertSame('fallback contents', $primary->get('fallback.txt'));
+        $this->assertSame('primary version', $readThrough->get('preferred.txt'));
+
+        $readThrough->put('written.txt', 'written contents');
+
+        $this->assertSame('written contents', $primary->get('written.txt'));
+        $this->assertTrue($fallback->missing('written.txt'));
+    }
+
+    public function testReadThroughDisksPromoteStreams()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('stream.txt', 'stream contents');
+
+        $stream = $readThrough->readStream('stream.txt');
+
+        $this->assertSame('stream contents', stream_get_contents($stream));
+        $this->assertSame('stream contents', $primary->get('stream.txt'));
+
+        fclose($stream);
+    }
+
+    public function testReadThroughDiskPromotionFailuresAreBestEffortByDefault()
+    {
+        $filesystem = $this->readThroughFilesystemManager([
+            'primary' => [
+                'driver' => 'local',
+                'root' => $this->temporaryDirectory('primary'),
+                'read-only' => true,
+            ],
+        ]);
+
+        $filesystem->disk('fallback')->put('fallback.txt', 'fallback contents');
+
+        $this->assertSame('fallback contents', $filesystem->disk('read-through')->get('fallback.txt'));
+    }
+
+    public function testReadThroughDiskCanThrowOnPromotionFailures()
+    {
+        $filesystem = $this->readThroughFilesystemManager([
+            'primary' => [
+                'driver' => 'local',
+                'root' => $this->temporaryDirectory('primary'),
+                'read-only' => true,
+            ],
+            'throw' => true,
+            'throw_on_promotion_failure' => true,
+        ]);
+
+        $filesystem->disk('fallback')->put('fallback.txt', 'fallback contents');
+
+        $this->expectException(UnableToReadFile::class);
+
+        $filesystem->disk('read-through')->get('fallback.txt');
+    }
+
     public function testCustomDriverClosureBoundObjectIsFilesystemManager()
     {
         $manager = new FilesystemManager(tap(new Application, function ($app) {
@@ -286,6 +377,35 @@ class FilesystemManagerTest extends TestCase
     //         rmdir(__DIR__.'/../../to-be-scoped');
     //     }
     // }
+
+    protected function readThroughFilesystemManager(array $readThroughConfig = []): FilesystemManager
+    {
+        $primary = $this->temporaryDirectory('primary');
+        $fallback = $this->temporaryDirectory('fallback');
+
+        return new FilesystemManager(tap(new Application, function ($app) use ($primary, $fallback, $readThroughConfig) {
+            $app['config'] = [
+                'filesystems.disks.primary' => [
+                    'driver' => 'local',
+                    'root' => $primary,
+                ],
+                'filesystems.disks.fallback' => [
+                    'driver' => 'local',
+                    'root' => $fallback,
+                ],
+                'filesystems.disks.read-through' => array_replace([
+                    'driver' => 'read-through',
+                    'primary' => 'primary',
+                    'fallback' => 'fallback',
+                ], $readThroughConfig),
+            ];
+        }));
+    }
+
+    protected function temporaryDirectory(string $name): string
+    {
+        return $this->temporaryDirectories[] = sys_get_temp_dir().'/laravel-read-through-'.$name.'-'.uniqid();
+    }
 }
 
 class CustomFilesystemDriver

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
@@ -308,6 +309,39 @@ class FilesystemManagerTest extends TestCase
         $filesystem->disk('read-through')->get('fallback.txt');
     }
 
+    public function testReadThroughDisksDelegateUrlsToTheDiskContainingTheFile()
+    {
+        $filesystem = $this->readThroughFilesystemManager([], [
+            'url' => 'https://primary.test',
+        ], [
+            'url' => 'https://fallback.test',
+        ]);
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+        $expiration = Carbon::create(2026, 8, 11);
+
+        $primary->put('primary.txt', 'primary contents');
+        $fallback->put('fallback.txt', 'fallback contents');
+        $primary->buildTemporaryUrlsUsing(fn ($path, $expiration, $options) => 'primary/'.$path.'/'.$options['version']);
+        $fallback->buildTemporaryUrlsUsing(fn ($path, $expiration, $options) => 'fallback/'.$path.'/'.$options['version']);
+        $primary->buildTemporaryUploadUrlsUsing(fn ($path, $expiration, $options) => [
+            'url' => 'upload/'.$path.'/'.$options['version'],
+            'headers' => ['X-Test' => 'header'],
+        ]);
+
+        $this->assertSame('https://primary.test/primary.txt', $readThrough->url('primary.txt'));
+        $this->assertSame('https://fallback.test/fallback.txt', $readThrough->url('fallback.txt'));
+        $this->assertTrue($readThrough->providesTemporaryUrls());
+        $this->assertSame('primary/primary.txt/1', $readThrough->temporaryUrl('primary.txt', $expiration, ['version' => 1]));
+        $this->assertSame('fallback/fallback.txt/1', $readThrough->temporaryUrl('fallback.txt', $expiration, ['version' => 1]));
+        $this->assertTrue($readThrough->providesTemporaryUploadUrls());
+        $this->assertSame([
+            'url' => 'upload/file.txt/1',
+            'headers' => ['X-Test' => 'header'],
+        ], $readThrough->temporaryUploadUrl('file.txt', $expiration, ['version' => 1]));
+    }
+
     public function testCustomDriverClosureBoundObjectIsFilesystemManager()
     {
         $manager = new FilesystemManager(tap(new Application, function ($app) {
@@ -378,21 +412,24 @@ class FilesystemManagerTest extends TestCase
     //     }
     // }
 
-    protected function readThroughFilesystemManager(array $readThroughConfig = []): FilesystemManager
-    {
+    protected function readThroughFilesystemManager(
+        array $readThroughConfig = [],
+        array $primaryConfig = [],
+        array $fallbackConfig = [],
+    ): FilesystemManager {
         $primary = $this->temporaryDirectory('primary');
         $fallback = $this->temporaryDirectory('fallback');
 
-        return new FilesystemManager(tap(new Application, function ($app) use ($primary, $fallback, $readThroughConfig) {
+        return new FilesystemManager(tap(new Application, function ($app) use ($primary, $fallback, $readThroughConfig, $primaryConfig, $fallbackConfig) {
             $app['config'] = [
-                'filesystems.disks.primary' => [
+                'filesystems.disks.primary' => array_replace([
                     'driver' => 'local',
                     'root' => $primary,
-                ],
-                'filesystems.disks.fallback' => [
+                ], $primaryConfig),
+                'filesystems.disks.fallback' => array_replace([
                     'driver' => 'local',
                     'root' => $fallback,
-                ],
+                ], $fallbackConfig),
                 'filesystems.disks.read-through' => array_replace([
                     'driver' => 'read-through',
                     'primary' => 'primary',


### PR DESCRIPTION
This PR adds a read-through filesystem driver that combines a primary and fallback disk. Reads check the primary first, then read from the fallback and copy the file to primary for future requests.

```php
'assets' => [
    'driver' => 'read-through',
    'primary' => 'r2',
    'fallback' => 'legacy-s3',
],
```

Writes and listings target the primary disk, while existence and metadata checks can use either disk without triggering a copy. Streamed reads are also supported without loading the entire file into memory.