### PR TITLE
[13.x] Accept enums in `inOrderOf()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3083,7 +3083,7 @@ class Builder implements BuilderContract
      * Add an "order by" clause to order results by a given sequence of values.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array<\UnitEnum|string|int|float|bool>  $values
      * @return $this
      */
     public function inOrderOf($column, $values)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3092,7 +3092,7 @@ class Builder implements BuilderContract
             $values = $values->toArray();
         }
 
-        $values = array_values($values);
+        $values = array_map(enum_value(...), array_values($values));
 
         if (empty($values)) {
             return $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2549,6 +2549,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([true, 'pending', 'approved'], $builder->getBindings());
     }
 
+    public function testInOrderOfWithBackedEnumValues()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->inOrderOf('status', [StringStatus::pending, StringStatus::done, StringStatus::draft]);
+        $this->assertSame('select * from "users" order by case when "status" = ? then 0 when "status" = ? then 1 when "status" = ? then 2 else 3 end', $builder->toSql());
+        $this->assertEquals(['pending', 'done', 'draft'], $builder->getBindings());
+    }
+
+    public function testInOrderOfWithIntegerBackedEnumValues()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->inOrderOf('status', [IntegerStatus::done, IntegerStatus::pending]);
+        $this->assertSame('select * from "users" order by case when "status" = ? then 0 when "status" = ? then 1 else 2 end', $builder->toSql());
+        $this->assertEquals([2, 1], $builder->getBindings());
+    }
+
     public function testOrderBysSqlServer()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
This PR allows enum values to be passed into the `inOrderOf()` query builder method:

```php
$orders = DB::table('orders')
      ->inOrderOf('status', [Status::Pending, Status::Processing, Status::Shipped])
      ->get();
```