### PR TITLE
[12.x] Stricten `upload` to be fetch only from request's query string for temporary upload urls

### DIFF
--- a/src/Illuminate/Filesystem/ReceiveFile.php
+++ b/src/Illuminate/Filesystem/ReceiveFile.php
@@ -44,6 +44,6 @@ class ReceiveFile
      */
     protected function hasValidSignature(Request $request): bool
     {
-        return $request->boolean('upload') && $request->hasValidRelativeSignature();
+        return filter_var($request->query('upload', false), FILTER_VALIDATE_BOOLEAN) && $request->hasValidRelativeSignature();
     }
 }

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -54,7 +54,7 @@ class ServeFile
      */
     protected function hasValidSignature(Request $request): bool
     {
-        return ! $request->boolean('upload') && (
+        return ! filter_var($request->query('upload', false), FILTER_VALIDATE_BOOLEAN) && (
             ($this->config['visibility'] ?? 'private') === 'public' ||
             $request->hasValidRelativeSignature()
         );


### PR DESCRIPTION


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
