### PR TITLE
[13.x] Use static closures where possible

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -639,7 +639,7 @@ class Gate implements GateContract
             return $this->abilities[$ability];
         }
 
-        return function () {
+        return static function () {
             //
         };
     }
@@ -718,14 +718,14 @@ class Gate implements GateContract
 
         $classDirnameSegments = explode('\\', $classDirname);
 
-        return Arr::wrap(Collection::times(count($classDirnameSegments), function ($index) use ($class, $classDirnameSegments) {
+        return Arr::wrap(Collection::times(count($classDirnameSegments), static function ($index) use ($class, $classDirnameSegments) {
             $classDirname = implode('\\', array_slice($classDirnameSegments, 0, $index));
 
             return $classDirname.'\\Policies\\'.class_basename($class).'Policy';
-        })->when(str_contains($classDirname, '\\Models\\'), function ($collection) use ($class, $classDirname) {
+        })->when(str_contains($classDirname, '\\Models\\'), static function ($collection) use ($class, $classDirname) {
             return $collection->concat([str_replace('\\Models\\', '\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy'])
                 ->concat([str_replace('\\Models\\', '\\Models\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy']);
-        })->reverse()->values()->first(function ($class) {
+        })->reverse()->values()->first(static function ($class) {
             return class_exists($class);
         }) ?: [$classDirname.'\\Policies\\'.class_basename($class).'Policy']);
     }
@@ -860,7 +860,7 @@ class Gate implements GateContract
     {
         $gate = new static(
             $this->container,
-            fn () => $user,
+            static fn () => $user,
             $this->abilities,
             $this->policies,
             $this->beforeCallbacks,

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -34,9 +34,9 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthenticator()
     {
-        $this->app->singleton('auth', fn ($app) => new AuthManager($app));
+        $this->app->singleton('auth', static fn ($app) => new AuthManager($app));
 
-        $this->app->singleton('auth.driver', fn ($app) => $app['auth']->guard());
+        $this->app->singleton('auth.driver', static fn ($app) => $app['auth']->guard());
     }
 
     /**
@@ -46,7 +46,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerUserResolver()
     {
-        $this->app->bind(AuthenticatableContract::class, fn ($app) => call_user_func($app['auth']->userResolver()));
+        $this->app->bind(AuthenticatableContract::class, static fn ($app) => call_user_func($app['auth']->userResolver()));
     }
 
     /**
@@ -56,8 +56,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAccessGate()
     {
-        $this->app->singleton(GateContract::class, function ($app) {
-            return new Gate($app, fn () => call_user_func($app['auth']->userResolver()));
+        $this->app->singleton(GateContract::class, static function ($app) {
+            return new Gate($app, static fn () => call_user_func($app['auth']->userResolver()));
         });
     }
 
@@ -68,7 +68,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerRequirePassword()
     {
-        $this->app->bind(RequirePassword::class, function ($app) {
+        $this->app->bind(RequirePassword::class, static function ($app) {
             return new RequirePassword(
                 $app[ResponseFactory::class],
                 $app[UrlGenerator::class],
@@ -84,8 +84,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerRequestRebindHandler()
     {
-        $this->app->rebinding('request', function ($app, $request) {
-            $request->setUserResolver(function ($guard = null) use ($app) {
+        $this->app->rebinding('request', static function ($app, $request) {
+            $request->setUserResolver(static function ($guard = null) use ($app) {
                 return call_user_func($app['auth']->userResolver(), $guard);
             });
         });
@@ -98,7 +98,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerEventRebindHandler()
     {
-        $this->app->rebinding('events', function ($app, $dispatcher) {
+        $this->app->rebinding('events', static function ($app, $dispatcher) {
             if (! $app->resolved('auth') ||
                 $app['auth']->hasResolvedGuards() === false) {
                 return;

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -101,7 +101,7 @@ class DatabaseUserProvider implements UserProvider
     {
         $credentials = array_filter(
             $credentials,
-            fn ($key) => ! str_contains($key, 'password'),
+            static fn ($key) => ! str_contains($key, 'password'),
             ARRAY_FILTER_USE_KEY
         );
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -112,7 +112,7 @@ class EloquentUserProvider implements UserProvider
     {
         $credentials = array_filter(
             $credentials,
-            fn ($key) => ! str_contains($key, 'password'),
+            static fn ($key) => ! str_contains($key, 'password'),
             ARRAY_FILTER_USE_KEY
         );
 

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -24,11 +24,11 @@ class PasswordResetServiceProvider extends ServiceProvider implements Deferrable
      */
     protected function registerPasswordBroker()
     {
-        $this->app->singleton('auth.password', function ($app) {
+        $this->app->singleton('auth.password', static function ($app) {
             return new PasswordBrokerManager($app);
         });
 
-        $this->app->bind('auth.password.broker', function ($app) {
+        $this->app->bind('auth.password.broker', static function ($app) {
             return $app->make('auth.password')->broker();
         });
     }

--- a/src/Illuminate/Broadcasting/AnonymousEvent.php
+++ b/src/Illuminate/Broadcasting/AnonymousEvent.php
@@ -73,7 +73,7 @@ class AnonymousEvent implements ShouldBroadcast
         $this->payload = $payload instanceof Arrayable
             ? $payload->toArray()
             : (new Collection($payload))->map(
-                fn ($p) => $p instanceof Arrayable ? $p->toArray() : $p
+                static fn ($p) => $p instanceof Arrayable ? $p->toArray() : $p
             )->all();
 
         return $this;

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -84,7 +84,7 @@ class BroadcastManager implements FactoryContract
 
         $attributes = $attributes ?: ['middleware' => ['web']];
 
-        $this->app['router']->group($attributes, function ($router) {
+        $this->app['router']->group($attributes, static function ($router) {
             $router->match(
                 ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'
@@ -106,7 +106,7 @@ class BroadcastManager implements FactoryContract
 
         $attributes = $attributes ?: ['middleware' => ['web']];
 
-        $this->app['router']->group($attributes, function ($router) {
+        $this->app['router']->group($attributes, static function ($router) {
             $router->match(
                 ['get', 'post'], '/broadcasting/user-auth',
                 '\\'.BroadcastController::class.'@authenticateUser'

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -16,9 +16,9 @@ class BroadcastServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function register()
     {
-        $this->app->singleton(BroadcastManager::class, fn ($app) => new BroadcastManager($app));
+        $this->app->singleton(BroadcastManager::class, static fn ($app) => new BroadcastManager($app));
 
-        $this->app->singleton(BroadcasterContract::class, function ($app) {
+        $this->app->singleton(BroadcasterContract::class, static function ($app) {
             return $app->make(BroadcastManager::class)->connection();
         });
 

--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -146,7 +146,7 @@ class AblyBroadcaster extends Broadcaster
      */
     protected function buildAblyMessage($event, array $payload = [])
     {
-        return tap(new AblyMessage, function ($message) use ($event, $payload) {
+        return tap(new AblyMessage, static function ($message) use ($event, $payload) {
             $message->name = $event;
             $message->data = $payload;
             $message->connectionKey = data_get($payload, 'socket');
@@ -189,7 +189,7 @@ class AblyBroadcaster extends Broadcaster
      */
     protected function formatChannels(array $channels)
     {
-        return array_map(function ($channel) {
+        return array_map(static function ($channel) {
             $channel = (string) $channel;
 
             if (Str::startsWith($channel, ['private-', 'presence-'])) {

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -142,7 +142,7 @@ abstract class Broadcaster implements BroadcasterContract
         $callbackParameters = $this->extractParameters($callback);
 
         return (new Collection($this->extractChannelKeys($pattern, $channel)))
-            ->reject(fn ($value, $key) => is_numeric($key))
+            ->reject(static fn ($value, $key) => is_numeric($key))
             ->map(fn ($value, $key) => $this->resolveBinding($key, $value, $callbackParameters))
             ->values()
             ->all();
@@ -285,7 +285,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function formatChannels(array $channels)
     {
-        return array_map(function ($channel) {
+        return array_map(static function ($channel) {
             return (string) $channel;
         }, $channels);
     }
@@ -314,7 +314,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function normalizeChannelHandlerToCallable($callback)
     {
-        return is_callable($callback) ? $callback : function (...$args) use ($callback) {
+        return is_callable($callback) ? $callback : static function (...$args) use ($callback) {
             return Container::getInstance()
                 ->make($callback)
                 ->join(...$args);

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -20,8 +20,8 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton(Dispatcher::class, function ($app) {
-            return new Dispatcher($app, function ($connection = null) {
+        $this->app->singleton(Dispatcher::class, static function ($app) {
+            return new Dispatcher($app, static function ($connection = null) {
                 return Container::getInstance()->make(QueueFactoryContract::class)->connection($connection);
             });
         });
@@ -44,7 +44,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerBatchServices()
     {
-        $this->app->singleton(BatchRepository::class, function ($app) {
+        $this->app->singleton(BatchRepository::class, static function ($app) {
             $driver = $app->config->get('queue.batching.driver', 'database');
 
             return $driver === 'dynamodb'
@@ -52,7 +52,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
                 : $app->make(DatabaseBatchRepository::class);
         });
 
-        $this->app->singleton(DatabaseBatchRepository::class, function ($app) {
+        $this->app->singleton(DatabaseBatchRepository::class, static function ($app) {
             return new DatabaseBatchRepository(
                 $app->make(BatchFactory::class),
                 $app->make('db')->connection($app->config->get('queue.batching.database')),
@@ -60,7 +60,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             );
         });
 
-        $this->app->singleton(DynamoBatchRepository::class, function ($app) {
+        $this->app->singleton(DynamoBatchRepository::class, static function ($app) {
             $config = $app->config->get('queue.batching');
 
             $dynamoConfig = [

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -59,7 +59,7 @@ class ChainedBatch implements ShouldQueue
      */
     public static function prepareNestedBatches(Collection $jobs): Collection
     {
-        return $jobs->filter()->values()->map(fn ($job) => match (true) {
+        return $jobs->filter()->values()->map(static fn ($job) => match (true) {
             is_array($job) => static::prepareNestedBatches(new Collection($job))->all(),
             $job instanceof Collection => static::prepareNestedBatches($job),
             $job instanceof PendingBatch => new ChainedBatch($job),
@@ -100,7 +100,7 @@ class ChainedBatch implements ShouldQueue
         }
 
         foreach ($this->chainCatchCallbacks ?? [] as $callback) {
-            $batch->catch(function (Batch $batch, ?Throwable $exception) use ($callback) {
+            $batch->catch(static function (Batch $batch, ?Throwable $exception) use ($callback) {
                 if (! $batch->allowsFailures()) {
                     $callback($exception);
                 }
@@ -130,7 +130,7 @@ class ChainedBatch implements ShouldQueue
             $next->chainQueue = $this->chainQueue;
             $next->chainCatchCallbacks = $this->chainCatchCallbacks;
 
-            $batch->finally(function (Batch $batch) use ($next) {
+            $batch->finally(static function (Batch $batch) use ($next) {
                 if (! $batch->cancelled()) {
                     Container::getInstance()->make(Dispatcher::class)->dispatch($next);
                 }

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -60,7 +60,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
         return $this->connection->table($this->table)
             ->orderByDesc('id')
             ->limit($limit)
-            ->when($before, fn ($q) => $q->where('id', '<', $before))
+            ->when($before, static fn ($q) => $q->where('id', '<', $before))
             ->get()
             ->map(function ($batch) {
                 return $this->toBatch($batch);
@@ -137,7 +137,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function decrementPendingJobs(string $batchId, string $jobId)
     {
-        $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
+        $values = $this->updateAtomicValues($batchId, static function ($batch) use ($jobId) {
             return [
                 'pending_jobs' => $batch->pending_jobs - 1,
                 'failed_jobs' => $batch->failed_jobs,
@@ -160,7 +160,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function incrementFailedJobs(string $batchId, string $jobId)
     {
-        $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
+        $values = $this->updateAtomicValues($batchId, static function ($batch) use ($jobId) {
             return [
                 'pending_jobs' => $batch->pending_jobs,
                 'failed_jobs' => $batch->failed_jobs + 1,
@@ -311,7 +311,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function transaction(Closure $callback)
     {
-        return $this->connection->transaction(fn () => $callback());
+        return $this->connection->transaction(static fn () => $callback());
     }
 
     /**

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -124,7 +124,7 @@ class Dispatcher implements QueueingDispatcher
         }
 
         if ($handler || $handler = $this->getCommandHandler($command)) {
-            $callback = function ($command) use ($handler) {
+            $callback = static function ($command) use ($handler) {
                 $method = method_exists($handler, 'handle') ? 'handle' : '__invoke';
 
                 return $handler->{$method}($command);

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -464,7 +464,7 @@ class PendingBatch
     {
         $batch = $repository->store($this);
 
-        (new Collection($this->beforeCallbacks()))->each(function ($handler) use ($batch) {
+        (new Collection($this->beforeCallbacks()))->each(static function ($handler) use ($batch) {
             try {
                 return $handler($batch);
             } catch (Throwable $e) {

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -358,7 +358,7 @@ trait Queueable
      */
     public function invokeChainCatchCallbacks($e)
     {
-        (new Collection($this->chainCatchCallbacks))->each(function ($callback) use ($e) {
+        (new Collection($this->chainCatchCallbacks))->each(static function ($callback) use ($e) {
             $callback($e);
         });
     }
@@ -376,10 +376,10 @@ trait Queueable
             'The expected chain can not be empty.'
         );
 
-        if ((new Collection($expectedChain))->contains(fn ($job) => is_object($job))) {
-            $expectedChain = (new Collection($expectedChain))->map(fn ($job) => serialize($job))->all();
+        if ((new Collection($expectedChain))->contains(static fn ($job) => is_object($job))) {
+            $expectedChain = (new Collection($expectedChain))->map(static fn ($job) => serialize($job))->all();
         } else {
-            $chain = (new Collection($this->chained))->map(fn ($job) => get_class(unserialize($job)))->all();
+            $chain = (new Collection($this->chained))->map(static fn ($job) => get_class(unserialize($job)))->all();
         }
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -15,23 +15,23 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('cache', function ($app) {
+        $this->app->singleton('cache', static function ($app) {
             return new CacheManager($app);
         });
 
-        $this->app->singleton('cache.store', function ($app) {
+        $this->app->singleton('cache.store', static function ($app) {
             return $app['cache']->driver();
         });
 
-        $this->app->singleton('cache.psr6', function ($app) {
+        $this->app->singleton('cache.psr6', static function ($app) {
             return new Psr16Adapter($app['cache.store']);
         });
 
-        $this->app->singleton('memcached.connector', function () {
+        $this->app->singleton('memcached.connector', static function () {
             return new MemcachedConnector;
         });
 
-        $this->app->singleton(RateLimiter::class, function ($app) {
+        $this->app->singleton(RateLimiter::class, static function ($app) {
             return new RateLimiter($app->make('cache')->driver(
                 $app['config']->get('cache.limiter')
             ));

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -140,7 +140,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
                 return $this->prefix.$key;
             }, $keys))
             ->get()
-            ->map(function ($value) {
+            ->map(static function ($value) {
                 return is_array($value) ? (object) $value : $value;
             });
 
@@ -149,7 +149,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
         // If this cache expiration date is past the current time, we will remove this
         // item from the cache. Then we will return a null value since the cache is
         // expired. We will use "Carbon" to make this comparison with the column.
-        [$values, $expired] = $values->partition(function ($cache) use ($currentTime) {
+        [$values, $expired] = $values->partition(static function ($cache) use ($currentTime) {
             return $cache->expiration > $currentTime;
         });
 
@@ -243,7 +243,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
      */
     public function increment($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current + $value;
         });
     }
@@ -257,7 +257,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
      */
     public function decrement($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current - $value;
         });
     }

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -124,7 +124,7 @@ class DynamoDbStore implements LockProvider, Store
         $now = Carbon::now();
 
         return array_merge(
-            Arr::mapWithKeys($keys, fn ($key) => [$key => null]),
+            Arr::mapWithKeys($keys, static fn ($key) => [$key => null]),
             (new Collection($response['Responses'][$this->table]))->mapWithKeys(function ($response) use ($now) {
                 if ($this->isExpired($response, $now)) {
                     $value = null;

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -71,7 +71,7 @@ class RateLimiter
             return;
         }
 
-        return function (...$args) use ($limiter) {
+        return static function (...$args) use ($limiter) {
             $result = $limiter(...$args);
 
             if (! is_array($result)) {

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -367,7 +367,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $prefix = $connectionPrefix.$this->getPrefix();
 
-        return (new LazyCollection(function () use ($connection, $chunkSize, $prefix, $defaultCursorValue) {
+        return (new LazyCollection(static function () use ($connection, $chunkSize, $prefix, $defaultCursorValue) {
             $cursor = $defaultCursorValue;
 
             do {
@@ -396,7 +396,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
                     yield $tag;
                 }
             } while (((string) $cursor) !== $defaultCursorValue);
-        }))->map(fn (string $tagKey) => Str::match('/^'.preg_quote($prefix, '/').'tag:(.*):entries$/', $tagKey));
+        }))->map(static fn (string $tagKey) => Str::match('/^'.preg_quote($prefix, '/').'tag:(.*):entries$/', $tagKey));
     }
 
     /**

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -162,7 +162,7 @@ class RedisTaggedCache extends TaggedCache
         $prefix = $this->store->getPrefix();
 
         $entries = $this->tags->entries()
-            ->map(fn (string $key) => $prefix.$key)
+            ->map(static fn (string $key) => $prefix.$key)
             ->chunk(1000);
 
         foreach ($entries as $keysToBeDeleted) {
@@ -206,14 +206,14 @@ class RedisTaggedCache extends TaggedCache
         $prefix = $this->store->getPrefix();
 
         $entries = $this->tags->entries()
-            ->map(fn (string $key) => $prefix.$key)
+            ->map(static fn (string $key) => $prefix.$key)
             ->chunk(1000);
 
         $connection = $this->store->connection();
 
         foreach ($entries as $cacheKeys) {
             if ($connection instanceof PredisClusterConnection) {
-                $connection->pipeline(function ($connection) use ($cacheKeys) {
+                $connection->pipeline(static function ($connection) use ($cacheKeys) {
                     foreach ($cacheKeys as $cacheKey) {
                         $connection->del($cacheKey);
                     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -165,7 +165,7 @@ class Repository implements ArrayAccess, CacheContract
         $this->event(new RetrievingManyKeys($this->getName(), $keys));
 
         $values = $this->store->many((new Collection($keys))
-            ->map(fn ($value, $key) => is_string($key) ? $key : enum_value($value))
+            ->map(static fn ($value, $key) => is_string($key) ? $key : enum_value($value))
             ->values()
             ->all()
         );

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -19,7 +19,7 @@ trait RetrievesMultipleKeys
         $return = [];
 
         $keys = (new Collection($keys))
-            ->mapWithKeys(fn ($value, $key) => [is_string($key) ? $key : $value => is_string($key) ? $value : null])
+            ->mapWithKeys(static fn ($value, $key) => [is_string($key) ? $key : $value => is_string($key) ? $value : null])
             ->all();
 
         foreach ($keys as $key => $default) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -186,7 +186,7 @@ class Arr
     {
         $results = [];
 
-        $flatten = function ($data, $prefix, $currentDepth) use (&$results, &$flatten, $depth): void {
+        $flatten = static function ($data, $prefix, $currentDepth) use (&$results, &$flatten, $depth): void {
             foreach ($data as $key => $value) {
                 $newKey = $prefix.$key;
 
@@ -249,7 +249,7 @@ class Arr
     {
         $values = (array) $values;
 
-        return array_filter($array, function ($value) use ($values, $strict) {
+        return array_filter($array, static function ($value) use ($values, $strict) {
             return ! in_array($value, $values, $strict);
         });
     }
@@ -562,7 +562,7 @@ class Arr
             return false;
         }
 
-        return array_all($keys, fn ($key) => static::has($array, $key));
+        return array_all($keys, static fn ($key) => static::has($array, $key));
     }
 
     /**
@@ -588,7 +588,7 @@ class Arr
             return false;
         }
 
-        return array_any($keys, fn ($key) => static::has($array, $key));
+        return array_any($keys, static fn ($key) => static::has($array, $key));
     }
 
     /**
@@ -729,7 +729,7 @@ class Arr
      */
     public static function prependKeysWith($array, $prependWith)
     {
-        return static::mapWithKeys($array, fn ($item, $key) => [$prependWith.$key => $item]);
+        return static::mapWithKeys($array, static fn ($item, $key) => [$prependWith.$key => $item]);
     }
 
     /**
@@ -756,7 +756,7 @@ class Arr
     {
         $values = (array) $values;
 
-        return array_filter($array, function ($value) use ($values, $strict) {
+        return array_filter($array, static function ($value) use ($values, $strict) {
             return in_array($value, $values, $strict);
         });
     }
@@ -772,7 +772,7 @@ class Arr
     {
         $keys = static::wrap($keys);
 
-        return static::map($array, function ($item) use ($keys) {
+        return static::map($array, static function ($item) use ($keys) {
             $result = [];
 
             foreach ($keys as $key) {
@@ -904,7 +904,7 @@ class Arr
      */
     public static function mapSpread(array $array, callable $callback)
     {
-        return static::map($array, function ($chunk, $key) use ($callback) {
+        return static::map($array, static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -1271,7 +1271,7 @@ class Arr
      */
     public static function reject($array, callable $callback)
     {
-        return static::where($array, fn ($value, $key) => ! $callback($value, $key));
+        return static::where($array, static fn ($value, $key) => ! $callback($value, $key));
     }
 
     /**
@@ -1311,7 +1311,7 @@ class Arr
      */
     public static function whereNotNull($array)
     {
-        return static::where($array, fn ($value) => ! is_null($value));
+        return static::where($array, static fn ($value) => ! is_null($value));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -98,7 +98,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function median($key = null)
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
-            ->reject(fn ($item) => is_null($item))
+            ->reject(static fn ($item) => is_null($item))
             ->sort()->values();
 
         $count = $values->count();
@@ -134,13 +134,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $counts = $this->newInstance();
 
-        $collection->each(fn ($value) => $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1);
+        $collection->each(static fn ($value) => $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1);
 
         $sorted = $counts->sort();
 
         $highestValue = $sorted->last();
 
-        return $sorted->filter(fn ($value) => $value == $highestValue)
+        return $sorted->filter(static fn ($value) => $value == $highestValue)
             ->sort()->keys()->all();
     }
 
@@ -215,7 +215,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function containsStrict($key, $value = null)
     {
         if (func_num_args() === 2) {
-            return $this->contains(fn ($item) => data_get($item, $key) === $value);
+            return $this->contains(static fn ($item) => data_get($item, $key) === $value);
         }
 
         if ($this->useAsCallable($key)) {
@@ -388,10 +388,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     protected function duplicateComparator($strict)
     {
         if ($strict) {
-            return fn ($a, $b) => $a === $b;
+            return static fn ($a, $b) => $a === $b;
         }
 
-        return fn ($a, $b) => $a == $b;
+        return static fn ($a, $b) => $a == $b;
     }
 
     /**
@@ -1628,7 +1628,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $items = $this->items;
 
-        uasort($items, function ($a, $b) use ($comparisons, $options) {
+        uasort($items, static function ($a, $b) use ($comparisons, $options) {
             foreach ($comparisons as $comparison) {
                 $comparison = Arr::wrap($comparison);
 
@@ -1853,7 +1853,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $exists = [];
 
-        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
+        return $this->reject(static function ($item, $key) use ($callback, $strict, &$exists) {
             if (in_array($id = $callback($item, $key), $exists, $strict)) {
                 return true;
             }

--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -46,7 +46,7 @@ class HigherOrderCollectionProxy
      */
     public function __get($key)
     {
-        return $this->collection->{$this->method}(function ($value) use ($key) {
+        return $this->collection->{$this->method}(static function ($value) use ($key) {
             return is_array($value) ? $value[$key] : $value->{$key};
         });
     }
@@ -60,7 +60,7 @@ class HigherOrderCollectionProxy
      */
     public function __call($method, $parameters)
     {
-        return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+        return $this->collection->{$this->method}(static function ($value) use ($method, $parameters) {
             return is_string($value)
                 ? $value::{$method}(...$parameters)
                 : $value->{$method}(...$parameters);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -100,7 +100,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             throw new InvalidArgumentException('Step value cannot be zero.');
         }
 
-        return new static(function () use ($from, $to, $step) {
+        return new static(static function () use ($from, $to, $step) {
             if ($from <= $to) {
                 for (; $from <= $to; $from += abs($step)) {
                     yield $from;
@@ -150,7 +150,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
         $cache = [];
 
-        return new static(function () use ($iterator, &$iteratorIndex, &$cache) {
+        return new static(static function () use ($iterator, &$iteratorIndex, &$cache) {
             for ($index = 0; true; $index++) {
                 if (array_key_exists($index, $cache)) {
                     yield $cache[$index][0] => $cache[$index][1];
@@ -275,7 +275,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function containsStrict($key, $value = null)
     {
         if (func_num_args() === 2) {
-            return $this->contains(fn ($item) => data_get($item, $key) === $value);
+            return $this->contains(static fn ($item) => data_get($item, $key) === $value);
         }
 
         if ($this->useAsCallable($key)) {
@@ -443,7 +443,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function filter(?callable $callback = null)
     {
         if (is_null($callback)) {
-            $callback = fn ($value) => (bool) $value;
+            $callback = static fn ($value) => (bool) $value;
         }
 
         return new static(function () use ($callback) {
@@ -1101,7 +1101,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         /** @var (callable(TValue,TKey): bool) $predicate */
         $predicate = $this->useAsCallable($value)
             ? $value
-            : function ($item) use ($value, $strict) {
+            : static function ($item) use ($value, $strict) {
                 return $strict ? $item === $value : $item == $value;
             };
 
@@ -1128,7 +1128,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         /** @var (callable(TValue,TKey): bool) $predicate */
         $predicate = $this->useAsCallable($value)
             ? $value
-            : function ($item) use ($value, $strict) {
+            : static function ($item) use ($value, $strict) {
                 return $strict ? $item === $value : $item == $value;
             };
 
@@ -1157,7 +1157,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         /** @var (callable(TValue,TKey): bool) $predicate */
         $predicate = $this->useAsCallable($value)
             ? $value
-            : function ($item) use ($value, $strict) {
+            : static function ($item) use ($value, $strict) {
                 return $strict ? $item === $value : $item == $value;
             };
 
@@ -1209,7 +1209,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 $chunk[$iterator->key()] = $iterator->current();
 
                 if (count($chunk) == $size) {
-                    yield (new static($chunk))->tap(function () use (&$chunk, $step) {
+                    yield (new static($chunk))->tap(static function () use (&$chunk, $step) {
                         $chunk = array_slice($chunk, $step, null, true);
                     });
 
@@ -1405,8 +1405,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         }
 
         $add = match ($preserveKeys) {
-            true => fn (array &$chunk, Traversable $iterator) => $chunk[$iterator->key()] = $iterator->current(),
-            false => fn (array &$chunk, Traversable $iterator) => $chunk[] = $iterator->current(),
+            true => static fn (array &$chunk, Traversable $iterator) => $chunk[$iterator->key()] = $iterator->current(),
+            false => static fn (array &$chunk, Traversable $iterator) => $chunk[] = $iterator->current(),
         };
 
         return new static(function () use ($size, $add) {
@@ -1663,7 +1663,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         /** @var callable(TValue, TKey): bool $callback */
         $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
 
-        return $this->takeUntil(fn ($item, $key) => ! $callback($item, $key));
+        return $this->takeUntil(static fn ($item, $key) => ! $callback($item, $key));
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -288,7 +288,7 @@ trait EnumeratesValues
      */
     public function eachSpread(callable $callback)
     {
-        return $this->each(function ($chunk, $key) use ($callback) {
+        return $this->each(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -365,7 +365,7 @@ trait EnumeratesValues
      */
     public function value($key, $default = null)
     {
-        $value = $this->first(function ($target) use ($key) {
+        $value = $this->first(static function ($target) use ($key) {
             return data_has($target, $key);
         });
 
@@ -386,7 +386,7 @@ trait EnumeratesValues
     {
         $allowedTypes = is_array($type) ? $type : [$type];
 
-        return $this->each(function ($item, $index) use ($allowedTypes) {
+        return $this->each(static function ($item, $index) use ($allowedTypes) {
             $itemType = get_debug_type($item);
 
             foreach ($allowedTypes as $allowedType) {
@@ -427,7 +427,7 @@ trait EnumeratesValues
      */
     public function mapSpread(callable $callback)
     {
-        return $this->map(function ($chunk, $key) use ($callback) {
+        return $this->map(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -477,10 +477,10 @@ trait EnumeratesValues
     public function mapInto($class)
     {
         if (is_subclass_of($class, BackedEnum::class)) {
-            return $this->map(fn ($value, $key) => $class::from($value));
+            return $this->map(static fn ($value, $key) => $class::from($value));
         }
 
-        return $this->map(fn ($value, $key) => new $class($value, $key));
+        return $this->map(static fn ($value, $key) => new $class($value, $key));
     }
 
     /**
@@ -495,9 +495,9 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->map(fn ($value) => $callback($value))
-            ->reject(fn ($value) => is_null($value))
-            ->reduce(fn ($result, $value) => is_null($result) || $value < $result ? $value : $result);
+        return $this->map(static fn ($value) => $callback($value))
+            ->reject(static fn ($value) => is_null($value))
+            ->reduce(static fn ($result, $value) => is_null($result) || $value < $result ? $value : $result);
     }
 
     /**
@@ -512,7 +512,7 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->reject(fn ($value) => is_null($value))->reduce(function ($result, $item) use ($callback) {
+        return $this->reject(static fn ($value) => is_null($value))->reduce(static function ($result, $item) use ($callback) {
             $value = $callback($item);
 
             return is_null($result) || $value > $result ? $value : $result;
@@ -585,7 +585,7 @@ trait EnumeratesValues
             ? $this->identity()
             : $this->valueRetriever($callback);
 
-        return $this->reduce(fn ($result, $item, $key) => $result + $callback($item, $key), 0);
+        return $this->reduce(static fn ($result, $item, $key) => $result + $callback($item, $key), 0);
     }
 
     /**
@@ -703,7 +703,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->filter(fn ($item) => in_array(data_get($item, $key), $values, $strict));
+        return $this->filter(static fn ($item) => in_array(data_get($item, $key), $values, $strict));
     }
 
     /**
@@ -740,7 +740,7 @@ trait EnumeratesValues
     public function whereNotBetween($key, $values)
     {
         return $this->filter(
-            fn ($item) => data_get($item, $key) < reset($values) || data_get($item, $key) > end($values)
+            static fn ($item) => data_get($item, $key) < reset($values) || data_get($item, $key) > end($values)
         );
     }
 
@@ -756,7 +756,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->reject(fn ($item) => in_array(data_get($item, $key), $values, $strict));
+        return $this->reject(static fn ($item) => in_array(data_get($item, $key), $values, $strict));
     }
 
     /**
@@ -781,9 +781,9 @@ trait EnumeratesValues
      */
     public function whereInstanceOf($type)
     {
-        return $this->filter(function ($value) use ($type) {
+        return $this->filter(static function ($value) use ($type) {
             if (is_array($type)) {
-                return array_any($type, fn ($classType) => $value instanceof $classType);
+                return array_any($type, static fn ($classType) => $value instanceof $classType);
             }
 
             return $value instanceof $type;
@@ -825,7 +825,7 @@ trait EnumeratesValues
     public function pipeThrough($callbacks)
     {
         return (new Collection($callbacks))->reduce(
-            fn ($carry, $callback) => $callback($carry),
+            static fn ($carry, $callback) => $callback($carry),
             $this,
         );
     }
@@ -921,7 +921,7 @@ trait EnumeratesValues
     {
         $useAsCallable = $this->useAsCallable($callback);
 
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
+        return $this->filter(static function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable
                 ? ! $callback($value, $key)
                 : $value != $callback;
@@ -954,7 +954,7 @@ trait EnumeratesValues
 
         $exists = [];
 
-        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
+        return $this->reject(static function ($item, $key) use ($callback, $strict, &$exists) {
             if (in_array($id = $callback($item, $key), $exists, $strict)) {
                 return true;
             }
@@ -991,7 +991,7 @@ trait EnumeratesValues
      */
     public function toArray()
     {
-        return $this->map(fn ($value) => $value instanceof Arrayable ? $value->toArray() : $value)->all();
+        return $this->map(static fn ($value) => $value instanceof Arrayable ? $value->toArray() : $value)->all();
     }
 
     /**
@@ -1001,7 +1001,7 @@ trait EnumeratesValues
      */
     public function jsonSerialize(): array
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             return match (true) {
                 $value instanceof JsonSerializable => $value->jsonSerialize(),
                 $value instanceof Jsonable => json_decode($value->toJson(), true),
@@ -1136,11 +1136,11 @@ trait EnumeratesValues
             $operator = '=';
         }
 
-        return function ($item) use ($key, $operator, $value) {
+        return static function ($item) use ($key, $operator, $value) {
             $retrieved = enum_value(data_get($item, $key));
             $value = enum_value($value);
 
-            $strings = array_filter([$retrieved, $value], function ($value) {
+            $strings = array_filter([$retrieved, $value], static function ($value) {
                 return match (true) {
                     is_string($value) => true,
                     $value instanceof \Stringable => true,
@@ -1192,7 +1192,7 @@ trait EnumeratesValues
             return $value;
         }
 
-        return fn ($item) => data_get($item, $value);
+        return static fn ($item) => data_get($item, $value);
     }
 
     /**
@@ -1203,7 +1203,7 @@ trait EnumeratesValues
      */
     protected function equality($value)
     {
-        return fn ($item) => $item === $value;
+        return static fn ($item) => $item === $value;
     }
 
     /**
@@ -1214,7 +1214,7 @@ trait EnumeratesValues
      */
     protected function negate(Closure $callback)
     {
-        return fn (...$params) => ! $callback(...$params);
+        return static fn (...$params) => ! $callback(...$params);
     }
 
     /**
@@ -1224,6 +1224,6 @@ trait EnumeratesValues
      */
     protected function identity()
     {
-        return fn ($value) => $value;
+        return static fn ($value) => $value;
     }
 }

--- a/src/Illuminate/Concurrency/ConcurrencyServiceProvider.php
+++ b/src/Illuminate/Concurrency/ConcurrencyServiceProvider.php
@@ -14,7 +14,7 @@ class ConcurrencyServiceProvider extends ServiceProvider implements DeferrablePr
      */
     public function register()
     {
-        $this->app->singleton(ConcurrencyManager::class, function ($app) {
+        $this->app->singleton(ConcurrencyManager::class, static function ($app) {
             return new ConcurrencyManager($app);
         });
     }

--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -48,7 +48,7 @@ class InvokeSerializedClosureCommand extends Command
                     isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize(
                         base64_decode($_SERVER['LARAVEL_INVOKABLE_CLOSURE'])
                     ),
-                    default => fn () => null,
+                    default => static fn () => null,
                 })),
             ]));
         } catch (Throwable $e) {

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -34,7 +34,7 @@ class ProcessDriver implements Driver
     {
         $command = Application::formatCommandString('invoke-serialized-closure');
 
-        $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
+        $results = $this->processFactory->pool(static function (Pool $pool) use ($tasks, $command, $timeout) {
             foreach (Arr::wrap($tasks) as $key => $task) {
                 $process = $pool->as($key)->path(base_path())->env([
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
@@ -48,7 +48,7 @@ class ProcessDriver implements Driver
             }
         })->start()->wait();
 
-        return $results->collect()->mapWithKeys(function ($result, $key) {
+        return $results->collect()->mapWithKeys(static function ($result, $key) {
             if ($result->failed()) {
                 throw new Exception('Concurrent process failed with exit code ['.$result->exitCode().']. Message: '.$result->errorOutput());
             }
@@ -63,7 +63,7 @@ class ProcessDriver implements Driver
 
             if (! $result['successful']) {
                 throw new $result['exception'](
-                    ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
+                    ...(! empty(array_filter($result['parameters'], static fn ($parameter) => ! is_null($parameter)))
                         ? $result['parameters']
                         : [$result['message']])
                 );

--- a/src/Illuminate/Concurrency/SyncDriver.php
+++ b/src/Illuminate/Concurrency/SyncDriver.php
@@ -18,7 +18,7 @@ class SyncDriver implements Driver
     public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
     {
         return Collection::wrap($tasks)->map(
-            fn ($task) => $task()
+            static fn ($task) => $task()
         )->all();
     }
 
@@ -27,6 +27,6 @@ class SyncDriver implements Driver
      */
     public function defer(Closure|array $tasks): DeferredCallback
     {
-        return defer(fn () => Collection::wrap($tasks)->each(fn ($task) => $task()));
+        return defer(static fn () => Collection::wrap($tasks)->each(static fn ($task) => $task()));
     }
 }

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -73,7 +73,7 @@ class CacheCommandMutex implements CommandMutex
         if ($this->shouldUseLocks($store->getStore())) {
             $lock = $store->getStore()->lock($this->commandMutexName($command));
 
-            return tap(! $lock->get(), function ($exists) use ($lock) {
+            return tap(! $lock->get(), static function ($exists) use ($lock) {
                 if ($exists) {
                     $lock->release();
                 }

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -82,7 +82,7 @@ trait CallsCommands
      */
     protected function createInputFromArguments(array $arguments)
     {
-        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
+        return tap(new ArrayInput(array_merge($this->context(), $arguments)), static function ($input) {
             if ($input->getParameterOption('--no-interaction')) {
                 $input->setInteractive(false);
             }
@@ -105,7 +105,7 @@ trait CallsCommands
                 'verbose',
             ])
             ->filter()
-            ->mapWithKeys(fn ($value, $key) => ["--{$key}" => $value])
+            ->mapWithKeys(static fn ($value, $key) => ["--{$key}" => $value])
             ->all();
     }
 }

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -291,13 +291,13 @@ trait ConfiguresPrompts
         $answers = $this->components->choice($label, $options, $default, null, true);
 
         if (! array_is_list($options)) {
-            $answers = array_map(fn ($value) => $value === (string) (int) $value ? (int) $value : $value, $answers);
+            $answers = array_map(static fn ($value) => $value === (string) (int) $value ? (int) $value : $value, $answers);
         }
 
         if ($required === false) {
             return array_is_list($options)
-                ? array_values(array_filter($answers, fn ($value) => $value !== 'None'))
-                : array_filter($answers, fn ($value) => $value !== '');
+                ? array_values(array_filter($answers, static fn ($value) => $value !== 'None'))
+                : array_filter($answers, static fn ($value) => $value !== '');
         }
 
         return $answers;

--- a/src/Illuminate/Console/Concerns/FindsAvailableModels.php
+++ b/src/Illuminate/Console/Concerns/FindsAvailableModels.php
@@ -17,7 +17,7 @@ trait FindsAvailableModels
         $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
 
         return (new Collection(Finder::create()->files()->depth(0)->in($modelPath)))
-            ->map(fn ($file) => $file->getBasename('.php'))
+            ->map(static fn ($file) => $file->getBasename('.php'))
             ->sort()
             ->values()
             ->all();

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -40,7 +40,7 @@ trait PromptsForMissingInput
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = (new Collection($this->getDefinition()->getArguments()))
-            ->filter(fn (InputArgument $argument) => $argument->getName() !== 'command' && $argument->isRequired() && match (true) {
+            ->filter(static fn (InputArgument $argument) => $argument->getName() !== 'command' && $argument->isRequired() && match (true) {
                 $argument->isArray() => empty($input->getArgument($argument->getName())),
                 default => is_null($input->getArgument($argument->getName())),
             })
@@ -59,7 +59,7 @@ trait PromptsForMissingInput
                 $answer = text(
                     label: $label,
                     placeholder: $placeholder ?? '',
-                    validate: fn ($value) => empty($value) ? "The {$argument->getName()} is required." : null,
+                    validate: static fn ($value) => empty($value) ? "The {$argument->getName()} is required." : null,
                 );
 
                 $input->setArgument($argument->getName(), $argument->isArray() ? [$answer] : $answer);
@@ -102,6 +102,6 @@ trait PromptsForMissingInput
     protected function didReceiveOptions(InputInterface $input)
     {
         return (new Collection($this->getDefinition()->getOptions()))
-            ->contains(fn ($option) => $input->getOption($option->getName()) !== $option->getDefault());
+            ->contains(static fn ($option) => $input->getOption($option->getName()) !== $option->getDefault());
     }
 }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -268,7 +268,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         return (new Collection(Finder::create()->files()->depth(0)->in($eventPath)))
-            ->map(fn ($file) => $file->getBasename('.php'))
+            ->map(static fn ($file) => $file->getBasename('.php'))
             ->sort()
             ->values()
             ->all();
@@ -460,7 +460,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         $name = strtolower($name);
 
         return (new Collection($this->reservedNames))
-            ->contains(fn ($reservedName) => strtolower($reservedName) === $name);
+            ->contains(static fn ($reservedName) => strtolower($reservedName) === $name);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -62,7 +62,7 @@ class CacheEventMutex implements EventMutex, CacheAware
         if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
             return ! $this->cache->store($this->store)->getStore()
                 ->lock($event->mutexName(), $event->expiresAt * 60)
-                ->get(fn () => true);
+                ->get(static fn () => true);
         }
 
         return $this->cache->store($this->store)->has($event->mutexName());

--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -69,7 +69,7 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
         if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
             return ! $this->cache->store($this->store)->getStore()
                 ->lock($mutexName, 3600)
-                ->get(fn () => true);
+                ->get(static fn () => true);
         }
 
         return $this->cache->store($this->store)->has($mutexName);

--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -173,7 +173,7 @@ class CronExpressionTimezoneConverter
             return null;
         }
 
-        return array_map(function ($group) use ($parts) {
+        return array_map(static function ($group) use ($parts) {
             [$parts[2], $parts[3]] = $group;
 
             return implode(' ', $parts);
@@ -248,7 +248,7 @@ class CronExpressionTimezoneConverter
             $groups[implode(',', $days)][] = $month;
         }
 
-        return (new Collection($groups))->map(function ($months, $days) {
+        return (new Collection($groups))->map(static function ($months, $days) {
             sort($months);
 
             return [
@@ -295,7 +295,7 @@ class CronExpressionTimezoneConverter
             $groups = [0 => static::mergeGroups($groups)];
         }
 
-        return array_map(fn ($group) => static::collapse($group, $min, $max), $groups);
+        return array_map(static fn ($group) => static::collapse($group, $min, $max), $groups);
     }
 
     /**
@@ -368,7 +368,7 @@ class CronExpressionTimezoneConverter
             $groups[$carry][] = $value + $offset - $carry * $mod;
         }
 
-        return array_map(function ($group) {
+        return array_map(static function ($group) {
             sort($group);
 
             return $group;
@@ -387,7 +387,7 @@ class CronExpressionTimezoneConverter
     protected static function shiftWrapped(array $values, int $offset, int $mod, int $min = 0)
     {
         $shifted = array_values(array_unique(array_map(
-            fn ($value) => (($value + $offset - $min) % $mod + $mod) % $mod + $min, $values
+            static fn ($value) => (($value + $offset - $min) % $mod + $mod) % $mod + $min, $values
         )));
 
         sort($shifted);
@@ -430,7 +430,7 @@ class CronExpressionTimezoneConverter
 
         $steps = (new Collection($values))
             ->sliding(2)
-            ->map(fn ($pair) => $pair->last() - $pair->first())
+            ->map(static fn ($pair) => $pair->last() - $pair->first())
             ->unique();
 
         if (count($values) < 3 || $steps->count() > 1) {
@@ -457,8 +457,8 @@ class CronExpressionTimezoneConverter
     protected static function collapseRuns(array $values)
     {
         return (new Collection($values))
-            ->chunkWhile(fn ($value, $key, $chunk) => $value === $chunk->last() + 1)
-            ->map(fn ($run) => $run->count() >= 3 ? $run->first().'-'.$run->last() : $run->implode(','))
+            ->chunkWhile(static fn ($value, $key, $chunk) => $value === $chunk->last() + 1)
+            ->map(static fn ($run) => $run->count() >= 3 ? $run->first().'-'.$run->last() : $run->implode(','))
             ->implode(',');
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -217,8 +217,8 @@ class Event
             $this->buildCommand(), base_path(), ['__LARAVEL_CONTEXT' => $context], null, null
         )->run(
             laravel_cloud()
-                ? fn ($type, $line) => fwrite($type === 'out' ? STDOUT : STDERR, $line)
-                : fn () => true
+                ? static fn ($type, $line) => fwrite($type === 'out' ? STDOUT : STDERR, $line)
+                : static fn () => true
         );
     }
 
@@ -876,7 +876,7 @@ class Event
      */
     public function createMutexNameUsing(Closure|string $mutexName)
     {
-        $this->mutexNameResolver = is_string($mutexName) ? fn () => $mutexName : $mutexName;
+        $this->mutexNameResolver = is_string($mutexName) ? static fn () => $mutexName : $mutexName;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -222,7 +222,7 @@ trait ManagesAttributes
      */
     public function when($callback)
     {
-        $this->filters[] = Reflector::isCallable($callback) ? $callback : function () use ($callback) {
+        $this->filters[] = Reflector::isCallable($callback) ? $callback : static function () use ($callback) {
             return $callback;
         };
 
@@ -237,7 +237,7 @@ trait ManagesAttributes
      */
     public function skip($callback)
     {
-        $this->rejects[] = Reflector::isCallable($callback) ? $callback : function () use ($callback) {
+        $this->rejects[] = Reflector::isCallable($callback) ? $callback : static function () use ($callback) {
             return $callback;
         };
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -395,16 +395,16 @@ class Schedule
      */
     public function compileArrayInput($key, $value)
     {
-        $value = (new Collection($value))->map(function ($value) {
+        $value = (new Collection($value))->map(static function ($value) {
             return ProcessUtils::escapeArgument($value);
         });
 
         if (str_starts_with($key, '--')) {
-            $value = $value->map(function ($value) use ($key) {
+            $value = $value->map(static function ($value) use ($key) {
                 return "{$key}={$value}";
             });
         } elseif (str_starts_with($key, '-')) {
-            $value = $value->map(function ($value) use ($key) {
+            $value = $value->map(static function ($value) use ($key) {
                 return "{$key} {$value}";
             });
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -104,7 +104,7 @@ class ScheduleListCommand extends Command
                 }
             }
 
-            return (new Collection(CronExpressionTimezoneConverter::forEvent($event, $timezone)))->map(fn ($expression) => [
+            return (new Collection(CronExpressionTimezoneConverter::forEvent($event, $timezone)))->map(static fn ($expression) => [
                 'expression' => $expression,
                 'command' => $command,
                 'description' => $event->description ?? null,
@@ -152,10 +152,10 @@ class ScheduleListCommand extends Command
      */
     private function getCronExpressionSpacing($events, DateTimeZone $timezone)
     {
-        $rows = $events->flatMap(fn ($event) => (new Collection(CronExpressionTimezoneConverter::forEvent($event, $timezone)))
-            ->map(fn ($expression) => array_map(mb_strlen(...), preg_split("/\s+/", $expression))));
+        $rows = $events->flatMap(static fn ($event) => (new Collection(CronExpressionTimezoneConverter::forEvent($event, $timezone)))
+            ->map(static fn ($expression) => array_map(mb_strlen(...), preg_split("/\s+/", $expression))));
 
-        return (new Collection($rows[0] ?? []))->keys()->map(fn ($key) => $rows->max($key))->all();
+        return (new Collection($rows[0] ?? []))->keys()->map(static fn ($key) => $rows->max($key))->all();
     }
 
     /**
@@ -323,7 +323,7 @@ class ScheduleListCommand extends Command
         $expressions = preg_split("/\s+/", $expression);
 
         return (new Collection($spacing))
-            ->map(fn ($length, $index) => str_pad($expressions[$index], $length))
+            ->map(static fn ($length, $index) => str_pad($expressions[$index], $length))
             ->implode(' ');
     }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -50,7 +50,7 @@ class ScheduleTestCommand extends Command
         if (! empty($name = $this->option('name'))) {
             $commandBinary = $phpBinary.' '.Application::artisanBinary();
 
-            $matches = array_filter($commandNames, function ($commandName) use ($commandBinary, $name) {
+            $matches = array_filter($commandNames, static function ($commandName) use ($commandBinary, $name) {
                 return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
@@ -100,7 +100,7 @@ class ScheduleTestCommand extends Command
     {
         if (count($commandNames) !== count(array_unique($commandNames))) {
             // Some commands (likely closures) have the same name, append unique indexes to each one...
-            $uniqueCommandNames = array_map(function ($index, $value) {
+            $uniqueCommandNames = array_map(static function ($index, $value) {
                 return "$value [$index]";
             }, array_keys($commandNames), $commandNames);
 

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -120,7 +120,7 @@ class ScheduleWorkCommand extends Command
      */
     protected function listenForSignals()
     {
-        $this->trap(fn () => [SIGINT, SIGTERM, SIGQUIT], function () {
+        $this->trap(static fn () => [SIGINT, SIGTERM, SIGQUIT], function () {
             $this->shouldQuit = true;
         });
     }

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -66,7 +66,7 @@ abstract class Component
 
         include __DIR__."/../../resources/views/components/$view.php";
 
-        return tap(ob_get_contents(), function () {
+        return tap(ob_get_contents(), static function () {
             ob_end_clean();
         });
     }

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -40,7 +40,7 @@ class Task extends Component
         $result = TaskResult::Failure->value;
 
         try {
-            $result = ($task ?: fn () => TaskResult::Success->value)();
+            $result = ($task ?: static fn () => TaskResult::Success->value)();
         } catch (Throwable $e) {
             throw $e;
         } finally {

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -46,7 +46,7 @@ class Bind
         $this->concrete = $concrete;
 
         $this->environments = array_map(
-            fn ($environment) => enum_value($environment),
+            static fn ($environment) => enum_value($environment),
             $environments,
         );
     }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -32,7 +32,7 @@ class BoundMethod
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }
 
-        return static::callBoundMethod($container, $callback, function () use ($container, $callback, $parameters) {
+        return static::callBoundMethod($container, $callback, static function () use ($container, $callback, $parameters) {
             return $callback(...array_values(static::getMethodDependencies($container, $callback, $parameters)));
         });
     }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -403,7 +403,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClosure($abstract, $concrete)
     {
-        return function ($container, $parameters = []) use ($abstract, $concrete) {
+        return static function ($container, $parameters = []) use ($abstract, $concrete) {
             if ($abstract == $concrete) {
                 return $container->build($concrete);
             }
@@ -728,7 +728,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function refresh($abstract, $target, $method)
     {
-        return $this->rebinding($abstract, function ($app, $instance) use ($target, $method) {
+        return $this->rebinding($abstract, static function ($app, $instance) use ($target, $method) {
             $target->{$method}($instance);
         });
     }
@@ -1850,7 +1850,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetSet($offset, $value): void
     {
-        $this->bind($offset, $value instanceof Closure ? $value : fn () => $value);
+        $this->bind($offset, $value instanceof Closure ? $value : static fn () => $value);
     }
 
     /**

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -76,7 +76,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function giveTagged($tag)
     {
-        return $this->give(function ($container) use ($tag) {
+        return $this->give(static function ($container) use ($tag) {
             $taggedServices = $container->tagged($tag);
 
             return is_array($taggedServices) ? $taggedServices : iterator_to_array($taggedServices);
@@ -92,6 +92,6 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function giveConfig($key, $default = null)
     {
-        return $this->give(fn ($container) => $container->get('config')->get($key, $default));
+        return $this->give(static fn ($container) => $container->get('config')->get($key, $default));
     }
 }

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -13,7 +13,7 @@ class CookieServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('cookie', function ($app) {
+        $this->app->singleton('cookie', static function ($app) {
             $config = $app->make('config')->get('session');
 
             return (new CookieJar)->setDefaultPathAndDomain(

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -91,8 +91,8 @@ trait BuildsQueries
     {
         $collection = new Collection;
 
-        $this->chunk($count, function ($items) use ($collection, $callback) {
-            $items->each(function ($item) use ($collection, $callback) {
+        $this->chunk($count, static function ($items) use ($collection, $callback) {
+            $items->each(static function ($item) use ($collection, $callback) {
                 $collection->push($callback($item));
             });
         });
@@ -111,7 +111,7 @@ trait BuildsQueries
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;
@@ -233,7 +233,7 @@ trait BuildsQueries
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
+        return $this->chunkById($count, static function ($results, $page) use ($callback, $count) {
             foreach ($results as $key => $value) {
                 if ($callback($value, (($page - 1) * $count) + $key) === false) {
                     return false;
@@ -468,7 +468,7 @@ trait BuildsQueries
                     );
 
                     if ($i < $orders->count() - 1) {
-                        $secondBuilder->orWhere(function (self $thirdBuilder) use ($addCursorConditions, $column, $originalColumn, $i) {
+                        $secondBuilder->orWhere(static function (self $thirdBuilder) use ($addCursorConditions, $column, $originalColumn, $i) {
                             $addCursorConditions($thirdBuilder, $column, $originalColumn, $i + 1);
                         });
                     }
@@ -485,7 +485,7 @@ trait BuildsQueries
                             );
 
                             if ($i < $orders->count() - 1) {
-                                $unionBuilder->orWhere(function (self $fourthBuilder) use ($addCursorConditions, $column, $originalColumn, $i) {
+                                $unionBuilder->orWhere(static function (self $fourthBuilder) use ($addCursorConditions, $column, $originalColumn, $i) {
                                     $addCursorConditions($fourthBuilder, $column, $originalColumn, $i + 1);
                                 });
                             }

--- a/src/Illuminate/Database/Concerns/ParsesSearchPath.php
+++ b/src/Illuminate/Database/Concerns/ParsesSearchPath.php
@@ -18,7 +18,7 @@ trait ParsesSearchPath
             $searchPath = $matches[0];
         }
 
-        return array_map(function ($schema) {
+        return array_map(static function ($schema) {
             return trim($schema, '\'"');
         }, $searchPath ?? []);
     }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -201,7 +201,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function buildConnectString($driver, array $arguments)
     {
-        return $driver.':'.implode(';', array_map(function ($key) use ($arguments) {
+        return $driver.':'.implode(';', array_map(static function ($key) use ($arguments) {
             return sprintf('%s=%s', $key, $arguments[$key]);
         }, array_keys($arguments)));
     }

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -280,7 +280,7 @@ class DbCommand extends Command
      */
     protected function getOptionalArguments(array $args, array $connection)
     {
-        return array_values(array_filter($args, function ($key) use ($connection) {
+        return array_values(array_filter($args, static function ($key) use ($connection) {
             return ! empty($connection[$key]);
         }, ARRAY_FILTER_USE_KEY));
     }

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -104,7 +104,7 @@ class DumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.sql'), function ($path) {
+        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.sql'), static function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -75,7 +75,7 @@ class StatusCommand extends BaseCommand
             $batches = $this->migrator->getRepository()->getMigrationBatches();
 
             $migrations = $this->getStatusFor($ran, $batches)
-                ->when($this->option('pending') !== false, fn ($collection) => $collection->filter(function ($migration) {
+                ->when($this->option('pending') !== false, static fn ($collection) => $collection->filter(static function ($migration) {
                     return (new Stringable($migration[1]))->contains('Pending');
                 }));
 
@@ -96,7 +96,7 @@ class StatusCommand extends BaseCommand
                 $this->components->info('No migrations found');
             }
 
-            if ($this->option('pending') && $migrations->some(fn ($m) => (new Stringable($m[1]))->contains('Pending'))) {
+            if ($this->option('pending') && $migrations->some(static fn ($m) => (new Stringable($m[1]))->contains('Pending'))) {
                 return $this->option('pending');
             }
         });

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -140,7 +140,7 @@ class PruneCommand extends Command
                     Str::after($model->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
                 );
             })
-            ->when(! empty($except), fn ($models) => $models->reject(fn ($model) => in_array($model, $except)))
+            ->when(! empty($except), static fn ($models) => $models->reject(static fn ($model) => in_array($model, $except)))
             ->filter(fn ($model) => $this->isPrunable($model))
             ->values();
     }
@@ -154,7 +154,7 @@ class PruneCommand extends Command
     {
         if (! empty($path = $this->option('path'))) {
             return (new Collection($path))
-                ->map(fn ($path) => base_path($path))
+                ->map(static fn ($path) => base_path($path))
                 ->all();
         }
 
@@ -172,7 +172,7 @@ class PruneCommand extends Command
         $instance = new $model;
 
         $count = $instance->prunable()
-            ->when($model::isSoftDeletable(), function ($query) {
+            ->when($model::isSoftDeletable(), static function ($query) {
                 $query->withTrashed();
             })->count();
 

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -14,6 +14,6 @@ trait WithoutModelEvents
      */
     public function withoutModelEvents(callable $callback)
     {
-        return fn () => Model::withoutEvents($callback);
+        return static fn () => Model::withoutEvents($callback);
     }
 }

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -85,7 +85,7 @@ class ShowCommand extends DatabaseInspectionCommand
             'schema_qualified_name' => $table['schema_qualified_name'],
             'size' => $table['size'],
             'rows' => $this->option('counts')
-                ? $connection->withoutTablePrefix(fn ($connection) => $connection->table($table['schema_qualified_name'])->count())
+                ? $connection->withoutTablePrefix(static fn ($connection) => $connection->table($table['schema_qualified_name'])->count())
                 : null,
             'engine' => $table['engine'],
             'collation' => $table['collation'],
@@ -103,10 +103,10 @@ class ShowCommand extends DatabaseInspectionCommand
     protected function views(ConnectionInterface $connection, Builder $schema)
     {
         return (new Collection($schema->getViews()))
-            ->map(fn ($view) => [
+            ->map(static fn ($view) => [
                 'view' => $view['name'],
                 'schema' => $view['schema'],
-                'rows' => $connection->withoutTablePrefix(fn ($connection) => $connection->table($view['schema_qualified_name'])->count()),
+                'rows' => $connection->withoutTablePrefix(static fn ($connection) => $connection->table($view['schema_qualified_name'])->count()),
             ]);
     }
 
@@ -120,7 +120,7 @@ class ShowCommand extends DatabaseInspectionCommand
     protected function types(ConnectionInterface $connection, Builder $schema)
     {
         return (new Collection($schema->getTypes()))
-            ->map(fn ($type) => [
+            ->map(static fn ($type) => [
                 'name' => $type['name'],
                 'schema' => $type['schema'],
                 'type' => $type['type'],

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -110,8 +110,8 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
                 '%s %s',
                 $attribute['name'],
                 (new Collection(['increments', 'unique', 'nullable', 'fillable', 'hidden', 'appended']))
-                    ->filter(fn ($property) => $attribute[$property])
-                    ->map(fn ($property) => sprintf('<fg=gray>%s</>', $property))
+                    ->filter(static fn ($property) => $attribute[$property])
+                    ->map(static fn ($property) => sprintf('<fg=gray>%s</>', $property))
                     ->implode('<fg=gray>,</> ')
             ));
 

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -49,8 +49,8 @@ class TableCommand extends DatabaseInspectionCommand
 
         $tableName = $this->argument('table') ?: search(
             'Which table would you like to inspect?',
-            fn (string $query) => $tableNames
-                ->filter(fn ($table) => str_contains(strtolower($table), strtolower($query)))
+            static fn (string $query) => $tableNames
+                ->filter(static fn ($table) => str_contains(strtolower($table), strtolower($query)))
                 ->values()
                 ->all()
         );
@@ -58,8 +58,8 @@ class TableCommand extends DatabaseInspectionCommand
         $table = $tables[$tableName] ?? (new Collection($tables))->when(
             Arr::wrap($connection->getSchemaBuilder()->getCurrentSchemaListing()
                 ?? $connection->getSchemaBuilder()->getCurrentSchemaName()),
-            fn (Collection $collection, array $currentSchemas) => $collection->sortBy(
-                function (array $table) use ($currentSchemas) {
+            static fn (Collection $collection, array $currentSchemas) => $collection->sortBy(
+                static function (array $table) use ($currentSchemas) {
                     $index = array_search($table['schema'], $currentSchemas);
 
                     return $index === false ? PHP_INT_MAX : $index;
@@ -180,7 +180,7 @@ class TableCommand extends DatabaseInspectionCommand
      */
     protected function foreignKeys(Builder $schema, string $table)
     {
-        return (new Collection($schema->getForeignKeys($table)))->map(fn ($foreignKey) => [
+        return (new Collection($schema->getForeignKeys($table)))->map(static fn ($foreignKey) => [
             'name' => $foreignKey['name'],
             'columns' => new Collection($foreignKey['columns']),
             'foreign_schema' => $foreignKey['foreign_schema'],

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -132,7 +132,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public static function calculateDynamicConnectionName(array $config)
     {
-        return 'dynamic_'.md5((new Collection($config))->map(function ($value, $key) {
+        return 'dynamic_'.md5((new Collection($config))->map(static function ($value, $key) {
             return $key.(is_string($value) || is_int($value) ? $value : '');
         })->implode(''));
     }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -57,34 +57,34 @@ class DatabaseServiceProvider extends ServiceProvider
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->singleton('db.factory', function ($app) {
+        $this->app->singleton('db.factory', static function ($app) {
             return new ConnectionFactory($app);
         });
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->singleton('db', function ($app) {
+        $this->app->singleton('db', static function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
 
-        $this->app->bind('db.connection', function ($app) {
+        $this->app->bind('db.connection', static function ($app) {
             return $app['db']->connection();
         });
 
-        $this->app->bind('db.schema', function ($app) {
+        $this->app->bind('db.schema', static function ($app) {
             return $app['db']->connection()->getSchemaBuilder();
         });
 
-        $this->app->singleton('db.transactions', function () {
+        $this->app->singleton('db.transactions', static function () {
             return new DatabaseTransactionsManager;
         });
 
-        $this->app->singleton(ConcurrencyErrorDetectorContract::class, function () {
+        $this->app->singleton(ConcurrencyErrorDetectorContract::class, static function () {
             return new ConcurrencyErrorDetector;
         });
 
-        $this->app->singleton(LostConnectionDetectorContract::class, function () {
+        $this->app->singleton(LostConnectionDetectorContract::class, static function () {
             return new LostConnectionDetector;
         });
     }
@@ -100,7 +100,7 @@ class DatabaseServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
+        $this->app->singleton(FakerGenerator::class, static function ($app, $parameters) {
             $locale = $parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US');
 
             if (! isset(static::$fakers[$locale])) {
@@ -120,7 +120,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton(EntityResolver::class, function () {
+        $this->app->singleton(EntityResolver::class, static function () {
             return new QueueEntityResolver;
         });
     }

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -81,12 +81,12 @@ class DatabaseTransactionsManager
         // shouldn't be any pending transactions, but going to clear them here anyways just
         // in case. This method could be refactored to receive a level in the future too.
         $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection === $connection &&
+            static fn ($transaction) => $transaction->connection === $connection &&
                 $transaction->level >= $levelBeingCommitted
         )->values();
 
         [$forThisConnection, $forOtherConnections] = $this->committedTransactions->partition(
-            fn ($transaction) => $transaction->connection == $connection
+            static fn ($transaction) => $transaction->connection == $connection
         );
 
         $this->committedTransactions = $forOtherConnections->values();
@@ -107,13 +107,13 @@ class DatabaseTransactionsManager
     {
         $this->committedTransactions = $this->committedTransactions->merge(
             $this->pendingTransactions->filter(
-                fn ($transaction) => $transaction->connection === $connection &&
+                static fn ($transaction) => $transaction->connection === $connection &&
                                      $transaction->level >= $levelBeingCommitted
             )
         );
 
         $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection === $connection &&
+            static fn ($transaction) => $transaction->connection === $connection &&
                                  $transaction->level >= $levelBeingCommitted
         );
     }
@@ -131,7 +131,7 @@ class DatabaseTransactionsManager
             $this->removeAllTransactionsForConnection($connection);
         } else {
             $this->pendingTransactions = $this->pendingTransactions->reject(
-                fn ($transaction) => $transaction->connection == $connection &&
+                static fn ($transaction) => $transaction->connection == $connection &&
                                      $transaction->level > $newTransactionLevel
             )->values();
 
@@ -159,7 +159,7 @@ class DatabaseTransactionsManager
     protected function removeAllTransactionsForConnection($connection)
     {
         $transactions = $this->committedTransactions->filter(
-            fn ($transaction) => $transaction->connection == $connection
+            static fn ($transaction) => $transaction->connection == $connection
         );
 
         for ($transaction = $this->currentTransaction[$connection] ?? null; isset($transaction); $transaction = $transaction->parent) {
@@ -167,17 +167,17 @@ class DatabaseTransactionsManager
         }
 
         $transactions
-            ->sortByDesc(fn ($transaction) => $transaction->level)
-            ->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
+            ->sortByDesc(static fn ($transaction) => $transaction->level)
+            ->each(static fn ($transaction) => $transaction->executeCallbacksForRollback());
 
         $this->currentTransaction[$connection] = null;
 
         $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection == $connection
+            static fn ($transaction) => $transaction->connection == $connection
         )->values();
 
         $this->committedTransactions = $this->committedTransactions->reject(
-            fn ($transaction) => $transaction->connection == $connection
+            static fn ($transaction) => $transaction->connection == $connection
         )->values();
     }
 
@@ -201,7 +201,7 @@ class DatabaseTransactionsManager
             fn ($transaction) => $this->removeCommittedTransactionsThatAreChildrenOf($transaction)
         );
 
-        $removedTransactions->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
+        $removedTransactions->each(static fn ($transaction) => $transaction->executeCallbacksForRollback());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -78,7 +78,7 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
             : $this->channels;
 
         return (new BaseCollection($channels))
-            ->map(fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel)
+            ->map(static fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel)
             ->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -13,25 +13,25 @@ trait BroadcastsEvents
      */
     public static function bootBroadcastsEvents()
     {
-        static::created(function ($model) {
+        static::created(static function ($model) {
             $model->broadcastCreated();
         });
 
-        static::updated(function ($model) {
+        static::updated(static function ($model) {
             $model->broadcastUpdated();
         });
 
         if (method_exists(static::class, 'bootSoftDeletes')) {
-            static::softDeleted(function ($model) {
+            static::softDeleted(static function ($model) {
                 $model->broadcastTrashed();
             });
 
-            static::restored(function ($model) {
+            static::restored(static function ($model) {
                 $model->broadcastRestored();
             });
         }
 
-        static::deleted(function ($model) {
+        static::deleted(static function ($model) {
             $model->broadcastDeleted();
         });
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -470,7 +470,7 @@ class Builder implements BuilderContract
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
+        return $instance->newCollection(array_map(static function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
             if (count($items) > 1) {
@@ -534,7 +534,7 @@ class Builder implements BuilderContract
             foreach ($values as $key => $rowValues) {
                 $values[$key] = tap(
                     $this->newModelInstance($rowValues),
-                    fn ($model) => $model->setUniqueIds()
+                    static fn ($model) => $model->setUniqueIds()
                 )->getAttributes();
             }
         });
@@ -743,7 +743,7 @@ class Builder implements BuilderContract
      */
     public function updateOrCreate(array $attributes, Closure|array $values = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        return tap($this->firstOrCreate($attributes, $values), static function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->fill(value($values))->save();
             }
@@ -762,7 +762,7 @@ class Builder implements BuilderContract
      */
     public function incrementOrCreate(array $attributes, string $column = 'count', $default = 1, $step = 1, array $extra = [])
     {
-        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column, $step, $extra) {
+        return tap($this->firstOrCreate($attributes, [$column => $default]), static function ($instance) use ($column, $step, $extra) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->increment($column, $step, $extra);
             }
@@ -1061,7 +1061,7 @@ class Builder implements BuilderContract
             $model = $this->newModelInstance()->newFromBuilder($record);
 
             return $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]))->first();
-        })->reject(fn ($model) => is_null($model));
+        })->reject(static fn ($model) => is_null($model));
     }
 
     /**
@@ -1201,7 +1201,7 @@ class Builder implements BuilderContract
             $this->enforceOrderBy();
         }
 
-        $reverseDirection = function ($order) {
+        $reverseDirection = static function ($order) {
             if (! isset($order['direction'])) {
                 return $order;
             }
@@ -1219,7 +1219,7 @@ class Builder implements BuilderContract
         $orders = ! empty($this->query->unionOrders) ? $this->query->unionOrders : $this->query->orders;
 
         return (new BaseCollection($orders))
-            ->filter(fn ($order) => Arr::has($order, 'direction'))
+            ->filter(static fn ($order) => Arr::has($order, 'direction'))
             ->values();
     }
 
@@ -1231,7 +1231,7 @@ class Builder implements BuilderContract
      */
     public function create(array $attributes = [])
     {
-        return tap($this->newModelInstance($attributes), function ($instance) {
+        return tap($this->newModelInstance($attributes), static function ($instance) {
             $instance->save();
         });
     }
@@ -1322,7 +1322,7 @@ class Builder implements BuilderContract
         $time = $this->model->freshTimestamp();
 
         if ($column) {
-            $columns = (new BaseCollection(Arr::wrap($column)))->mapWithKeys(fn ($column) => [$column => $time])->all();
+            $columns = (new BaseCollection(Arr::wrap($column)))->mapWithKeys(static fn ($column) => [$column => $time])->all();
 
             return $this->toBase()->update($columns);
         }
@@ -1707,7 +1707,7 @@ class Builder implements BuilderContract
         // Here we'll check if the given subset of where clauses contains any "or"
         // booleans and in this case create a nested where expression. That way
         // we don't add any unnecessary nesting thus keeping the query clean.
-        if ($whereBooleans->contains(fn ($logicalOperator) => str_contains($logicalOperator, 'or'))) {
+        if ($whereBooleans->contains(static fn ($logicalOperator) => str_contains($logicalOperator, 'or'))) {
             $query->wheres[] = $this->createNestedWhere(
                 $whereSlice, str_replace(' not', '', $whereBooleans->first())
             );
@@ -1882,7 +1882,7 @@ class Builder implements BuilderContract
      */
     protected function combineConstraints(array $constraints)
     {
-        return function ($builder) use ($constraints) {
+        return static function ($builder) use ($constraints) {
             foreach ($constraints as $constraint) {
                 $builder = $constraint($builder) ?? $builder;
             }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -44,7 +44,7 @@ class AsEnumArrayObject implements Castable
 
                 $enumClass = $this->arguments[0];
 
-                return new ArrayObject((new Collection($data))->map(function ($value) use ($enumClass) {
+                return new ArrayObject((new Collection($data))->map(static function ($value) use ($enumClass) {
                     return is_subclass_of($enumClass, BackedEnum::class)
                         ? $enumClass::from($value)
                         : constant($enumClass.'::'.$value);

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -44,7 +44,7 @@ class AsEnumCollection implements Castable
 
                 $enumClass = $this->arguments[0];
 
-                return (new Collection($data))->map(function ($value) use ($enumClass) {
+                return (new Collection($data))->map(static function ($value) use ($enumClass) {
                     return is_subclass_of($enumClass, BackedEnum::class)
                         ? $enumClass::from($value)
                         : constant($enumClass.'::'.$value);

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -47,7 +47,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->whereIn($this->first()->getKeyName(), $key);
         }
 
-        return Arr::first($this->items, fn ($model) => $model->getKey() == $key, $default);
+        return Arr::first($this->items, static fn ($model) => $model->getKey() == $key, $default);
     }
 
     /**
@@ -128,7 +128,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $models->first()->getKeyName()
         );
 
-        $this->each(function ($model) use ($models, $attributes) {
+        $this->each(static function ($model) use ($models, $attributes) {
             $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
 
             $model->forceFill($extraAttributes)
@@ -258,7 +258,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         [$relation, $class] = array_shift($tuples);
 
-        $this->filter(function ($model) use ($relation, $class) {
+        $this->filter(static function ($model) use ($relation, $class) {
             return ! is_null($model) &&
                 $model::class === $class &&
                 ! $model->relationLoaded($relation);
@@ -294,7 +294,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $relation = reset($relation);
         }
 
-        $models->filter(fn ($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
+        $models->filter(static fn ($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
 
         if (empty($path)) {
             return;
@@ -320,8 +320,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
-            ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
+            ->groupBy(static fn ($model) => get_class($model))
+            ->each(static fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
 
         return $this;
     }
@@ -337,8 +337,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
-            ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
+            ->groupBy(static fn ($model) => get_class($model))
+            ->each(static fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
 
         return $this;
     }
@@ -358,10 +358,10 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         if ($key instanceof Model) {
-            return parent::contains(fn ($model) => $model->is($key));
+            return parent::contains(static fn ($model) => $model->is($key));
         }
 
-        return parent::contains(fn ($model) => $model->getKey() == $key);
+        return parent::contains(static fn ($model) => $model->getKey() == $key);
     }
 
     /**
@@ -384,7 +384,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_map(fn ($model) => $model->getKey(), $this->items);
+        return array_map(static fn ($model) => $model->getKey(), $this->items);
     }
 
     /**
@@ -420,7 +420,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(static fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -438,7 +438,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::mapWithKeys($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(static fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -461,8 +461,8 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))
-            ->map(fn ($model) => $freshModels[$model->getKey()]);
+        return $this->filter(static fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))
+            ->map(static fn ($model) => $freshModels[$model->getKey()]);
     }
 
     /**
@@ -800,7 +800,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function duplicateComparator($strict)
     {
-        return fn ($a, $b) => $a->is($b);
+        return static fn ($a, $b) => $a->is($b);
     }
 
     /**
@@ -911,7 +911,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $connection = $this->first()->getConnectionName();
 
-        $this->each(function ($model) use ($connection) {
+        $this->each(static function ($model) use ($connection) {
             if ($model->getConnectionName() !== $connection) {
                 throw new LogicException('Queueing collections with multiple model connections is not supported.');
             }
@@ -937,7 +937,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($model);
 
-        if ($this->contains(fn ($model) => ! $model instanceof $class)) {
+        if ($this->contains(static fn ($model) => ! $model instanceof $class)) {
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -748,7 +748,7 @@ trait HasAttributes
 
         $attribute = $this->{Str::camel($key)}();
 
-        $value = call_user_func($attribute->get ?: function ($value) {
+        $value = call_user_func($attribute->get ?: static function ($value) {
             return $value;
         }, $value, $this->attributes);
 
@@ -813,7 +813,7 @@ trait HasAttributes
     {
         foreach ($casts as $attribute => $cast) {
             $casts[$attribute] = match (true) {
-                is_object($cast) => value(function () use ($cast, $attribute) {
+                is_object($cast) => value(static function () use ($cast, $attribute) {
                     if ($cast instanceof Stringable) {
                         return (string) $cast;
                     }
@@ -822,7 +822,7 @@ trait HasAttributes
                         "The cast object for the {$attribute} attribute must implement Stringable."
                     );
                 }),
-                is_array($cast) => value(function () use ($cast) {
+                is_array($cast) => value(static function () use ($cast) {
                     if (count($cast) === 1) {
                         return $cast[0];
                     }
@@ -1346,7 +1346,7 @@ trait HasAttributes
      */
     protected function getArrayAttributeWithValue($path, $key, $value)
     {
-        return tap($this->getArrayAttributeByKey($key), function (&$array) use ($path, $value) {
+        return tap($this->getArrayAttributeByKey($key), static function (&$array) use ($path, $value) {
             Arr::set($array, str_replace('->', '.', $path), $value);
         });
     }
@@ -2541,12 +2541,12 @@ trait HasAttributes
         $class = $reflection->getName();
 
         static::$getAttributeMutatorCache[$class] = (new Collection($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance)))
-            ->mapWithKeys(fn ($match) => [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true])
+            ->mapWithKeys(static fn ($match) => [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true])
             ->all();
 
         static::$mutatorCache[$class] = (new Collection(static::getMutatorMethods($class)))
             ->merge($attributeMutatorMethods)
-            ->map(fn ($match) => lcfirst(static::$snakeAttributes ? Str::snake($match) : $match))
+            ->map(static fn ($match) => lcfirst(static::$snakeAttributes ? Str::snake($match) : $match))
             ->all();
     }
 
@@ -2573,7 +2573,7 @@ trait HasAttributes
     {
         $instance = is_object($class) ? $class : new $class;
 
-        return (new Collection((new ReflectionClass($instance))->getMethods()))->filter(function ($method) use ($instance) {
+        return (new Collection((new ReflectionClass($instance))->getMethods()))->filter(static function ($method) use ($instance) {
             $returnType = $method->getReturnType();
 
             if ($returnType instanceof ReflectionNamedType &&

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -38,7 +38,7 @@ trait HasEvents
      */
     public static function bootHasEvents()
     {
-        static::whenBooted(fn () => static::observe(static::resolveObserveAttributes()));
+        static::whenBooted(static fn () => static::observe(static::resolveObserveAttributes()));
     }
 
     /**
@@ -54,9 +54,9 @@ trait HasEvents
             && get_parent_class(static::class) !== Model::class;
 
         return (new Collection($reflectionClass->getAttributes(ObservedBy::class)))
-            ->map(fn ($attribute) => $attribute->getArguments())
+            ->map(static fn ($attribute) => $attribute->getArguments())
             ->flatten()
-            ->when($isEloquentGrandchild, function (Collection $attributes) {
+            ->when($isEloquentGrandchild, static function (Collection $attributes) {
                 return (new Collection(get_parent_class(static::class)::resolveObserveAttributes()))
                     ->merge($attributes);
             })
@@ -255,7 +255,7 @@ trait HasEvents
     protected function filterModelEventResults($result)
     {
         if (is_array($result)) {
-            $result = array_filter($result, function ($response) {
+            $result = array_filter($result, static function ($response) {
                 return ! is_null($response);
             });
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -42,9 +42,9 @@ trait HasGlobalScopes
         $isEloquentGrandchild = is_subclass_of(static::class, Model::class)
             && get_parent_class(static::class) !== Model::class;
 
-        return $attributes->map(fn ($attribute) => $attribute->getArguments())
+        return $attributes->map(static fn ($attribute) => $attribute->getArguments())
             ->flatten()
-            ->when($isEloquentGrandchild, function (Collection $attributes) {
+            ->when($isEloquentGrandchild, static function (Collection $attributes) {
                 return (new Collection(get_parent_class(static::class)::resolveGlobalScopeAttributes()))
                     ->merge($attributes);
             })

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -922,7 +922,7 @@ trait HasRelationships
      */
     protected function guessBelongsToManyRelation()
     {
-        $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($trace) {
+        $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), static function ($trace) {
             return ! in_array(
                 $trace['function'],
                 array_merge(static::$manyMethods, ['guessBelongsToManyRelation'])

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -250,6 +250,6 @@ trait HasTimestamps
     {
         $class ??= static::class;
 
-        return array_any(static::$ignoreTimestampsOn, fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
+        return array_any(static::$ignoreTimestampsOn, static fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
@@ -99,7 +99,7 @@ trait PreventsCircularRecursion
     {
         static::getRecursionCache()->offsetSet(
             $object,
-            tap(static::getRecursiveCallStack($object), fn (&$stack) => $stack[$hash] = $value),
+            tap(static::getRecursiveCallStack($object), static fn (&$stack) => $stack[$hash] = $value),
         );
 
         return static::getRecursiveCallStack($object)[$hash];

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -98,7 +98,7 @@ trait QueriesRelationships
             $count = 1;
         }
 
-        $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback, $initialRelations) {
+        $closure = static function ($q) use (&$closure, &$relations, $operator, $count, $callback, $initialRelations) {
             // If the same closure is called multiple times, reset the relation array to loop through them again...
             if ($count === 1 && empty($relations)) {
                 $relations = [...$initialRelations];
@@ -186,7 +186,7 @@ trait QueriesRelationships
     public function withWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
-            ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+            ->with($callback ? [$relation => static fn ($query) => $callback($query)] : $relation);
     }
 
     /**
@@ -263,7 +263,7 @@ trait QueriesRelationships
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
                 ->filter()
-                ->map(fn ($item) => enum_value($item))
+                ->map(static fn ($item) => enum_value($item))
                 ->all();
         }
 
@@ -281,7 +281,7 @@ trait QueriesRelationships
                     $belongsTo = $this->getBelongsToRelation($relation, $type);
 
                     if ($callback) {
-                        $callback = function ($query) use ($callback, $type) {
+                        $callback = static function ($query) use ($callback, $type) {
                             return $callback($query, $type);
                         };
                     }
@@ -291,7 +291,7 @@ trait QueriesRelationships
                 });
             }
 
-            $query->when($checkMorphNull, fn (self $query) => $query->orWhereMorphedTo($relation, null));
+            $query->when($checkMorphNull, static fn (self $query) => $query->orWhereMorphedTo($relation, null));
         }, null, null, $boolean);
     }
 
@@ -439,7 +439,7 @@ trait QueriesRelationships
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
+        return $this->whereHas($relation, static function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
             } else {
@@ -461,7 +461,7 @@ trait QueriesRelationships
     {
         return $this->whereRelation($relation, $column, $operator, $value)
             ->with([
-                $relation => fn ($query) => $column instanceof Closure
+                $relation => static fn ($query) => $column instanceof Closure
                     ? $column($query)
                     : $query->where($column, $operator, $value),
             ]);
@@ -480,7 +480,7 @@ trait QueriesRelationships
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
+        return $this->orWhereHas($relation, static function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
             } else {
@@ -502,7 +502,7 @@ trait QueriesRelationships
      */
     public function whereDoesntHaveRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->whereDoesntHave($relation, function ($query) use ($column, $operator, $value) {
+        return $this->whereDoesntHave($relation, static function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
             } else {
@@ -524,7 +524,7 @@ trait QueriesRelationships
      */
     public function orWhereDoesntHaveRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->orWhereDoesntHave($relation, function ($query) use ($column, $operator, $value) {
+        return $this->orWhereDoesntHave($relation, static function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
             } else {
@@ -547,7 +547,7 @@ trait QueriesRelationships
      */
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
-        return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+        return $this->whereHasMorph($relation, $types, static function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
     }
@@ -566,7 +566,7 @@ trait QueriesRelationships
      */
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
-        return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+        return $this->orWhereHasMorph($relation, $types, static function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
     }
@@ -585,7 +585,7 @@ trait QueriesRelationships
      */
     public function whereMorphDoesntHaveRelation($relation, $types, $column, $operator = null, $value = null)
     {
-        return $this->whereDoesntHaveMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+        return $this->whereDoesntHaveMorph($relation, $types, static function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
     }
@@ -604,7 +604,7 @@ trait QueriesRelationships
      */
     public function orWhereMorphDoesntHaveRelation($relation, $types, $column, $operator = null, $value = null)
     {
-        return $this->orWhereDoesntHaveMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+        return $this->orWhereDoesntHaveMorph($relation, $types, static function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
     }
@@ -644,9 +644,9 @@ trait QueriesRelationships
             throw new InvalidArgumentException('Collection given to whereMorphedTo method may not be empty.');
         }
 
-        return $this->where(function ($query) use ($relation, $models) {
-            $models->groupBy(fn ($model) => $model->getMorphClass())->each(function ($models) use ($query, $relation) {
-                $query->orWhere(function ($query) use ($relation, $models) {
+        return $this->where(static function ($query) use ($relation, $models) {
+            $models->groupBy(static fn ($model) => $model->getMorphClass())->each(static function ($models) use ($query, $relation) {
+                $query->orWhere(static function ($query) use ($relation, $models) {
                     $query->where($relation->qualifyColumn($relation->getMorphType()), $models->first()->getMorphClass())
                         ->whereIn($relation->qualifyColumn($relation->getForeignKeyName()), $models->map->getKey());
                 });
@@ -676,7 +676,7 @@ trait QueriesRelationships
                 $model = array_search($model, $morphMap, true);
             }
 
-            return $this->whereNot(fn ($query) => $query->whereNullSafeEquals(
+            return $this->whereNot(static fn ($query) => $query->whereNullSafeEquals(
                 $relation->qualifyColumn($relation->getMorphType()), $model
             ), null, null, $boolean);
         }
@@ -687,9 +687,9 @@ trait QueriesRelationships
             throw new InvalidArgumentException('Collection given to whereNotMorphedTo method may not be empty.');
         }
 
-        return $this->whereNot(function ($query) use ($relation, $models) {
-            $models->groupBy(fn ($model) => $model->getMorphClass())->each(function ($models) use ($query, $relation) {
-                $query->orWhere(function ($query) use ($relation, $models) {
+        return $this->whereNot(static function ($query) use ($relation, $models) {
+            $models->groupBy(static fn ($model) => $model->getMorphClass())->each(static function ($models) use ($query, $relation) {
+                $query->orWhere(static function ($query) use ($relation, $models) {
                     $query->whereNullSafeEquals($relation->qualifyColumn($relation->getMorphType()), $models->first()->getMorphClass())
                         ->whereIn($relation->qualifyColumn($relation->getForeignKeyName()), $models->map->getKey());
                 });
@@ -819,7 +819,7 @@ trait QueriesRelationships
         $this->has(
             $relationshipName,
             boolean: $boolean,
-            callback: fn (Builder $query) => $query->whereKey($relatedCollection->pluck($related->getKeyName())),
+            callback: static fn (Builder $query) => $query->whereKey($relatedCollection->pluck($related->getKeyName())),
         );
 
         return $this;
@@ -1082,8 +1082,8 @@ trait QueriesRelationships
      */
     protected function requalifyWhereTables(array $wheres, string $from, string $to): array
     {
-        return (new BaseCollection($wheres))->map(function ($where) use ($from, $to) {
-            return (new BaseCollection($where))->map(function ($value) use ($from, $to) {
+        return (new BaseCollection($wheres))->map(static function ($where) use ($from, $to) {
+            return (new BaseCollection($where))->map(static function ($value) use ($from, $to) {
                 return is_string($value) && str_starts_with($value, $from.'.')
                     ? $to.'.'.Str::afterLast($value, '.')
                     : $value;

--- a/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
@@ -14,7 +14,7 @@ class CrossJoinSequence extends Sequence
     public function __construct(...$sequences)
     {
         $crossJoined = array_map(
-            function ($a) {
+            static function ($a) {
                 return array_merge(...$a);
             },
             Arr::crossJoin(...$sequences),

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -600,7 +600,7 @@ abstract class Factory
 
                 return $attribute;
             })
-            ->map(function ($attribute, $key) use (&$definition, $evaluateRelations) {
+            ->map(static function ($attribute, $key) use (&$definition, $evaluateRelations) {
                 if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
                     $attribute = $attribute($definition);
                 }
@@ -728,7 +728,7 @@ abstract class Factory
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
-        if (is_array($pivot) && $pivot !== [] && array_is_list($pivot) && array_all($pivot, fn ($p) => is_array($p))) {
+        if (is_array($pivot) && $pivot !== [] && array_is_list($pivot) && array_all($pivot, static fn ($p) => is_array($p))) {
             $factory = $factory instanceof Factory && $factory->count === null
                 ? $factory->count(count($pivot))
                 : $factory;
@@ -781,7 +781,7 @@ abstract class Factory
                 ->merge(
                     Collection::wrap($model instanceof Model ? func_get_args() : $model)
                         ->flatten()
-                )->groupBy(fn ($model) => get_class($model)),
+                )->groupBy(static fn ($model) => get_class($model)),
         ]);
     }
 
@@ -849,7 +849,7 @@ abstract class Factory
     protected function callAfterMaking(Collection $instances)
     {
         $instances->each(function ($model) {
-            $this->afterMaking->each(function ($callback) use ($model) {
+            $this->afterMaking->each(static function ($callback) use ($model) {
                 $callback($model);
             });
         });
@@ -865,7 +865,7 @@ abstract class Factory
     protected function callAfterCreating(Collection $instances, ?Model $parent = null)
     {
         $instances->each(function ($model) use ($parent) {
-            $this->afterCreating->each(function ($callback) use ($model, $parent) {
+            $this->afterCreating->each(static function ($callback) use ($model, $parent) {
                 $callback($model, $parent);
             });
         });
@@ -972,7 +972,7 @@ abstract class Factory
             return $this->model;
         }
 
-        $resolver = static::$modelNameResolvers[static::class] ?? static::$modelNameResolvers[self::class] ?? static::$modelNameResolver ?? function (self $factory) {
+        $resolver = static::$modelNameResolvers[static::class] ?? static::$modelNameResolvers[self::class] ?? static::$modelNameResolver ?? static function (self $factory) {
             $namespacedFactoryBasename = Str::replaceLast(
                 'Factory', '', Str::replaceFirst(static::$namespace, '', $factory::class)
             );
@@ -1081,7 +1081,7 @@ abstract class Factory
      */
     public static function resolveFactoryName(string $modelName)
     {
-        $resolver = static::$factoryNameResolver ?? function (string $modelName) {
+        $resolver = static::$factoryNameResolver ?? static function (string $modelName) {
             $appNamespace = static::appNamespace();
 
             $modelName = Str::startsWith($modelName, $appNamespace.'Models\\')
@@ -1160,7 +1160,7 @@ abstract class Factory
         if (str_starts_with($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);
         } elseif (str_starts_with($method, 'has')) {
-            if (count($parameters) > 1 && array_all($parameters, fn ($p) => is_array($p))) {
+            if (count($parameters) > 1 && array_all($parameters, static fn ($p) => is_array($p))) {
                 return $this->has($factory->forEachSequence(...$parameters), $relationship);
             }
 

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -54,7 +54,7 @@ trait HasFactory
 
             $factory = $useFactory->factoryClass::new();
 
-            $factory->guessModelNamesUsing(fn () => static::class);
+            $factory->guessModelNamesUsing(static fn () => static::class);
 
             return $factory;
         }

--- a/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
@@ -42,7 +42,7 @@ class HigherOrderBuilderProxy
      */
     public function __call($method, $parameters)
     {
-        return $this->builder->{$this->method}(function ($value) use ($method, $parameters) {
+        return $this->builder->{$this->method}(static function ($value) use ($method, $parameters) {
             return $value->{$method}(...$parameters);
         });
     }

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -15,8 +15,8 @@ trait MassPrunable
      */
     public function pruneAll(int $chunkSize = 1000)
     {
-        $query = tap($this->prunable(), function ($query) use ($chunkSize) {
-            $query->when(! $query->getQuery()->limit, function ($query) use ($chunkSize) {
+        $query = tap($this->prunable(), static function ($query) use ($chunkSize) {
+            $query->when(! $query->getQuery()->limit, static function ($query) use ($chunkSize) {
                 $query->limit($chunkSize);
             });
         });

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -552,7 +552,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return true;
         }
 
-        return array_any(static::$ignoreOnTouch, fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
+        return array_any(static::$ignoreOnTouch, static fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
     }
 
     /**
@@ -2117,7 +2117,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         );
 
         $this->load((new BaseCollection($this->relations))->reject(
-            fn ($relation) => $relation instanceof Pivot
+            static fn ($relation) => $relation instanceof Pivot
                 || (is_object($relation) && isset(class_uses_recursive($relation)[AsPivot::class]))
         )->keys()->all());
 

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -122,11 +122,11 @@ class ModelInspector
 
         return (new BaseCollection($class->getMethods()))
             ->reject(
-                fn (ReflectionMethod $method) => $method->isStatic()
+                static fn (ReflectionMethod $method) => $method->isStatic()
                     || $method->isAbstract()
                     || $method->getDeclaringClass()->getName() === Model::class
             )
-            ->mapWithKeys(function (ReflectionMethod $method) use ($model) {
+            ->mapWithKeys(static function (ReflectionMethod $method) use ($model) {
                 if (preg_match('/^get(.+)Attribute$/', $method->getName(), $matches) === 1) {
                     return [Str::snake($matches[1]) => 'accessor'];
                 } elseif ($model->hasAttributeMutator($method->getName())) {
@@ -135,7 +135,7 @@ class ModelInspector
                     return [];
                 }
             })
-            ->reject(fn ($cast, $name) => (new BaseCollection($columns))->contains('name', $name))
+            ->reject(static fn ($cast, $name) => (new BaseCollection($columns))->contains('name', $name))
             ->map(fn ($cast, $name) => [
                 'name' => $name,
                 'type' => null,
@@ -160,9 +160,9 @@ class ModelInspector
     protected function getRelations($model)
     {
         return (new BaseCollection(get_class_methods($model)))
-            ->map(fn ($method) => new ReflectionMethod($model, $method))
+            ->map(static fn ($method) => new ReflectionMethod($model, $method))
             ->reject(
-                fn (ReflectionMethod $method) => $method->isStatic()
+                static fn (ReflectionMethod $method) => $method->isStatic()
                     || $method->isAbstract()
                     || $method->getDeclaringClass()->getName() === Model::class
                     || $method->getNumberOfParameters() > 0
@@ -182,9 +182,9 @@ class ModelInspector
                 }
 
                 return (new BaseCollection($this->relationMethods))
-                    ->contains(fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
+                    ->contains(static fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
             })
-            ->map(function (ReflectionMethod $method) use ($model) {
+            ->map(static function (ReflectionMethod $method) use ($model) {
                 $relation = $method->invoke($model);
 
                 if (! $relation instanceof Relation) {
@@ -223,7 +223,7 @@ class ModelInspector
     protected function getEvents($model)
     {
         return (new BaseCollection($model->dispatchesEvents()))
-            ->map(fn (string $class, string $event) => [
+            ->map(static fn (string $class, string $event) => [
                 'event' => $event,
                 'class' => $class,
             ])->values();
@@ -242,12 +242,12 @@ class ModelInspector
         $listeners = $this->app->make('events')->getRawListeners();
 
         // Get the Eloquent observers for this model...
-        $listeners = array_filter($listeners, function ($v, $key) use ($model) {
+        $listeners = array_filter($listeners, static function ($v, $key) use ($model) {
             return Str::startsWith($key, 'eloquent.') && Str::endsWith($key, $model::class);
         }, ARRAY_FILTER_USE_BOTH);
 
         // Format listeners Eloquent verb => Observer methods...
-        $extractVerb = function ($key) {
+        $extractVerb = static function ($key) {
             preg_match('/eloquent.([a-zA-Z]+)\: /', $key, $matches);
 
             return $matches[1] ?? '?';
@@ -258,7 +258,7 @@ class ModelInspector
         foreach ($listeners as $key => $observerMethods) {
             $formatted[] = [
                 'event' => $extractVerb($key),
-                'observer' => array_map(fn ($obs) => is_string($obs) ? $obs : 'Closure', $observerMethods),
+                'observer' => array_map(static fn ($obs) => is_string($obs) ? $obs : 'Closure', $observerMethods),
             ];
         }
 
@@ -360,7 +360,7 @@ class ModelInspector
         return (new BaseCollection($model->getDates()))
             ->filter()
             ->flip()
-            ->map(fn () => 'datetime')
+            ->map(static fn () => 'datetime')
             ->merge($model->getCasts());
     }
 
@@ -408,7 +408,7 @@ class ModelInspector
     protected function columnIsUnique($column, $indexes)
     {
         return (new BaseCollection($indexes))->contains(
-            fn ($index) => count($index['columns']) === 1 && $index['columns'][0] === $column && $index['unique']
+            static fn ($index) => count($index['columns']) === 1 && $index['columns'][0] === $column && $index['unique']
         );
     }
 }

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -22,10 +22,10 @@ trait Prunable
         $total = 0;
 
         $this->prunable()
-            ->when(static::isSoftDeletable(), function ($query) {
+            ->when(static::isSoftDeletable(), static function ($query) {
                 $query->withTrashed();
-            })->chunkById($chunkSize, function ($models) use (&$total) {
-                $models->each(function ($model) use (&$total) {
+            })->chunkById($chunkSize, static function ($models) use (&$total) {
+                $models->each(static function ($model) use (&$total) {
                     try {
                         $model->prune();
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -709,7 +709,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, Closure|array $values = [], array $joining = [], $touch = true)
     {
-        return tap($this->firstOrCreate($attributes, $values, $joining, $touch), function ($instance) use ($values) {
+        return tap($this->firstOrCreate($attributes, $values, $joining, $touch), static function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->fill(value($values));
 
@@ -1091,7 +1091,7 @@ class BelongsToMany extends Relation
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
+        return $this->chunkById($count, static function ($results, $page) use ($callback, $count) {
             foreach ($results as $key => $value) {
                 if ($callback($value, (($page - 1) * $count) + $key) === false) {
                     return false;
@@ -1134,7 +1134,7 @@ class BelongsToMany extends Relation
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -331,7 +331,7 @@ trait AsPivot
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
                 return $query->where($segments[0], $segments[1])
                     ->where($segments[2], $segments[3]);
             });

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -151,7 +151,7 @@ trait CanBeOneOfMany
      */
     public function latestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany(Collection::wrap($column)->mapWithKeys(function ($column) {
+        return $this->ofMany(Collection::wrap($column)->mapWithKeys(static function ($column) {
             return [$column => 'MAX'];
         })->all(), 'MAX', $relation);
     }
@@ -165,7 +165,7 @@ trait CanBeOneOfMany
      */
     public function oldestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany(Collection::wrap($column)->mapWithKeys(function ($column) {
+        return $this->ofMany(Collection::wrap($column)->mapWithKeys(static function ($column) {
             return [$column => 'MIN'];
         })->all(), 'MIN', $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -183,7 +183,7 @@ trait InteractsWithPivotTable
      */
     public function syncWithPivotValues($ids, array $values, bool $detaching = true)
     {
-        return $this->sync((new BaseCollection($this->parseIds($ids)))->mapWithKeys(function ($id) use ($values) {
+        return $this->sync((new BaseCollection($this->parseIds($ids)))->mapWithKeys(static function ($id) use ($values) {
             return [$id => $values];
         }), $detaching);
     }
@@ -211,7 +211,7 @@ trait InteractsWithPivotTable
      */
     protected function formatRecordsList(array $records)
     {
-        return (new BaseCollection($records))->mapWithKeys(function ($attributes, $id) {
+        return (new BaseCollection($records))->mapWithKeys(static function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
@@ -572,7 +572,7 @@ trait InteractsWithPivotTable
     protected function detachUsingCustomClass($ids)
     {
         return $this->getCurrentlyAttachedPivotsForIds($ids)
-            ->reduce(fn ($carry, $record) => $carry + $record->delete(), 0);
+            ->reduce(static fn ($carry, $record) => $carry + $record->delete(), 0);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -25,7 +25,7 @@ class HasManyThrough extends HasOneOrManyThrough
     public function one()
     {
         return HasOneThrough::noConstraints(fn () => new HasOneThrough(
-            tap($this->getQuery(), fn (Builder $query) => $query->getQuery()->joins = []),
+            tap($this->getQuery(), static fn (Builder $query) => $query->getQuery()->joins = []),
             $this->farParent,
             $this->throughParent,
             $this->getFirstKeyName(),

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -297,7 +297,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function updateOrCreate(array $attributes, Closure|array $values = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        return tap($this->firstOrCreate($attributes, $values), static function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->fill(value($values))->save();
             }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -259,7 +259,7 @@ abstract class HasOneOrManyThrough extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        return tap($this->firstOrCreate($attributes, $values), static function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->fill($values)->save();
             }
@@ -619,7 +619,7 @@ abstract class HasOneOrManyThrough extends Relation
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -172,7 +172,7 @@ class MorphPivot extends Pivot
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
                 return $query->where($segments[0], $segments[1])
                     ->where($segments[2], $segments[3])
                     ->where($segments[4], $segments[5]);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -187,7 +187,7 @@ class MorphTo extends BelongsTo
     {
         return $keyType !== 'string'
             ? array_keys($this->dictionary[$type])
-            : array_map(function ($modelId) {
+            : array_map(static function ($modelId) {
                 return (string) $modelId;
             }, array_filter(array_keys($this->dictionary[$type])));
     }
@@ -365,7 +365,7 @@ class MorphTo extends BelongsTo
      */
     public function withTrashed()
     {
-        $callback = fn ($query) => $query->hasMacro('withTrashed') ? $query->withTrashed() : $query;
+        $callback = static fn ($query) => $query->hasMacro('withTrashed') ? $query->withTrashed() : $query;
 
         $this->macroBuffer[] = [
             'method' => 'when',
@@ -382,7 +382,7 @@ class MorphTo extends BelongsTo
      */
     public function withoutTrashed()
     {
-        $callback = fn ($query) => $query->hasMacro('withoutTrashed') ? $query->withoutTrashed() : $query;
+        $callback = static fn ($query) => $query->hasMacro('withoutTrashed') ? $query->withoutTrashed() : $query;
 
         $this->macroBuffer[] = [
             'method' => 'when',
@@ -399,7 +399,7 @@ class MorphTo extends BelongsTo
      */
     public function onlyTrashed()
     {
-        $callback = fn ($query) => $query->hasMacro('onlyTrashed') ? $query->onlyTrashed() : $query;
+        $callback = static fn ($query) => $query->hasMacro('onlyTrashed') ? $query->onlyTrashed() : $query;
 
         $this->macroBuffer[] = [
             'method' => 'when',

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -363,7 +363,7 @@ abstract class Relation implements BuilderContract
      */
     protected function getKeys(array $models, $key = null)
     {
-        return (new BaseCollection($models))->map(function ($value) use ($key) {
+        return (new BaseCollection($models))->map(static function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
         })->values()->unique(null, true)->sort()->all();
     }
@@ -568,7 +568,7 @@ abstract class Relation implements BuilderContract
             return $models;
         }
 
-        return array_combine(array_map(function ($model) {
+        return array_combine(array_map(static function ($model) {
             return (new $model)->getTable();
         }, $models), $models);
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -72,7 +72,7 @@ class SoftDeletingScope implements Scope
      */
     protected function addRestore(Builder $builder)
     {
-        $builder->macro('restore', function (Builder $builder) {
+        $builder->macro('restore', static function (Builder $builder) {
             $builder->withTrashed();
 
             return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);
@@ -87,10 +87,10 @@ class SoftDeletingScope implements Scope
      */
     protected function addRestoreOrCreate(Builder $builder)
     {
-        $builder->macro('restoreOrCreate', function (Builder $builder, array $attributes = [], array $values = []) {
+        $builder->macro('restoreOrCreate', static function (Builder $builder, array $attributes = [], array $values = []) {
             $builder->withTrashed();
 
-            return tap($builder->firstOrCreate($attributes, $values), function ($instance) {
+            return tap($builder->firstOrCreate($attributes, $values), static function ($instance) {
                 $instance->restore();
             });
         });
@@ -104,10 +104,10 @@ class SoftDeletingScope implements Scope
      */
     protected function addCreateOrRestore(Builder $builder)
     {
-        $builder->macro('createOrRestore', function (Builder $builder, array $attributes = [], array $values = []) {
+        $builder->macro('createOrRestore', static function (Builder $builder, array $attributes = [], array $values = []) {
             $builder->withTrashed();
 
-            return tap($builder->createOrFirst($attributes, $values), function ($instance) {
+            return tap($builder->createOrFirst($attributes, $values), static function ($instance) {
                 $instance->restore();
             });
         });

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -58,7 +58,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerRepository()
     {
-        $this->app->singleton('migration.repository', function ($app) {
+        $this->app->singleton('migration.repository', static function ($app) {
             $migrations = $app['config']['database.migrations'];
 
             $table = is_array($migrations) ? ($migrations['table'] ?? null) : $migrations;
@@ -77,13 +77,13 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
+        $this->app->singleton('migrator', static function ($app) {
             $repository = $app['migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
         });
 
-        $this->app->bind(Migrator::class, fn ($app) => $app['migrator']);
+        $this->app->bind(Migrator::class, static fn ($app) => $app['migrator']);
     }
 
     /**
@@ -93,7 +93,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerCreator()
     {
-        $this->app->singleton('migration.creator', function ($app) {
+        $this->app->singleton('migration.creator', static function ($app) {
             return new MigrationCreator($app['files'], $app->basePath('stubs'));
         });
     }
@@ -120,7 +120,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton(MigrateCommand::class, function ($app) {
+        $this->app->singleton(MigrateCommand::class, static function ($app) {
             return new MigrateCommand($app['migrator'], $app[Dispatcher::class]);
         });
     }
@@ -132,7 +132,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton(FreshCommand::class, function ($app) {
+        $this->app->singleton(FreshCommand::class, static function ($app) {
             return new FreshCommand($app['migrator']);
         });
     }
@@ -144,7 +144,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton(InstallCommand::class, function ($app) {
+        $this->app->singleton(InstallCommand::class, static function ($app) {
             return new InstallCommand($app['migration.repository']);
         });
     }
@@ -156,7 +156,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton(MigrateMakeCommand::class, function ($app) {
+        $this->app->singleton(MigrateMakeCommand::class, static function ($app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.
@@ -185,7 +185,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton(ResetCommand::class, function ($app) {
+        $this->app->singleton(ResetCommand::class, static function ($app) {
             return new ResetCommand($app['migrator']);
         });
     }
@@ -197,7 +197,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton(RollbackCommand::class, function ($app) {
+        $this->app->singleton(RollbackCommand::class, static function ($app) {
             return new RollbackCommand($app['migrator']);
         });
     }
@@ -209,7 +209,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton(StatusCommand::class, function ($app) {
+        $this->app->singleton(StatusCommand::class, static function ($app) {
             return new StatusCommand($app['migrator']);
         });
     }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -163,7 +163,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->getConnection()->getSchemaBuilder();
 
-        $schema->create($this->table, function ($table) {
+        $schema->create($this->table, static function ($table) {
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
             // table to hold the migration file's path as well as the batch ID.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -248,7 +248,7 @@ class Migrator
         if (! $shouldRunMigration) {
             $this->fireMigrationEvent(new MigrationSkipped($name));
 
-            $this->write(Task::class, $name, fn () => MigrationResult::Skipped->value);
+            $this->write(Task::class, $name, static fn () => MigrationResult::Skipped->value);
         } else {
             $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up', $name));
 
@@ -386,7 +386,7 @@ class Migrator
         // Since the getRan method that retrieves the migration name just gives us the
         // migration name, we will format the names into objects with the name as a
         // property on the objects so that we can pass it to the rollback method.
-        $migrations = (new Collection($migrations))->map(fn ($m) => (object) ['migration' => $m])->all();
+        $migrations = (new Collection($migrations))->map(static fn ($m) => (object) ['migration' => $m])->all();
 
         return $this->rollbackMigrations(
             $migrations, $paths, ['pretend' => $pretend]
@@ -472,7 +472,7 @@ class Migrator
 
         $this->write(
             BulletList::class,
-            (new Collection($this->getQueries($migration, $method)))->map(fn ($query) => $query['query'])
+            (new Collection($this->getQueries($migration, $method)))->map(static fn ($query) => $query['query'])
         );
     }
 
@@ -582,7 +582,7 @@ class Migrator
             ->filter()
             ->values()
             ->keyBy(fn ($file) => $this->getMigrationName($file))
-            ->sortBy(fn ($file, $key) => $key)
+            ->sortBy(static fn ($file, $key) => $key)
             ->all();
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1039,7 +1039,7 @@ class Builder implements BuilderContract
      */
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
+        return $this->whereNested(static function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value), boolean: $boolean);
@@ -1139,7 +1139,7 @@ class Builder implements BuilderContract
     public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
         if (is_array($column)) {
-            return $this->whereNested(function ($query) use ($column, $operator, $value, $boolean) {
+            return $this->whereNested(static function ($query) use ($column, $operator, $value, $boolean) {
                 $query->where($column, $operator, $value, $boolean);
             }, $boolean.' not');
         }
@@ -2577,7 +2577,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+        $this->whereNested(static function ($query) use ($columns, $operator, $value) {
             foreach ($columns as $column) {
                 $query->where($column, $operator, $value, 'and');
             }
@@ -2614,7 +2614,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+        $this->whereNested(static function ($query) use ($columns, $operator, $value) {
             foreach ($columns as $column) {
                 $query->where($column, $operator, $value, 'or');
             }
@@ -3294,7 +3294,7 @@ class Builder implements BuilderContract
     protected function removeExistingOrdersFor($column)
     {
         return (new Collection($this->orders))
-            ->reject(fn ($order) => isset($order['column']) && $order['column'] === $column)
+            ->reject(static fn ($order) => isset($order['column']) && $order['column'] === $column)
             ->values()
             ->all();
     }
@@ -3592,7 +3592,7 @@ class Builder implements BuilderContract
             $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap('pivot_'.$column);
         }
 
-        $items->each(function ($item) use ($keysToRemove) {
+        $items->each(static function ($item) use ($keysToRemove) {
             foreach ($keysToRemove as $key) {
                 unset($item->$key);
             }
@@ -3678,7 +3678,7 @@ class Builder implements BuilderContract
             $this->enforceOrderBy();
         }
 
-        $reverseDirection = function ($order) {
+        $reverseDirection = static function ($order) {
             if (! isset($order['direction'])) {
                 return $order;
             }
@@ -3696,7 +3696,7 @@ class Builder implements BuilderContract
         $orders = ! empty($this->unionOrders) ? $this->unionOrders : $this->orders;
 
         return (new Collection($orders))
-            ->filter(fn ($order) => Arr::has($order, 'direction'))
+            ->filter(static fn ($order) => Arr::has($order, 'direction'))
             ->values();
     }
 
@@ -3771,7 +3771,7 @@ class Builder implements BuilderContract
      */
     protected function withoutSelectAliases(array $columns)
     {
-        return array_map(function ($column) {
+        return array_map(static function ($column) {
             return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
                 ? substr($column, 0, $aliasPosition)
                 : $column;
@@ -3795,7 +3795,7 @@ class Builder implements BuilderContract
             );
         }))->map(function ($item) {
             return $this->applyAfterQueryCallbacks(new Collection([$item]))->first();
-        })->reject(fn ($item) => is_null($item));
+        })->reject(static fn ($item) => is_null($item));
     }
 
     /**
@@ -4313,13 +4313,13 @@ class Builder implements BuilderContract
 
             [$query, $bindings] = $this->parseSub($value);
 
-            return ['value' => new Expression("({$query})"), 'bindings' => fn () => $bindings];
+            return ['value' => new Expression("({$query})"), 'bindings' => static fn () => $bindings];
         });
 
-        $sql = $this->grammar->compileUpdate($this, $values->map(fn ($value) => $value['value'])->all());
+        $sql = $this->grammar->compileUpdate($this, $values->map(static fn ($value) => $value['value'])->all());
 
         return $this->connection->update($sql, $this->cleanBindings(
-            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(fn ($value) => $value['bindings'])->all())
+            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(static fn ($value) => $value['bindings'])->all())
         ));
     }
 
@@ -4406,7 +4406,7 @@ class Builder implements BuilderContract
         $bindings = $this->cleanBindings(array_merge(
             Arr::flatten($values, 1),
             (new Collection($update))
-                ->reject(fn ($value, $key) => is_int($key))
+                ->reject(static fn ($value, $key) => is_int($key))
                 ->all()
         ));
 
@@ -4727,7 +4727,7 @@ class Builder implements BuilderContract
     public function cleanBindings(array $bindings)
     {
         return (new Collection($bindings))
-            ->reject(function ($binding) {
+            ->reject(static function ($binding) {
                 return $binding instanceof ExpressionContract;
             })
             ->map($this->castBinding(...))
@@ -4856,7 +4856,7 @@ class Builder implements BuilderContract
      */
     public function cloneWithout(array $properties)
     {
-        return tap($this->clone(), function ($clone) use ($properties) {
+        return tap($this->clone(), static function ($clone) use ($properties) {
             foreach ($properties as $property) {
                 $clone->{$property} = null;
             }
@@ -4870,7 +4870,7 @@ class Builder implements BuilderContract
      */
     public function cloneWithoutBindings(array $except)
     {
-        return tap($this->clone(), function ($clone) use ($except) {
+        return tap($this->clone(), static function ($clone) use ($except) {
             foreach ($except as $type) {
                 $clone->bindings[$type] = [];
             }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1431,7 +1431,7 @@ class Grammar extends BaseGrammar
     {
         $cleanBindings = Arr::except($bindings, ['select', 'join']);
 
-        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+        $values = Arr::flatten(array_map(static fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($bindings['join'], $values, Arr::flatten($cleanBindings))
@@ -1595,7 +1595,7 @@ class Grammar extends BaseGrammar
      */
     protected function concatenate($segments)
     {
-        return implode(' ', array_filter($segments, function ($value) {
+        return implode(' ', array_filter($segments, static function ($value) {
             return (string) $value !== '';
         }));
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -514,7 +514,7 @@ class MySqlGrammar extends Grammar
     {
         $values = (new Collection($values))
             ->reject(fn ($value, $column) => $this->isJsonSelector($column) && is_bool($value))
-            ->map(fn ($value) => is_array($value) ? json_encode($value) : $value)
+            ->map(static fn ($value) => is_array($value) ? json_encode($value) : $value)
             ->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -656,7 +656,7 @@ class PostgresGrammar extends Grammar
 
         $cleanBindings = Arr::except($bindings, 'select');
 
-        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+        $values = Arr::flatten(array_map(static fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))
@@ -779,7 +779,7 @@ class PostgresGrammar extends Grammar
         return (new Collection($path))
             ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
             ->collapse()
-            ->map(function ($attribute) use ($quote) {
+            ->map(static function ($attribute) use ($quote) {
                 if (filter_var($attribute, FILTER_VALIDATE_INT) !== false) {
                     return $attribute;
                 }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -434,12 +434,12 @@ class SQLiteGrammar extends Grammar
         $values = (new Collection($values))
             ->reject(fn ($value, $key) => $this->isJsonSelector($key))
             ->merge($groups)
-            ->map(fn ($value) => is_array($value) ? json_encode($value) : $value)
+            ->map(static fn ($value) => is_array($value) ? json_encode($value) : $value)
             ->all();
 
         $cleanBindings = Arr::except($bindings, 'select');
 
-        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+        $values = Arr::flatten(array_map(static fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -481,7 +481,7 @@ class SqlServerGrammar extends Grammar
     {
         $cleanBindings = Arr::except($bindings, 'select');
 
-        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+        $values = Arr::flatten(array_map(static fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -16,7 +16,7 @@ class MySqlProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->column_name;
         }, $results);
     }
@@ -42,7 +42,7 @@ class MySqlProcessor extends Processor
     /** @inheritDoc */
     public function processColumns($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -69,7 +69,7 @@ class MySqlProcessor extends Processor
     /** @inheritDoc */
     public function processIndexes($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -85,7 +85,7 @@ class MySqlProcessor extends Processor
     /** @inheritDoc */
     public function processForeignKeys($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -33,7 +33,7 @@ class PostgresProcessor extends Processor
     /** @inheritDoc */
     public function processTypes($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -77,7 +77,7 @@ class PostgresProcessor extends Processor
     /** @inheritDoc */
     public function processColumns($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             $autoincrement = $result->default !== null && str_starts_with($result->default, 'nextval(');
@@ -106,7 +106,7 @@ class PostgresProcessor extends Processor
     /** @inheritDoc */
     public function processIndexes($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -122,7 +122,7 @@ class PostgresProcessor extends Processor
     /** @inheritDoc */
     public function processForeignKeys($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -44,7 +44,7 @@ class Processor
      */
     public function processSchemas($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -63,7 +63,7 @@ class Processor
      */
     public function processTables($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -86,7 +86,7 @@ class Processor
      */
     public function processViews($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -9,7 +9,7 @@ class SQLiteProcessor extends Processor
     {
         $hasPrimaryKey = array_sum(array_column($results, 'primary')) === 1;
 
-        return array_map(function ($result) use ($hasPrimaryKey, $sql) {
+        return array_map(static function ($result) use ($hasPrimaryKey, $sql) {
             $result = (object) $result;
 
             $type = strtolower($result->type);
@@ -56,7 +56,7 @@ class SQLiteProcessor extends Processor
     {
         $primaryCount = 0;
 
-        $indexes = array_map(function ($result) use (&$primaryCount) {
+        $indexes = array_map(static function ($result) use (&$primaryCount) {
             $result = (object) $result;
 
             if ($isPrimary = (bool) $result->primary) {
@@ -73,7 +73,7 @@ class SQLiteProcessor extends Processor
         }, $results);
 
         if ($primaryCount > 1) {
-            $indexes = array_filter($indexes, fn ($index) => $index['name'] !== 'primary');
+            $indexes = array_filter($indexes, static fn ($index) => $index['name'] !== 'primary');
         }
 
         return $indexes;
@@ -82,7 +82,7 @@ class SQLiteProcessor extends Processor
     /** @inheritDoc */
     public function processForeignKeys($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -58,7 +58,7 @@ class SqlServerProcessor extends Processor
     /** @inheritDoc */
     public function processColumns($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             $type = match ($typeName = $result->type_name) {
@@ -88,7 +88,7 @@ class SqlServerProcessor extends Processor
     /** @inheritDoc */
     public function processIndexes($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [
@@ -104,7 +104,7 @@ class SqlServerProcessor extends Processor
     /** @inheritDoc */
     public function processForeignKeys($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             $result = (object) $result;
 
             return [

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -183,7 +183,7 @@ class Blueprint
     protected function commandsNamed(array $names)
     {
         return (new Collection($this->commands))
-            ->filter(fn ($command) => in_array($command->name, $names));
+            ->filter(static fn ($command) => in_array($command->name, $names));
     }
 
     /**
@@ -327,7 +327,7 @@ class Blueprint
     public function creating()
     {
         return (new Collection($this->commands))
-            ->contains(fn ($command) => ! $command instanceof ColumnDefinition && $command->name === 'create');
+            ->contains(static fn ($command) => ! $command instanceof ColumnDefinition && $command->name === 'create');
     }
 
     /**
@@ -1168,7 +1168,7 @@ class Blueprint
      */
     public function enum($column, array $allowed)
     {
-        $allowed = array_map(fn ($value) => enum_value($value), $allowed);
+        $allowed = array_map(static fn ($value) => enum_value($value), $allowed);
 
         return $this->addColumn('enum', $column, ['allowed' => $allowed]);
     }
@@ -1889,11 +1889,11 @@ class Blueprint
      */
     public function removeColumn($name)
     {
-        $this->columns = array_values(array_filter($this->columns, function ($c) use ($name) {
+        $this->columns = array_values(array_filter($this->columns, static function ($c) use ($name) {
             return $c['name'] != $name;
         }));
 
-        $this->commands = array_values(array_filter($this->commands, function ($c) use ($name) {
+        $this->commands = array_values(array_filter($this->commands, static function ($c) use ($name) {
             return ! $c instanceof ColumnDefinition || $c['name'] != $name;
         }));
 
@@ -1995,7 +1995,7 @@ class Blueprint
      */
     public function getAddedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return ! $column->change;
         });
     }
@@ -2009,7 +2009,7 @@ class Blueprint
      */
     public function getChangedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return (bool) $column->change;
         });
     }

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -66,7 +66,7 @@ class BlueprintState
         $schema = $connection->getSchemaBuilder();
         $table = $blueprint->getTable();
 
-        $this->columns = (new Collection($schema->getColumns($table)))->map(fn ($column) => new ColumnDefinition([
+        $this->columns = (new Collection($schema->getColumns($table)))->map(static fn ($column) => new ColumnDefinition([
             'name' => $column['name'],
             'type' => $column['type_name'],
             'full_type_definition' => $column['type'],
@@ -83,7 +83,7 @@ class BlueprintState
                 : null,
         ]))->all();
 
-        [$primary, $indexes] = (new Collection($schema->getIndexes($table)))->map(fn ($index) => new IndexDefinition([
+        [$primary, $indexes] = (new Collection($schema->getIndexes($table)))->map(static fn ($index) => new IndexDefinition([
             'name' => match (true) {
                 $index['primary'] => 'primary',
                 $index['unique'] => 'unique',
@@ -91,12 +91,12 @@ class BlueprintState
             },
             'index' => $index['name'],
             'columns' => $index['columns'],
-        ]))->partition(fn ($index) => $index->name === 'primary');
+        ]))->partition(static fn ($index) => $index->name === 'primary');
 
         $this->indexes = $indexes->all();
         $this->primaryKey = $primary->first();
 
-        $this->foreignKeys = (new Collection($schema->getForeignKeys($table)))->map(fn ($foreignKey) => new ForeignKeyDefinition([
+        $this->foreignKeys = (new Collection($schema->getForeignKeys($table)))->map(static fn ($foreignKey) => new ForeignKeyDefinition([
             'columns' => $foreignKey['columns'],
             'on' => new Expression($foreignKey['foreign_table']),
             'references' => $foreignKey['foreign_columns'],
@@ -196,7 +196,7 @@ class BlueprintState
 
             case 'dropColumn':
                 $this->columns = array_values(
-                    array_filter($this->columns, fn ($column) => ! in_array($column->name, $command->columns))
+                    array_filter($this->columns, static fn ($column) => ! in_array($column->name, $command->columns))
                 );
 
                 break;
@@ -231,14 +231,14 @@ class BlueprintState
             case 'dropIndex':
             case 'dropUnique':
                 $this->indexes = array_values(
-                    array_filter($this->indexes, fn ($index) => $index->index !== $command->index)
+                    array_filter($this->indexes, static fn ($index) => $index->index !== $command->index)
                 );
 
                 break;
 
             case 'dropForeign':
                 $this->foreignKeys = array_values(
-                    array_filter($this->foreignKeys, fn ($fk) => $fk->columns !== $command->columns)
+                    array_filter($this->foreignKeys, static fn ($fk) => $fk->columns !== $command->columns)
                 );
 
                 break;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -285,7 +285,7 @@ class Builder
     {
         $tableColumns = array_map(strtolower(...), $this->getColumnListing($table));
 
-        return array_all($columns, fn ($column) => in_array(strtolower($column), $tableColumns));
+        return array_all($columns, static fn ($column) => in_array(strtolower($column), $tableColumns));
     }
 
     /**
@@ -299,7 +299,7 @@ class Builder
     public function whenTableHasColumn(string $table, string $column, Closure $callback)
     {
         if ($this->hasColumn($table, $column)) {
-            $this->table($table, fn (Blueprint $table) => $callback($table));
+            $this->table($table, static fn (Blueprint $table) => $callback($table));
         }
     }
 
@@ -314,7 +314,7 @@ class Builder
     public function whenTableDoesntHaveColumn(string $table, string $column, Closure $callback)
     {
         if (! $this->hasColumn($table, $column)) {
-            $this->table($table, fn (Blueprint $table) => $callback($table));
+            $this->table($table, static fn (Blueprint $table) => $callback($table));
         }
     }
 
@@ -330,7 +330,7 @@ class Builder
     public function whenTableHasIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
     {
         if ($this->hasIndex($table, $index, $type)) {
-            $this->table($table, fn (Blueprint $table) => $callback($table));
+            $this->table($table, static fn (Blueprint $table) => $callback($table));
         }
     }
 
@@ -346,7 +346,7 @@ class Builder
     public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
     {
         if (! $this->hasIndex($table, $index, $type)) {
-            $this->table($table, fn (Blueprint $table) => $callback($table));
+            $this->table($table, static fn (Blueprint $table) => $callback($table));
         }
     }
 
@@ -517,7 +517,7 @@ class Builder
      */
     public function create($table, Closure $callback)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) use ($callback) {
             $blueprint->create();
 
             $callback($blueprint);
@@ -532,7 +532,7 @@ class Builder
      */
     public function drop($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
             $blueprint->drop();
         }));
     }
@@ -545,7 +545,7 @@ class Builder
      */
     public function dropIfExists($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
             $blueprint->dropIfExists();
         }));
     }
@@ -559,7 +559,7 @@ class Builder
      */
     public function dropColumns($table, $columns)
     {
-        $this->table($table, function (Blueprint $blueprint) use ($columns) {
+        $this->table($table, static function (Blueprint $blueprint) use ($columns) {
             $blueprint->dropColumn($columns);
         });
     }
@@ -609,7 +609,7 @@ class Builder
      */
     public function rename($from, $to)
     {
-        $this->build(tap($this->createBlueprint($from), function ($blueprint) use ($to) {
+        $this->build(tap($this->createBlueprint($from), static function ($blueprint) use ($to) {
             $blueprint->rename($to);
         }));
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -433,7 +433,7 @@ abstract class Grammar extends BaseGrammar
      */
     protected function getCommandsByName(Blueprint $blueprint, $name)
     {
-        return array_filter($blueprint->getCommands(), function ($value) use ($name) {
+        return array_filter($blueprint->getCommands(), static function ($value) use ($name) {
             return $value->name == $name;
         });
     }
@@ -465,7 +465,7 @@ abstract class Grammar extends BaseGrammar
      */
     public function prefixArray($prefix, array $values)
     {
-        return array_map(function ($value) use ($prefix) {
+        return array_map(static function ($value) use ($prefix) {
             return $prefix.' '.$value;
         }, $values);
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -345,7 +345,7 @@ class SQLiteGrammar extends Grammar
             })->all();
 
         $indexes = (new Collection($blueprint->getState()->getIndexes()))
-            ->reject(fn ($index) => str_starts_with('sqlite_', $index->index))
+            ->reject(static fn ($index) => str_starts_with('sqlite_', $index->index))
             ->map(fn ($index) => $this->{'compile'.ucfirst($index->name)}($blueprint, $index))
             ->all();
 
@@ -534,7 +534,7 @@ class SQLiteGrammar extends Grammar
 
         $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));
 
-        return (new Collection($columns))->map(fn ($column) => 'alter table '.$table.' '.$column)->all();
+        return (new Collection($columns))->map(static fn ($column) => 'alter table '.$table.' '.$column)->all();
     }
 
     /**
@@ -637,7 +637,7 @@ class SQLiteGrammar extends Grammar
     {
         $indexes = $this->connection->getSchemaBuilder()->getIndexes($blueprint->getTable());
 
-        $index = Arr::first($indexes, fn ($index) => $index['name'] === $command->from);
+        $index = Arr::first($indexes, static fn ($index) => $index['name'] === $command->from);
 
         if (! $index) {
             throw new RuntimeException("Index [{$command->from}] does not exist.");

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -56,11 +56,11 @@ abstract class SchemaState
 
         $this->files = $files ?: new Filesystem;
 
-        $this->processFactory = $processFactory ?: function (...$arguments) {
+        $this->processFactory = $processFactory ?: static function (...$arguments) {
             return Process::fromShellCommandline(...$arguments)->setTimeout(null);
         };
 
-        $this->handleOutputUsing(function () {
+        $this->handleOutputUsing(static function () {
             //
         });
     }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -35,6 +35,6 @@ class SqlServerBuilder extends Builder
      */
     public function getCurrentSchemaName()
     {
-        return Arr::first($this->getSchemas(), fn ($schema) => $schema['default'])['name'];
+        return Arr::first($this->getSchemas(), static fn ($schema) => $schema['default'])['name'];
     }
 }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -46,7 +46,7 @@ class SqliteSchemaState extends SchemaState
         ]));
 
         $migrations = (new Collection(preg_split("/\r\n|\n|\r/", $process->getOutput())))
-            ->filter(fn ($line) => preg_match('/^\s*(--|INSERT\s)/iu', $line) === 1 && $line !== '')
+            ->filter(static fn ($line) => preg_match('/^\s*(--|INSERT\s)/iu', $line) === 1 && $line !== '')
             ->all();
 
         $this->files->append($path, implode(PHP_EOL, $migrations).PHP_EOL);

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -78,7 +78,7 @@ class EncryptionServiceProvider extends ServiceProvider
      */
     protected function key(array $config)
     {
-        return tap($config['key'], function ($key) {
+        return tap($config['key'], static function ($key) {
             if (empty($key)) {
                 throw new MissingAppKeyException;
             }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -255,7 +255,7 @@ class CallQueuedListener implements ShouldQueue
      */
     public function __clone()
     {
-        $this->data = array_map(function ($data) {
+        $this->data = array_map(static function ($data) {
             return is_object($data) ? clone $data : $data;
         }, $this->data);
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -181,7 +181,7 @@ class Dispatcher implements DispatcherContract
      */
     public function hasWildcardListeners($eventName)
     {
-        return array_any($this->wildcards, fn ($listeners, $key) => Str::is($key, $eventName));
+        return array_any($this->wildcards, static fn ($listeners, $key) => Str::is($key, $eventName));
     }
 
     /**
@@ -485,7 +485,7 @@ class Dispatcher implements DispatcherContract
             return $this->createClassListener($listener, $wildcard);
         }
 
-        return function ($event, $payload) use ($listener, $wildcard) {
+        return static function ($event, $payload) use ($listener, $wildcard) {
             if ($wildcard) {
                 return $listener($event, $payload);
             }
@@ -582,7 +582,7 @@ class Dispatcher implements DispatcherContract
     protected function createQueuedHandlerCallable($class, $method)
     {
         return function () use ($class, $method) {
-            $arguments = array_map(function ($a) {
+            $arguments = array_map(static function ($a) {
                 return is_object($a) ? clone $a : $a;
             }, func_get_args());
 
@@ -618,7 +618,7 @@ class Dispatcher implements DispatcherContract
             $payload = func_get_args();
 
             $this->resolveTransactionManager()->addCallback(
-                function () use ($listener, $method, $payload) {
+                static function () use ($listener, $method, $payload) {
                     $listener->$method(...$payload);
                 }
             );

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -14,10 +14,10 @@ class EventServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('events', function ($app) {
-            return (new Dispatcher($app))->setQueueResolver(function () {
+        $this->app->singleton('events', static function ($app) {
+            return (new Dispatcher($app))->setQueueResolver(static function () {
                 return app(QueueFactoryContract::class);
-            })->setTransactionManagerResolver(function () {
+            })->setTransactionManagerResolver(static function () {
                 return app()->bound('db.transactions')
                     ? app('db.transactions')
                     : null;

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -165,7 +165,7 @@ class QueuedClosure
                 'closure' => new SerializableClosure($this->closure),
                 'arguments' => $arguments,
                 'catch' => (new Collection($this->catchCallbacks))
-                    ->map(fn ($callback) => new SerializableClosure($callback))
+                    ->map(static fn ($callback) => new SerializableClosure($callback))
                     ->all(),
             ]))
                 ->onConnection($this->connection)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -168,7 +168,7 @@ class Filesystem
             );
         }
 
-        return new LazyCollection(function () use ($path) {
+        return new LazyCollection(static function () use ($path) {
             $file = new SplFileObject($path);
 
             $file->setFlags(SplFileObject::DROP_NEW_LINE);

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -947,11 +947,11 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function files($directory = null, $recursive = false)
     {
         return $this->driver->listContents($directory ?? '', $recursive)
-            ->filter(function (StorageAttributes $attributes) {
+            ->filter(static function (StorageAttributes $attributes) {
                 return $attributes->isFile();
             })
             ->sortByPath()
-            ->map(function (StorageAttributes $attributes) {
+            ->map(static function (StorageAttributes $attributes) {
                 return $attributes->path();
             })
             ->toArray();
@@ -978,10 +978,10 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function directories($directory = null, $recursive = false)
     {
         return $this->driver->listContents($directory ?? '', $recursive)
-            ->filter(function (StorageAttributes $attributes) {
+            ->filter(static function (StorageAttributes $attributes) {
                 return $attributes->isDir();
             })
-            ->map(function (StorageAttributes $attributes) {
+            ->map(static function (StorageAttributes $attributes) {
                 return $attributes->path();
             })
             ->toArray();

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -305,7 +305,7 @@ class FilesystemManager implements FactoryContract
 
         return $this->build(tap(
             is_string($config['disk']) ? $this->getConfig($config['disk']) : $config['disk'],
-            function (&$parent) use ($config) {
+            static function (&$parent) use ($config) {
                 if (empty($parent['prefix'])) {
                     $parent['prefix'] = $config['prefix'];
                 } else {

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -38,7 +38,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerNativeFilesystem()
     {
-        $this->app->singleton('files', function () {
+        $this->app->singleton('files', static function () {
             return new Filesystem;
         });
     }
@@ -68,7 +68,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerManager()
     {
-        $this->app->singleton('filesystem', function ($app) {
+        $this->app->singleton('filesystem', static function ($app) {
             return new FilesystemManager($app);
         });
     }
@@ -93,7 +93,7 @@ class FilesystemServiceProvider extends ServiceProvider
                 continue;
             }
 
-            $this->app->booted(function ($app) use ($disk, $config, &$served) {
+            $this->app->booted(static function ($app) use ($disk, $config, &$served) {
                 $uri = isset($config['url'])
                     ? rtrim(parse_url($config['url'])['path'], '/')
                     : '/storage';
@@ -108,7 +108,7 @@ class FilesystemServiceProvider extends ServiceProvider
 
                 $isProduction = $app->isProduction();
 
-                Route::get($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {
+                Route::get($uri.'/{path}', static function (Request $request, string $path) use ($disk, $config, $isProduction) {
                     return (new ServeFile(
                         $disk,
                         $config,
@@ -116,7 +116,7 @@ class FilesystemServiceProvider extends ServiceProvider
                     ))($request, $path);
                 })->where('path', '.*')->name('storage.'.$disk);
 
-                Route::put($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {
+                Route::put($uri.'/{path}', static function (Request $request, string $path) use ($disk, $config, $isProduction) {
                     return (new ReceiveFile(
                         $disk,
                         $config,

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -38,7 +38,7 @@ class ServeFile
 
             return tap(
                 Storage::disk($this->disk)->serve($request, $path, headers: $headers),
-                function ($response) use ($headers) {
+                static function ($response) use ($headers) {
                     if (! $response->headers->has('Content-Security-Policy')) {
                         $response->headers->replace($headers);
                     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -264,7 +264,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             isset($_SERVER['APP_BASE_PATH']) => $_SERVER['APP_BASE_PATH'],
             default => dirname(array_values(array_filter(
                 array_keys(ClassLoader::getRegisteredLoaders()),
-                fn ($path) => ! str_starts_with($path, 'phar://'),
+                static fn ($path) => ! str_starts_with($path, 'phar://'),
             ))[0]),
         };
     }
@@ -870,7 +870,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function registerConfiguredProviders()
     {
         $providers = (new Collection($this->make('config')->get('app.providers')))
-            ->partition(fn ($provider) => str_starts_with($provider, 'Illuminate\\'));
+            ->partition(static fn ($provider) => str_starts_with($provider, 'Illuminate\\'));
 
         $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);
 
@@ -954,7 +954,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $name = is_string($provider) ? $provider : get_class($provider);
 
-        return Arr::where($this->serviceProviders, fn ($value) => $value instanceof $name);
+        return Arr::where($this->serviceProviders, static fn ($value) => $value instanceof $name);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -103,7 +103,7 @@ class HandleExceptions
 
             $options = static::$app['config']->get('logging.deprecations') ?? [];
 
-            with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
+            with($logger->channel('deprecations'), static function ($log) use ($message, $file, $line, $level, $options) {
                 if ($options['trace'] ?? false) {
                     $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
                 } else {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -58,7 +58,7 @@ class LoadConfiguration
         // Finally, we will set the application's environment based on the configuration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
-        $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
+        $app->detectEnvironment(static fn () => $config->get('app.env', 'production'));
 
         $app->resolveEnvironmentUsing($app->environment(...));
 

--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -21,10 +21,10 @@ class Cloud
     public static function bootstrapperBootstrapping(Application $app, string $bootstrapper): void
     {
         (match ($bootstrapper) {
-            BootProviders::class => function () use ($app) {
+            BootProviders::class => static function () use ($app) {
                 static::bootManagedQueues($app);
             },
-            default => fn () => true,
+            default => static fn () => true,
         })();
     }
 
@@ -34,16 +34,16 @@ class Cloud
     public static function bootstrapperBootstrapped(Application $app, string $bootstrapper): void
     {
         (match ($bootstrapper) {
-            LoadConfiguration::class => function () use ($app) {
+            LoadConfiguration::class => static function () use ($app) {
                 static::configureDisks($app);
                 static::configureUnpooledPostgresConnection($app);
                 static::ensureMigrationsUseUnpooledConnection($app);
                 static::configureManagedQueues($app);
             },
-            HandleExceptions::class => function () use ($app) {
+            HandleExceptions::class => static function () use ($app) {
                 static::configureCloudLogging($app);
             },
-            default => fn () => true,
+            default => static fn () => true,
         })();
     }
 
@@ -121,7 +121,7 @@ class Cloud
             return;
         }
 
-        Migrator::resolveConnectionsUsing(function ($resolver, $connection) use ($app) {
+        Migrator::resolveConnectionsUsing(static function ($resolver, $connection) use ($app) {
             $connection ??= $app['config']->get('database.default');
 
             return $resolver->connection(
@@ -164,15 +164,15 @@ class Cloud
             return;
         }
 
-        $app->singleton(Events::class, fn () => new Events(Cloud::socket()));
-        $app->bind(QueueConnector::class, fn ($app) => new QueueConnector(new SqsConnector, $app));
+        $app->singleton(Events::class, static fn () => new Events(Cloud::socket()));
+        $app->bind(QueueConnector::class, static fn ($app) => new QueueConnector(new SqsConnector, $app));
 
         $app['queue']->addConnector('cloud', $app->factory(QueueConnector::class));
 
         $failer = $app['queue.failer'];
         unset($app['queue.failer']);
 
-        $app->singleton('queue.failer', fn ($app) => new FailedJobProvider(
+        $app->singleton('queue.failer', static fn ($app) => new FailedJobProvider(
             $failer, $app[Events::class], $app['encrypter'],
         ));
     }

--- a/src/Illuminate/Foundation/Cloud/Events.php
+++ b/src/Illuminate/Foundation/Cloud/Events.php
@@ -104,7 +104,7 @@ class Events
      */
     protected function format(array $payloads): string
     {
-        return array_reduce($payloads, function (string $carry, array $line) {
+        return array_reduce($payloads, static function (string $carry, array $line) {
             if ($carry !== '') {
                 $carry .= "\n";
             }
@@ -202,7 +202,7 @@ class Events
 
         $meta = stream_get_meta_data($this->socket);
 
-        return $prefix.array_reduce(array_keys($meta), function ($carry, $key) use ($meta) {
+        return $prefix.array_reduce(array_keys($meta), static function ($carry, $key) use ($meta) {
             try {
                 return $carry.$key.': '.match ($meta[$key]) {
                     true => 'true',

--- a/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
+++ b/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
@@ -114,7 +114,7 @@ class FailedJobProvider implements FailedJobProviderInterface, CountableFailedJo
 
         $response = Http::connectTimeout(10)
             ->timeout(10)
-            ->retry(3, 1000, fn ($exception) => $exception instanceof ConnectionException)
+            ->retry(3, 1000, static fn ($exception) => $exception instanceof ConnectionException)
             ->throw()
             ->get($id);
 

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -293,13 +293,13 @@ class Queue implements QueueContract, ClearableQueue
             $this->agentRequest()
                 ->timeout(10)
                 ->throw()
-                ->retry(3, 100, fn ($exception) => $exception instanceof ConnectionException)
+                ->retry(3, 100, static fn ($exception) => $exception instanceof ConnectionException)
                 ->post('/result', array_filter([
                     'messageId' => $messageId,
                     'receiptHandle' => $receiptHandle,
                     'status' => $status,
                     'delay' => $delay,
-                ], fn ($value) => $value !== null));
+                ], static fn ($value) => $value !== null));
         } catch (ConnectionException $e) {
             throw new AgentUnreachableException(
                 'The Laravel Cloud agent runtime socket is unreachable.', previous: $e
@@ -520,8 +520,8 @@ class Queue implements QueueContract, ClearableQueue
         $suffix = $this->config['connection']['suffix'] ?? null;
 
         return (new Stringable($this->queue->getQueue($queue)))
-            ->when($prefix, fn ($str) => $str->chopStart($prefix.'/'))
-            ->when($suffix, fn ($str) => $str->endsWith('.fifo')
+            ->when($prefix, static fn ($str) => $str->chopStart($prefix.'/'))
+            ->when($suffix, static fn ($str) => $str->endsWith('.fifo')
                 ? $str->chopEnd('.fifo')->chopEnd($suffix)->append('.fifo')
                 : $str->chopEnd($suffix))
             ->toString();

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -67,9 +67,9 @@ class QueueConnector implements ConnectorInterface
      */
     protected function registerErrorHandling(SqsClient $sqs, Queue $queue): void
     {
-        $sqs->getHandlerList()->appendSign(function (callable $handler) use ($queue) {
-            return function (CommandInterface $command, RequestInterface $request) use ($handler, $queue) {
-                return $handler($command, $request)->otherwise(function ($reason) use ($command, $queue) {
+        $sqs->getHandlerList()->appendSign(static function (callable $handler) use ($queue) {
+            return static function (CommandInterface $command, RequestInterface $request) use ($handler, $queue) {
+                return $handler($command, $request)->otherwise(static function ($reason) use ($command, $queue) {
                     if ($reason instanceof AwsException &&
                         $reason->getAwsErrorCode() === 'AWS.SimpleQueueService.NonExistentQueue') {
                         $name = $queue->normalizeQueue($command['QueueUrl'] ?? null);
@@ -90,7 +90,7 @@ class QueueConnector implements ConnectorInterface
      */
     protected function configureQueue(Queue $queue): void
     {
-        $this->app['events']->listen(fn (JobQueued $event) => $event->connectionName === $queue->getConnectionName()
+        $this->app['events']->listen(static fn (JobQueued $event) => $event->connectionName === $queue->getConnectionName()
             ? $queue->finishQueueingJob($event->queue)
             : null);
     }
@@ -106,17 +106,17 @@ class QueueConnector implements ConnectorInterface
         // Exit the worker (and restart the pod) when the agent socket is unreachable...
         $this->app->extend(
             LostConnectionDetector::class,
-            fn ($detector) => new AgentAwareLostConnectionDetector($detector),
+            static fn ($detector) => new AgentAwareLostConnectionDetector($detector),
         );
 
-        $this->app['events']->listen(fn (WorkerStopping $event) => match ($event->reason) {
+        $this->app['events']->listen(static fn (WorkerStopping $event) => match ($event->reason) {
             WorkerStopReason::TimedOut => $queue->finishProcessingJob(default: 'released'),
             default => $queue->finishProcessingJob(),
         });
 
         static::$reservedMemory = str_repeat('x', 32768);
 
-        register_shutdown_function(function () use ($queue) {
+        register_shutdown_function(static function () use ($queue) {
             static::$reservedMemory = null;
 
             if (! is_null($error = error_get_last()) && in_array($error['type'], [E_COMPILE_ERROR, E_CORE_ERROR, E_ERROR, E_PARSE])) {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -221,7 +221,7 @@ class ApplicationBuilder
             }
 
             if (is_string($health)) {
-                Route::get($health, function (Request $request) {
+                Route::get($health, static function (Request $request) {
                     $exception = null;
 
                     try {
@@ -288,7 +288,7 @@ class ApplicationBuilder
     {
         $this->app->afterResolving(HttpKernel::class, function ($kernel) use ($callback) {
             $middleware = (new Middleware)
-                ->redirectGuestsTo(fn () => route('login'));
+                ->redirectGuestsTo(static fn () => route('login'));
 
             if (! is_null($callback)) {
                 $callback($middleware);
@@ -316,7 +316,7 @@ class ApplicationBuilder
             }
         });
 
-        $this->app->afterResolving(ConsoleKernel::class, function () use ($callback) {
+        $this->app->afterResolving(ConsoleKernel::class, static function () use ($callback) {
             if (! is_null($callback)) {
                 $callback(new Middleware);
             }
@@ -338,8 +338,8 @@ class ApplicationBuilder
         }
 
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($commands) {
-            [$commands, $paths] = (new Collection($commands))->partition(fn ($command) => class_exists($command));
-            [$routes, $paths] = $paths->partition(fn ($path) => is_file($path));
+            [$commands, $paths] = (new Collection($commands))->partition(static fn ($command) => class_exists($command));
+            [$routes, $paths] = $paths->partition(static fn ($path) => is_file($path));
 
             $this->app->booted(static function () use ($kernel, $commands, $paths, $routes) {
                 $kernel->addCommands($commands->all());
@@ -360,7 +360,7 @@ class ApplicationBuilder
     protected function withCommandRouting(array $paths)
     {
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
-            $this->app->booted(fn () => $kernel->addCommandRoutePaths($paths));
+            $this->app->booted(static fn () => $kernel->addCommandRoutePaths($paths));
         });
 
         return $this;
@@ -375,7 +375,7 @@ class ApplicationBuilder
     public function withSchedule(callable $callback)
     {
         Artisan::starting(function () use ($callback) {
-            $this->app->afterResolving(Schedule::class, fn ($schedule) => $callback($schedule));
+            $this->app->afterResolving(Schedule::class, static fn ($schedule) => $callback($schedule));
 
             if ($this->app->resolved(Schedule::class)) {
                 $callback($this->app->make(Schedule::class));
@@ -401,7 +401,7 @@ class ApplicationBuilder
         if ($using !== null) {
             $this->app->afterResolving(
                 \Illuminate\Foundation\Exceptions\Handler::class,
-                fn ($handler) => $using(new Exceptions($handler)),
+                static fn ($handler) => $using(new Exceptions($handler)),
             );
         }
 
@@ -416,7 +416,7 @@ class ApplicationBuilder
      */
     public function withBindings(array $bindings)
     {
-        return $this->registered(function ($app) use ($bindings) {
+        return $this->registered(static function ($app) use ($bindings) {
             foreach ($bindings as $abstract => $concrete) {
                 $app->bind($abstract, $concrete);
             }
@@ -431,7 +431,7 @@ class ApplicationBuilder
      */
     public function withSingletons(array $singletons)
     {
-        return $this->registered(function ($app) use ($singletons) {
+        return $this->registered(static function ($app) use ($singletons) {
             foreach ($singletons as $abstract => $concrete) {
                 if (is_string($abstract)) {
                     $app->singleton($abstract, $concrete);
@@ -450,7 +450,7 @@ class ApplicationBuilder
      */
     public function withScopedSingletons(array $scopedSingletons)
     {
-        return $this->registered(function ($app) use ($scopedSingletons) {
+        return $this->registered(static function ($app) use ($scopedSingletons) {
             foreach ($scopedSingletons as $abstract => $concrete) {
                 if (is_string($abstract)) {
                     $app->scoped($abstract, $concrete);

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -539,7 +539,7 @@ class Middleware
     public function redirectGuestsTo(callable|string|null $redirect)
     {
         if (is_null($redirect)) {
-            $redirect = fn () => null;
+            $redirect = static fn () => null;
         }
 
         return $this->redirectTo(guests: $redirect);
@@ -565,8 +565,8 @@ class Middleware
      */
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
-        $guests = is_string($guests) ? fn () => $guests : $guests;
-        $users = is_string($users) ? fn () => $users : $users;
+        $guests = is_string($guests) ? static fn () => $guests : $guests;
+        $users = is_string($users) ? static fn () => $users : $users;
 
         if ($guests) {
             Authenticate::redirectUsing($guests);
@@ -648,7 +648,7 @@ class Middleware
      */
     public function convertEmptyStringsToNull(array $except = [])
     {
-        (new Collection($except))->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
+        (new Collection($except))->each(static fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
 
         return $this;
     }
@@ -661,9 +661,9 @@ class Middleware
      */
     public function trimStrings(array $except = [])
     {
-        [$skipWhen, $except] = (new Collection($except))->partition(fn ($value) => $value instanceof Closure);
+        [$skipWhen, $except] = (new Collection($except))->partition(static fn ($value) => $value instanceof Closure);
 
-        $skipWhen->each(fn (Closure $callback) => TrimStrings::skipWhen($callback));
+        $skipWhen->each(static fn (Closure $callback) => TrimStrings::skipWhen($callback));
 
         TrimStrings::except($except->all());
 

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -82,12 +82,12 @@ class AboutCommand extends Command
                     }
 
                     return (new Collection($this->laravel->call($value)))
-                        ->map(fn ($value, $key) => [$key, $value])
+                        ->map(static fn ($value, $key) => [$key, $value])
                         ->values()
                         ->all();
                 })->flatten(1)
             )
-            ->sortBy(function ($data, $key) {
+            ->sortBy(static function ($data, $key) {
                 $index = array_search($key, ['Environment', 'Cache', 'Drivers']);
 
                 return $index === false ? 99 : $index;
@@ -126,7 +126,7 @@ class AboutCommand extends Command
 
             $this->components->twoColumnDetail('  <fg=green;options=bold>'.$section.'</>');
 
-            $data->pipe(fn ($data) => $section !== 'Environment' ? $data->sort() : $data)->each(function ($detail) {
+            $data->pipe(static fn ($data) => $section !== 'Environment' ? $data->sort() : $data)->each(function ($detail) {
                 [$label, $value] = $detail;
 
                 $this->components->twoColumnDetail($label, value($value, false));
@@ -162,9 +162,9 @@ class AboutCommand extends Command
     {
         self::$data = [];
 
-        $formatEnabledStatus = fn ($value) => $value ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF';
-        $formatCachedStatus = fn ($value) => $value ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>';
-        $formatStorageLinkedStatus = fn ($value) => $value ? '<fg=green;options=bold>LINKED</>' : '<fg=yellow;options=bold>NOT LINKED</>';
+        $formatEnabledStatus = static fn ($value) => $value ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF';
+        $formatCachedStatus = static fn ($value) => $value ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>';
+        $formatStorageLinkedStatus = static fn ($value) => $value ? '<fg=green;options=bold>LINKED</>' : '<fg=yellow;options=bold>NOT LINKED</>';
 
         static::addToSection('Environment', fn () => [
             'Application Name' => config('app.name'),
@@ -186,9 +186,9 @@ class AboutCommand extends Command
             'Views' => static::format($this->hasPhpFiles(config('view.compiled')), console: $formatCachedStatus),
         ]);
 
-        static::addToSection('Drivers', fn () => array_filter([
+        static::addToSection('Drivers', static fn () => array_filter([
             'Broadcasting' => config('broadcasting.default'),
-            'Cache' => function ($json) {
+            'Cache' => static function ($json) {
                 $cacheStore = config('cache.default');
 
                 if (config('cache.stores.'.$cacheStore.'.driver') === 'failover') {
@@ -196,15 +196,15 @@ class AboutCommand extends Command
 
                     return value(static::format(
                         value: $cacheStore,
-                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
-                        json: fn () => $secondary->all(),
+                        console: static fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: static fn () => $secondary->all(),
                     ), $json);
                 }
 
                 return $cacheStore;
             },
             'Database' => config('database.default'),
-            'Logs' => function ($json) {
+            'Logs' => static function ($json) {
                 $logChannel = config('logging.default');
 
                 if (config('logging.channels.'.$logChannel.'.driver') === 'stack') {
@@ -212,8 +212,8 @@ class AboutCommand extends Command
 
                     return value(static::format(
                         value: $logChannel,
-                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
-                        json: fn () => $secondary->all(),
+                        console: static fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: static fn () => $secondary->all(),
                     ), $json);
                 } else {
                     $logs = $logChannel;
@@ -221,7 +221,7 @@ class AboutCommand extends Command
 
                 return $logs;
             },
-            'Mail' => function ($json) {
+            'Mail' => static function ($json) {
                 $mailMailer = config('mail.default');
 
                 if (in_array(config('mail.mailers.'.$mailMailer.'.transport'), ['failover', 'roundrobin'])) {
@@ -229,15 +229,15 @@ class AboutCommand extends Command
 
                     return value(static::format(
                         value: $mailMailer,
-                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
-                        json: fn () => $secondary->all(),
+                        console: static fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: static fn () => $secondary->all(),
                     ), $json);
                 }
 
                 return $mailMailer;
             },
             'Octane' => config('octane.server'),
-            'Queue' => function ($json) {
+            'Queue' => static function ($json) {
                 $queueConnection = config('queue.default');
 
                 if (config('queue.connections.'.$queueConnection.'.driver') === 'failover') {
@@ -245,8 +245,8 @@ class AboutCommand extends Command
 
                     return value(static::format(
                         value: $queueConnection,
-                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
-                        json: fn () => $secondary->all(),
+                        console: static fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: static fn () => $secondary->all(),
                     ), $json);
                 }
 
@@ -272,7 +272,7 @@ class AboutCommand extends Command
     protected function determineStoragePathLinkStatus(callable $formatStorageLinkedStatus): array
     {
         return (new Collection(config('filesystems.links', [])))
-            ->mapWithKeys(function ($target, $link) use ($formatStorageLinkedStatus) {
+            ->mapWithKeys(static function ($target, $link) use ($formatStorageLinkedStatus) {
                 $path = Str::replace(public_path(), '', $link);
 
                 return [public_path($path) => static::format(file_exists($link), console: $formatStorageLinkedStatus)];
@@ -301,7 +301,7 @@ class AboutCommand extends Command
      */
     public static function add(string $section, $data, ?string $value = null)
     {
-        static::$customDataResolvers[] = fn () => static::addToSection($section, $data, $value);
+        static::$customDataResolvers[] = static fn () => static::addToSection($section, $data, $value);
     }
 
     /**
@@ -348,7 +348,7 @@ class AboutCommand extends Command
      */
     public static function format($value, ?Closure $console = null, ?Closure $json = null)
     {
-        return function ($isJson) use ($value, $console, $json) {
+        return static function ($isJson) use ($value, $console, $json) {
             if ($isJson === true && $json instanceof Closure) {
                 return value($json, $value);
             } elseif ($isJson === false && $console instanceof Closure) {

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -126,7 +126,7 @@ class ApiInstallCommand extends Command
             'laravel/sanctum:^4.0',
         ]);
 
-        $migrationPublished = (new Collection(scandir($this->laravel->databasePath('migrations'))))->contains(function ($migration) {
+        $migrationPublished = (new Collection(scandir($this->laravel->databasePath('migrations'))))->contains(static function ($migration) {
             return preg_match('/\d{4}_\d{2}_\d{2}_\d{6}_create_personal_access_tokens_table.php/', $migration);
         });
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -320,7 +320,7 @@ class BroadcastingInstallCommand extends Command
             ];
         }
 
-        $filePath = array_filter($filePaths, function ($path) {
+        $filePath = array_filter($filePaths, static function ($path) {
             return file_exists($path);
         })[0] ?? null;
 

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -74,7 +74,7 @@ class ChannelListCommand extends Command
      */
     protected function forCli($channels)
     {
-        $maxChannelName = $channels->keys()->max(function ($channelName) {
+        $maxChannelName = $channels->keys()->max(static function ($channelName) {
             return mb_strlen($channelName);
         });
 
@@ -82,7 +82,7 @@ class ChannelListCommand extends Command
 
         $channelCount = $this->determineChannelCountOutput($channels, $terminalWidth);
 
-        return $channels->map(function ($channel, $channelName) use ($maxChannelName, $terminalWidth) {
+        return $channels->map(static function ($channel, $channelName) use ($maxChannelName, $terminalWidth) {
             $resolver = $channel instanceof Closure ? 'Closure' : $channel;
 
             $spaces = str_repeat(' ', max($maxChannelName + 6 - mb_strlen($channelName), 0));

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -73,7 +73,7 @@ class CliDumper extends BaseCliDumper
 
         $dumper = new static(new ConsoleOutput(), $basePath, $compiledViewPath);
 
-        VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
+        VarDumper::setHandler(static fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -137,7 +137,7 @@ class ComponentMakeCommand extends GeneratorCommand
         $path[] = $name;
 
         return (new Collection($path))
-            ->map(fn ($segment) => Str::kebab($segment))
+            ->map(static fn ($segment) => Str::kebab($segment))
             ->implode('.');
     }
 

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -48,7 +48,7 @@ class ConfigPublishCommand extends Command
 
         $name = (string) (is_null($this->argument('name')) ? select(
             label: 'Which configuration file would you like to publish?',
-            options: (new Collection($config))->map(fn (string $path) => basename($path, '.php')),
+            options: (new Collection($config))->map(static fn (string $path) => basename($path, '.php')),
         ) : $this->argument('name'));
 
         if (! is_null($name) && ! isset($config[$name])) {

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -93,7 +93,7 @@ class ConfigShowCommand extends Command
     protected function formatKey($key)
     {
         return preg_replace_callback(
-            '/(.*)\.(.*)$/', fn ($matches) => sprintf(
+            '/(.*)\.(.*)$/', static fn ($matches) => sprintf(
                 '<fg=gray>%s ⇁</> %s',
                 str_replace('.', ' ⇁ ', $matches[1]),
                 $matches[2]

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -100,7 +100,7 @@ class DevCommand extends Command
     protected function buildMultiplexCommand(array $devCommands): string
     {
         $args = collect($devCommands)
-            ->map(fn ($devCommand) => implode(',', [
+            ->map(static fn ($devCommand) => implode(',', [
                 $devCommand['name'].'@'.$devCommand['color'],
                 $devCommand['command'],
             ]));
@@ -121,7 +121,7 @@ class DevCommand extends Command
         ])
             ->filter()
             ->keys()
-            ->map(fn ($flag) => "--$flag");
+            ->map(static fn ($flag) => "--$flag");
 
         if ($bufferSize = $this->option('buffer-size') ?? DevCommands::getBufferSize()) {
             $flags->push('--buffer-size='.escapeshellarg($bufferSize));

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -236,16 +236,16 @@ class DocsCommand extends Command
         $choice = suggest(
             label: 'Which page would you like to open?',
             options: fn ($value) => $this->pages()
-                ->mapWithKeys(fn ($option) => [
+                ->mapWithKeys(static fn ($option) => [
                     Str::lower($option['title']) => $option['title'],
                 ])
-                ->filter(fn ($title) => str_contains(Str::lower($title), Str::lower($value)))
+                ->filter(static fn ($title) => str_contains(Str::lower($title), Str::lower($value)))
                 ->all(),
             placeholder: 'E.g. Collections'
         );
 
         return $this->pages()->filter(
-            fn ($page) => $page['title'] === $choice || Str::lower($page['title']) === $choice
+            static fn ($page) => $page['title'] === $choice || Str::lower($page['title']) === $choice
         )->keys()->first() ?: $this->guessPage($choice);
     }
 
@@ -257,14 +257,14 @@ class DocsCommand extends Command
     protected function guessPage($search)
     {
         return $this->pages()
-            ->filter(fn ($page) => str_starts_with(
+            ->filter(static fn ($page) => str_starts_with(
                 Str::slug($page['title'], ' '),
                 Str::slug($search, ' ')
-            ))->keys()->first() ?? $this->pages()->map(fn ($page) => similar_text(
+            ))->keys()->first() ?? $this->pages()->map(static fn ($page) => similar_text(
                 Str::slug($page['title'], ' '),
                 Str::slug($search, ' '),
             ))
-            ->filter(fn ($score) => $score >= min(3, Str::length($search)))
+            ->filter(static fn ($score) => $score >= min(3, Str::length($search)))
             ->sortDesc()
             ->keys()
             ->sortByDesc(fn ($slug) => Str::contains(
@@ -388,7 +388,7 @@ class DocsCommand extends Command
         $binary = (new Collection(match ($this->systemOsFamily) {
             'Darwin' => ['open'],
             'Linux' => ['xdg-open', 'wslview'],
-        }))->first(fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
+        }))->first(static fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
 
         if ($binary === null) {
             $this->components->warn('Unable to open the URL on your system. You will need to open it yourself or create a custom opener for your system.');

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -73,7 +73,7 @@ class EventListCommand extends Command
         $data = $events->map(function ($listeners, $event) {
             return [
                 'event' => strip_tags($this->appendEventInterfaces($event)),
-                'listeners' => (new Collection($listeners))->map(fn ($listener) => strip_tags($listener))->values()->all(),
+                'listeners' => (new Collection($listeners))->map(static fn ($listener) => strip_tags($listener))->values()->all(),
             ];
         })->values();
 
@@ -212,7 +212,7 @@ class EventListCommand extends Command
         }
 
         return $events->filter(
-            fn ($listeners, $event) => str_contains($event, $eventName)
+            static fn ($listeners, $event) => str_contains($event, $eventName)
         );
     }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -310,7 +310,7 @@ class Kernel implements KernelContract
      */
     protected function scheduleCache()
     {
-        return $this->app['config']->get('cache.schedule_store', Env::get('SCHEDULE_CACHE_DRIVER', function () {
+        return $this->app['config']->get('cache.schedule_store', Env::get('SCHEDULE_CACHE_DRIVER', static function () {
             return Env::get('SCHEDULE_CACHE_STORE');
         }));
     }
@@ -336,7 +336,7 @@ class Kernel implements KernelContract
     {
         $command = new ClosureCommand($signature, $callback);
 
-        Artisan::starting(function ($artisan) use ($command) {
+        Artisan::starting(static function ($artisan) use ($command) {
             $artisan->add($command);
         });
 
@@ -353,7 +353,7 @@ class Kernel implements KernelContract
     {
         $paths = array_unique(Arr::wrap($paths));
 
-        $paths = array_filter($paths, function ($path) {
+        $paths = array_filter($paths, static function ($path) {
             return is_dir($path);
         });
 
@@ -374,7 +374,7 @@ class Kernel implements KernelContract
 
             $possibleCommands[$file] = $commandClassName;
 
-            $command = rescue(fn () => new ReflectionClass($commandClassName), null, false);
+            $command = rescue(static fn () => new ReflectionClass($commandClassName), null, false);
 
             return $command instanceof ReflectionClass
                 && $command->isSubClassOf(Command::class)
@@ -382,7 +382,7 @@ class Kernel implements KernelContract
         };
 
         foreach ($this->findCommands($paths)->filter($filterCommands) as $file) {
-            Artisan::starting(function ($artisan) use ($file, $possibleCommands) {
+            Artisan::starting(static function ($artisan) use ($file, $possibleCommands) {
                 $artisan->resolve($possibleCommands[$file]);
             });
         }
@@ -534,7 +534,7 @@ class Kernel implements KernelContract
     {
         $this->app->bootstrapWith(
             (new Collection($this->bootstrappers()))
-                ->reject(fn ($bootstrapper) => $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class)
+                ->reject(static fn ($bootstrapper) => $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class)
                 ->all()
         );
     }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -169,7 +169,7 @@ class MailMakeCommand extends GeneratorCommand
             $name = str_replace('\\', '/', $this->argument('name'));
 
             $view = 'mail.'.(new Stringable($name))->explode('/')
-                ->map(fn ($part) => Str::kebab($part))
+                ->map(static fn ($part) => Str::kebab($part))
                 ->implode('.');
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -315,6 +315,6 @@ class ModelMakeCommand extends GeneratorCommand
             'migration' => 'Migration',
             'policy' => 'Policy',
             'resource' => 'Resource Controller',
-        ])))->each(fn ($option) => $input->setOption($option, true));
+        ])))->each(static fn ($option) => $input->setOption($option, true));
     }
 }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -154,7 +154,7 @@ class NotificationMakeCommand extends GeneratorCommand
 
         if ($wantsMarkdownView) {
             $defaultMarkdownView = (new Stringable($this->argument('name')))->replace('\\', '/')->explode('/')
-                ->map(fn ($path) => Str::kebab($path))
+                ->map(static fn ($path) => Str::kebab($path))
                 ->prepend('mail')
                 ->implode('.');
 

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -35,13 +35,13 @@ class OptimizeClearCommand extends Command
         $this->components->info('Clearing cached bootstrap files.');
 
         $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
-            ->map(fn ($except) => trim($except))
+            ->map(static fn ($except) => trim($except))
             ->filter()
             ->unique()
             ->flip();
 
         $tasks = Collection::wrap($this->getOptimizeClearTasks())
-            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->reject(static fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
         foreach ($tasks as $description => $command) {

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -35,13 +35,13 @@ class OptimizeCommand extends Command
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
         $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
-            ->map(fn ($except) => trim($except))
+            ->map(static fn ($except) => trim($except))
             ->filter()
             ->unique()
             ->flip();
 
         $tasks = Collection::wrap($this->getOptimizeTasks())
-            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->reject(static fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
         foreach ($tasks as $description => $command) {

--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -35,13 +35,13 @@ class ReloadCommand extends Command
         $this->components->info('Reloading services.');
 
         $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
-            ->map(fn ($except) => trim($except))
+            ->map(static fn ($except) => trim($except))
             ->filter()
             ->unique()
             ->flip();
 
         $tasks = Collection::wrap($this->getReloadTasks())
-            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->reject(static fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
         foreach ($tasks as $description => $command) {

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -77,7 +77,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplicationRoutes()
     {
-        return tap($this->getFreshApplication()['router']->getRoutes(), function ($routes) {
+        return tap($this->getFreshApplication()['router']->getRoutes(), static function ($routes) {
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
         });
@@ -90,7 +90,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplication()
     {
-        return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
+        return tap(require $this->laravel->bootstrapPath('app.php'), static function ($app) {
             $app->make(ConsoleKernelContract::class)->bootstrap();
         });
     }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -238,7 +238,7 @@ class RouteListCommand extends Command
     protected function getMiddleware($route)
     {
         return (new Collection($this->router->gatherRouteMiddleware($route)))
-            ->map(fn ($middleware) => $middleware instanceof Closure ? 'Closure' : $middleware)
+            ->map(static fn ($middleware) => $middleware instanceof Closure ? 'Closure' : $middleware)
             ->implode("\n");
     }
 
@@ -385,7 +385,7 @@ class RouteListCommand extends Command
     protected function asJson($routes)
     {
         return $routes
-            ->map(function ($route) {
+            ->map(static function ($route) {
                 $route['middleware'] = empty($route['middleware']) ? [] : explode("\n", $route['middleware']);
 
                 return $route;
@@ -426,8 +426,8 @@ class RouteListCommand extends Command
             ] = $route;
 
             $middleware = (new Stringable($middleware))->explode("\n")->filter()->whenNotEmpty(
-                fn ($collection) => $collection->map(
-                    fn ($middleware) => sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware)
+                static fn ($collection) => $collection->map(
+                    static fn ($middleware) => sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware)
                 )
             )->implode("\n");
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -200,7 +200,7 @@ class ServeCommand extends Command
             return $this->shouldPassThroughEnvironmentVariable($key) ? [$key => $value] : [$key => false];
         })->merge(['PHP_CLI_SERVER_WORKERS' => $this->phpServerWorkers])->all());
 
-        $this->trap(fn () => [SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], function ($signal) use ($process) {
+        $this->trap(static fn () => [SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], static function ($signal) use ($process) {
             if ($process->isRunning()) {
                 $process->stop(10, $signal);
             }
@@ -336,7 +336,7 @@ class ServeCommand extends Command
         $this->outputBuffer = (string) $lines->pop();
 
         $lines
-            ->map(fn ($line) => trim($line))
+            ->map(static fn ($line) => trim($line))
             ->filter()
             ->each(function ($line) {
                 if ((new Stringable($line))->contains('Development Server (http')) {

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -141,9 +141,9 @@ class VendorPublishCommand extends Command
             )
             : search(
                 label: "Which provider or tag's files would you like to publish?",
-                options: fn ($search) => array_values(array_filter(
+                options: static fn ($search) => array_values(array_filter(
                     $choices,
-                    fn ($choice) => str_contains(strtolower($choice), strtolower($search))
+                    static fn ($choice) => str_contains(strtolower($choice), strtolower($search))
                 )),
                 placeholder: 'Search...',
                 scroll: 15,

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -78,9 +78,9 @@ class ViewCacheCommand extends Command
     protected function bladeFilesIn(array $paths)
     {
         $extensions = (new Collection($this->laravel['view']->getExtensions()))
-            ->filter(fn ($value) => $value === 'blade')
+            ->filter(static fn ($value) => $value === 'blade')
             ->keys()
-            ->map(fn ($extension) => "*.{$extension}")
+            ->map(static fn ($extension) => "*.{$extension}")
             ->all();
 
         return new Collection(
@@ -105,7 +105,7 @@ class ViewCacheCommand extends Command
             (new Collection($finder->getHints()))->flatten()
         )->unique();
 
-        return $paths->reject(fn ($path) => $paths->contains(function ($existing) use ($path) {
+        return $paths->reject(static fn ($path) => $paths->contains(static function ($existing) use ($path) {
             return $existing !== $path && str_starts_with(realpath($path) ?: $path, realpath($existing) ?: $existing);
         }))->values();
     }

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -190,12 +190,12 @@ class ViewMakeCommand extends GeneratorCommand
             (new Stringable($name))
                 ->replace('/', ' ')
                 ->explode(' ')
-                ->map(fn ($part) => (new Stringable($part))->ucfirst())
+                ->map(static fn ($part) => (new Stringable($part))->ucfirst())
                 ->implode('\\')
         ))
             ->replace(['-', '_'], ' ')
             ->explode(' ')
-            ->map(fn ($part) => (new Stringable($part))->ucfirst())
+            ->map(static fn ($part) => (new Stringable($part))->ucfirst())
             ->implode('');
 
         return 'Tests\\Feature\\View\\'.$namespacedName;

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -347,7 +347,7 @@ class DevCommands
     protected static function getColor(array $commands): string
     {
         $available = array_values(array_diff(
-            $colors = array_map(fn ($color) => $color->value, DevCommandColor::cases()),
+            $colors = array_map(static fn ($color) => $color->value, DevCommandColor::cases()),
             $existing = array_values(array_filter(array_column($commands, 'color')))
         ));
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -277,7 +277,7 @@ class Handler implements ExceptionHandlerContract
     public function map($from, $to = null)
     {
         if (is_string($to)) {
-            $to = fn ($exception) => new $to('', 0, $exception);
+            $to = static fn ($exception) => new $to('', 0, $exception);
         }
 
         if (is_callable($from) && is_null($to)) {
@@ -378,11 +378,11 @@ class Handler implements ExceptionHandlerContract
      */
     public function shouldStopRetries(Throwable $e)
     {
-        if (! is_null(Arr::first($this->dontRetry, fn ($type) => $e instanceof $type))) {
+        if (! is_null(Arr::first($this->dontRetry, static fn ($type) => $e instanceof $type))) {
             return true;
         }
 
-        return array_any($this->dontRetryCallbacks, fn ($dontRetryCallback) => $dontRetryCallback($e) === true);
+        return array_any($this->dontRetryCallbacks, static fn ($dontRetryCallback) => $dontRetryCallback($e) === true);
     }
 
     /**
@@ -516,7 +516,7 @@ class Handler implements ExceptionHandlerContract
 
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        if (! is_null(Arr::first($dontReport, fn ($type) => $e instanceof $type))) {
+        if (! is_null(Arr::first($dontReport, static fn ($type) => $e instanceof $type))) {
             return true;
         }
 
@@ -538,7 +538,7 @@ class Handler implements ExceptionHandlerContract
             return ! $this->container->make(RateLimiter::class)->attempt(
                 with($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class, fn ($key) => $this->hashThrottleKeys ? hash('xxh128', $key) : $key),
                 $throttle->maxAttempts,
-                fn () => true,
+                static fn () => true,
                 $throttle->decaySeconds
             );
         }), rescue: false, report: false);
@@ -1127,7 +1127,7 @@ class Handler implements ExceptionHandlerContract
             'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
-            'trace' => (new Collection($e->getTrace()))->map(fn ($trace) => Arr::except($trace, ['args']))->all(),
+            'trace' => (new Collection($e->getTrace()))->map(static fn ($trace) => Arr::except($trace, ['args']))->all(),
         ] : [
             'message' => $this->isHttpException($e) ? $e->getMessage() : 'Server Error',
         ];
@@ -1196,7 +1196,7 @@ class Handler implements ExceptionHandlerContract
     protected function mapLogLevel(Throwable $e)
     {
         return Arr::first(
-            $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
+            $this->levels, static fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
     }
 

--- a/src/Illuminate/Foundation/Exceptions/RegisterErrorViewPaths.php
+++ b/src/Illuminate/Foundation/Exceptions/RegisterErrorViewPaths.php
@@ -15,7 +15,7 @@ class RegisterErrorViewPaths
     public function __invoke()
     {
         View::replaceNamespace('errors', (new Collection(config('view.paths')))
-            ->map(fn ($path) => "{$path}/errors")
+            ->map(static fn ($path) => "{$path}/errors")
             ->push(__DIR__.'/views')
             ->all()
         );

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -126,7 +126,7 @@ class Exception
     public function frames()
     {
         return once(function () {
-            $classMap = array_map(function ($path) {
+            $classMap = array_map(static function ($path) {
                 return (string) realpath($path);
             }, array_values(ClassLoader::getRegisteredLoaders())[0]->getClassMap());
 
@@ -140,7 +140,7 @@ class Exception
             }
 
             $trace = array_values(array_filter(
-                $trace, fn ($trace) => isset($trace['file']),
+                $trace, static fn ($trace) => isset($trace['file']),
             ));
 
             if (($trace[1]['class'] ?? '') === HandleExceptions::class) {
@@ -212,7 +212,7 @@ class Exception
      */
     public function requestHeaders()
     {
-        return array_map(function (array $header) {
+        return array_map(static function (array $header) {
             return implode(', ', $header);
         }, $this->request()->headers->all());
     }
@@ -245,7 +245,7 @@ class Exception
         return $route ? array_filter([
             'controller' => $route->getActionName(),
             'route name' => $route->getName() ?: null,
-            'middleware' => implode(', ', array_map(function ($middleware) {
+            'middleware' => implode(', ', array_map(static function ($middleware) {
                 return $middleware instanceof Closure ? 'Closure' : $middleware;
             }, $route->gatherMiddleware())),
         ]) : [];
@@ -261,7 +261,7 @@ class Exception
         $parameters = $this->request()->route()?->parameters();
 
         return $parameters ? json_encode(array_map(
-            fn ($value) => $value instanceof Model ? $value->withoutRelations() : $value,
+            static fn ($value) => $value instanceof Model ? $value->withoutRelations() : $value,
             $parameters
         ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) : null;
     }
@@ -273,7 +273,7 @@ class Exception
      */
     public function applicationQueries()
     {
-        return array_map(function (array $query) {
+        return array_map(static function (array $query) {
             $sql = $query['sql'];
 
             foreach ($query['bindings'] as $binding) {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -174,7 +174,7 @@ class Frame
             return [];
         }
 
-        return array_map(function ($argument) {
+        return array_map(static function ($argument) {
             [$key, $value] = $argument;
 
             return match ($key) {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -150,7 +150,7 @@ class BladeMapper
      */
     protected function filterViewData(array $data)
     {
-        return array_filter($data, function ($value, $key) {
+        return array_filter($data, static function ($value, $key) {
             if ($key === 'app') {
                 return ! $value instanceof Application;
             }

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -75,7 +75,7 @@ class HtmlDumper extends BaseHtmlDumper
 
         $dumper = new static($basePath, $compiledViewPath);
 
-        VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
+        VarDumper::setHandler(static fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -65,8 +65,8 @@ class HandlePrecognitiveRequests
     {
         $request->attributes->set('precognitive', true);
 
-        $this->container->bind(CallableDispatcherContract::class, fn ($app) => new PrecognitionCallableDispatcher($app));
-        $this->container->bind(ControllerDispatcherContract::class, fn ($app) => new PrecognitionControllerDispatcher($app));
+        $this->container->bind(CallableDispatcherContract::class, static fn ($app) => new PrecognitionCallableDispatcher($app));
+        $this->container->bind(ControllerDispatcherContract::class, static fn ($app) => new PrecognitionControllerDispatcher($app));
     }
 
     /**
@@ -78,7 +78,7 @@ class HandlePrecognitiveRequests
      */
     protected function appendVaryHeader($request, $response)
     {
-        return tap($response, fn () => $response->headers->set('Vary', implode(', ', array_filter([
+        return tap($response, static fn () => $response->headers->set('Vary', implode(', ', array_filter([
             $response->headers->get('Vary'),
             'Precognition',
         ]))));

--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -33,6 +33,6 @@ class InvokeDeferredCallbacks
     {
         Container::getInstance()
             ->make(DeferredCallbackCollection::class)
-            ->invokeWhen(fn ($callback) => $response->getStatusCode() < 400 || $callback->always);
+            ->invokeWhen(static fn ($callback) => $response->getStatusCode() < 400 || $callback->always);
     }
 }

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -88,7 +88,7 @@ class PackageManifest
     public function config($key)
     {
         return (new Collection($this->getManifest()))
-            ->flatMap(fn ($configuration) => (array) ($configuration[$key] ?? []))
+            ->flatMap(static fn ($configuration) => (array) ($configuration[$key] ?? []))
             ->filter()
             ->all();
     }
@@ -131,9 +131,9 @@ class PackageManifest
 
         $this->write((new Collection($packages))->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
-        })->each(function ($configuration) use (&$ignore) {
+        })->each(static function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
-        })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
+        })->reject(static function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore) || empty($configuration);
         })->all());
     }

--- a/src/Illuminate/Foundation/Precognition.php
+++ b/src/Illuminate/Foundation/Precognition.php
@@ -12,7 +12,7 @@ class Precognition
      */
     public static function afterValidationHook($request)
     {
-        return function ($validator) use ($request) {
+        return static function ($validator) use ($request) {
             if ($validator->messages()->isEmpty() && $request->headers->has('Precognition-Validate-Only')) {
                 abort(204, headers: ['Precognition-Success' => 'true']);
             }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -301,7 +301,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerAboutCommand()
     {
-        $this->app->singleton(AboutCommand::class, function ($app) {
+        $this->app->singleton(AboutCommand::class, static function ($app) {
             return new AboutCommand($app['composer']);
         });
     }
@@ -313,7 +313,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheClearCommand()
     {
-        $this->app->singleton(CacheClearCommand::class, function ($app) {
+        $this->app->singleton(CacheClearCommand::class, static function ($app) {
             return new CacheClearCommand($app['cache'], $app['files']);
         });
     }
@@ -325,7 +325,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheForgetCommand()
     {
-        $this->app->singleton(CacheForgetCommand::class, function ($app) {
+        $this->app->singleton(CacheForgetCommand::class, static function ($app) {
             return new CacheForgetCommand($app['cache']);
         });
     }
@@ -337,7 +337,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheTableCommand()
     {
-        $this->app->singleton(CacheTableCommand::class, function ($app) {
+        $this->app->singleton(CacheTableCommand::class, static function ($app) {
             return new CacheTableCommand($app['files']);
         });
     }
@@ -349,7 +349,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCastMakeCommand()
     {
-        $this->app->singleton(CastMakeCommand::class, function ($app) {
+        $this->app->singleton(CastMakeCommand::class, static function ($app) {
             return new CastMakeCommand($app['files']);
         });
     }
@@ -361,7 +361,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerChannelMakeCommand()
     {
-        $this->app->singleton(ChannelMakeCommand::class, function ($app) {
+        $this->app->singleton(ChannelMakeCommand::class, static function ($app) {
             return new ChannelMakeCommand($app['files']);
         });
     }
@@ -373,7 +373,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClassMakeCommand()
     {
-        $this->app->singleton(ClassMakeCommand::class, function ($app) {
+        $this->app->singleton(ClassMakeCommand::class, static function ($app) {
             return new ClassMakeCommand($app['files']);
         });
     }
@@ -385,7 +385,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerComponentMakeCommand()
     {
-        $this->app->singleton(ComponentMakeCommand::class, function ($app) {
+        $this->app->singleton(ComponentMakeCommand::class, static function ($app) {
             return new ComponentMakeCommand($app['files']);
         });
     }
@@ -397,7 +397,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigCacheCommand()
     {
-        $this->app->singleton(ConfigCacheCommand::class, function ($app) {
+        $this->app->singleton(ConfigCacheCommand::class, static function ($app) {
             return new ConfigCacheCommand($app['files']);
         });
     }
@@ -409,7 +409,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigClearCommand()
     {
-        $this->app->singleton(ConfigClearCommand::class, function ($app) {
+        $this->app->singleton(ConfigClearCommand::class, static function ($app) {
             return new ConfigClearCommand($app['files']);
         });
     }
@@ -421,7 +421,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigMakeCommand()
     {
-        $this->app->singleton(ConfigMakeCommand::class, function ($app) {
+        $this->app->singleton(ConfigMakeCommand::class, static function ($app) {
             return new ConfigMakeCommand($app['files']);
         });
     }
@@ -433,7 +433,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigPublishCommand()
     {
-        $this->app->singleton(ConfigPublishCommand::class, function () {
+        $this->app->singleton(ConfigPublishCommand::class, static function () {
             return new ConfigPublishCommand;
         });
     }
@@ -445,7 +445,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConsoleMakeCommand()
     {
-        $this->app->singleton(ConsoleMakeCommand::class, function ($app) {
+        $this->app->singleton(ConsoleMakeCommand::class, static function ($app) {
             return new ConsoleMakeCommand($app['files']);
         });
     }
@@ -457,7 +457,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerControllerMakeCommand()
     {
-        $this->app->singleton(ControllerMakeCommand::class, function ($app) {
+        $this->app->singleton(ControllerMakeCommand::class, static function ($app) {
             return new ControllerMakeCommand($app['files']);
         });
     }
@@ -469,7 +469,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEnumMakeCommand()
     {
-        $this->app->singleton(EnumMakeCommand::class, function ($app) {
+        $this->app->singleton(EnumMakeCommand::class, static function ($app) {
             return new EnumMakeCommand($app['files']);
         });
     }
@@ -481,7 +481,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventMakeCommand()
     {
-        $this->app->singleton(EventMakeCommand::class, function ($app) {
+        $this->app->singleton(EventMakeCommand::class, static function ($app) {
             return new EventMakeCommand($app['files']);
         });
     }
@@ -493,7 +493,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerExceptionMakeCommand()
     {
-        $this->app->singleton(ExceptionMakeCommand::class, function ($app) {
+        $this->app->singleton(ExceptionMakeCommand::class, static function ($app) {
             return new ExceptionMakeCommand($app['files']);
         });
     }
@@ -505,7 +505,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerFactoryMakeCommand()
     {
-        $this->app->singleton(FactoryMakeCommand::class, function ($app) {
+        $this->app->singleton(FactoryMakeCommand::class, static function ($app) {
             return new FactoryMakeCommand($app['files']);
         });
     }
@@ -517,7 +517,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventClearCommand()
     {
-        $this->app->singleton(EventClearCommand::class, function ($app) {
+        $this->app->singleton(EventClearCommand::class, static function ($app) {
             return new EventClearCommand($app['files']);
         });
     }
@@ -529,7 +529,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerInterfaceMakeCommand()
     {
-        $this->app->singleton(InterfaceMakeCommand::class, function ($app) {
+        $this->app->singleton(InterfaceMakeCommand::class, static function ($app) {
             return new InterfaceMakeCommand($app['files']);
         });
     }
@@ -541,7 +541,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerJobMakeCommand()
     {
-        $this->app->singleton(JobMakeCommand::class, function ($app) {
+        $this->app->singleton(JobMakeCommand::class, static function ($app) {
             return new JobMakeCommand($app['files']);
         });
     }
@@ -553,7 +553,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerJobMiddlewareMakeCommand()
     {
-        $this->app->singleton(JobMiddlewareMakeCommand::class, function ($app) {
+        $this->app->singleton(JobMiddlewareMakeCommand::class, static function ($app) {
             return new JobMiddlewareMakeCommand($app['files']);
         });
     }
@@ -565,7 +565,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerListenerMakeCommand()
     {
-        $this->app->singleton(ListenerMakeCommand::class, function ($app) {
+        $this->app->singleton(ListenerMakeCommand::class, static function ($app) {
             return new ListenerMakeCommand($app['files']);
         });
     }
@@ -577,7 +577,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMailMakeCommand()
     {
-        $this->app->singleton(MailMakeCommand::class, function ($app) {
+        $this->app->singleton(MailMakeCommand::class, static function ($app) {
             return new MailMakeCommand($app['files']);
         });
     }
@@ -589,7 +589,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMiddlewareMakeCommand()
     {
-        $this->app->singleton(MiddlewareMakeCommand::class, function ($app) {
+        $this->app->singleton(MiddlewareMakeCommand::class, static function ($app) {
             return new MiddlewareMakeCommand($app['files']);
         });
     }
@@ -601,7 +601,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerModelMakeCommand()
     {
-        $this->app->singleton(ModelMakeCommand::class, function ($app) {
+        $this->app->singleton(ModelMakeCommand::class, static function ($app) {
             return new ModelMakeCommand($app['files']);
         });
     }
@@ -613,7 +613,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationMakeCommand()
     {
-        $this->app->singleton(NotificationMakeCommand::class, function ($app) {
+        $this->app->singleton(NotificationMakeCommand::class, static function ($app) {
             return new NotificationMakeCommand($app['files']);
         });
     }
@@ -625,7 +625,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationTableCommand()
     {
-        $this->app->singleton(NotificationTableCommand::class, function ($app) {
+        $this->app->singleton(NotificationTableCommand::class, static function ($app) {
             return new NotificationTableCommand($app['files']);
         });
     }
@@ -637,7 +637,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerObserverMakeCommand()
     {
-        $this->app->singleton(ObserverMakeCommand::class, function ($app) {
+        $this->app->singleton(ObserverMakeCommand::class, static function ($app) {
             return new ObserverMakeCommand($app['files']);
         });
     }
@@ -649,7 +649,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPolicyMakeCommand()
     {
-        $this->app->singleton(PolicyMakeCommand::class, function ($app) {
+        $this->app->singleton(PolicyMakeCommand::class, static function ($app) {
             return new PolicyMakeCommand($app['files']);
         });
     }
@@ -661,7 +661,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerProviderMakeCommand()
     {
-        $this->app->singleton(ProviderMakeCommand::class, function ($app) {
+        $this->app->singleton(ProviderMakeCommand::class, static function ($app) {
             return new ProviderMakeCommand($app['files']);
         });
     }
@@ -683,7 +683,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueListenCommand()
     {
-        $this->app->singleton(QueueListenCommand::class, function ($app) {
+        $this->app->singleton(QueueListenCommand::class, static function ($app) {
             return new QueueListenCommand($app['queue.listener']);
         });
     }
@@ -695,7 +695,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueMonitorCommand()
     {
-        $this->app->singleton(QueueMonitorCommand::class, function ($app) {
+        $this->app->singleton(QueueMonitorCommand::class, static function ($app) {
             return new QueueMonitorCommand($app['queue'], $app['events']);
         });
     }
@@ -707,7 +707,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueuePruneBatchesCommand()
     {
-        $this->app->singleton(QueuePruneBatchesCommand::class, function () {
+        $this->app->singleton(QueuePruneBatchesCommand::class, static function () {
             return new QueuePruneBatchesCommand;
         });
     }
@@ -719,7 +719,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueuePruneFailedJobsCommand()
     {
-        $this->app->singleton(QueuePruneFailedJobsCommand::class, function () {
+        $this->app->singleton(QueuePruneFailedJobsCommand::class, static function () {
             return new QueuePruneFailedJobsCommand;
         });
     }
@@ -731,7 +731,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton(QueueRestartCommand::class, function ($app) {
+        $this->app->singleton(QueueRestartCommand::class, static function ($app) {
             return new QueueRestartCommand($app['cache.store']);
         });
     }
@@ -743,7 +743,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueWorkCommand()
     {
-        $this->app->singleton(QueueWorkCommand::class, function ($app) {
+        $this->app->singleton(QueueWorkCommand::class, static function ($app) {
             return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
@@ -755,7 +755,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedTableCommand()
     {
-        $this->app->singleton(FailedTableCommand::class, function ($app) {
+        $this->app->singleton(FailedTableCommand::class, static function ($app) {
             return new FailedTableCommand($app['files']);
         });
     }
@@ -767,7 +767,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueTableCommand()
     {
-        $this->app->singleton(TableCommand::class, function ($app) {
+        $this->app->singleton(TableCommand::class, static function ($app) {
             return new TableCommand($app['files']);
         });
     }
@@ -779,7 +779,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueBatchesTableCommand()
     {
-        $this->app->singleton(BatchesTableCommand::class, function ($app) {
+        $this->app->singleton(BatchesTableCommand::class, static function ($app) {
             return new BatchesTableCommand($app['files']);
         });
     }
@@ -791,7 +791,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRequestMakeCommand()
     {
-        $this->app->singleton(RequestMakeCommand::class, function ($app) {
+        $this->app->singleton(RequestMakeCommand::class, static function ($app) {
             return new RequestMakeCommand($app['files']);
         });
     }
@@ -803,7 +803,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerResourceMakeCommand()
     {
-        $this->app->singleton(ResourceMakeCommand::class, function ($app) {
+        $this->app->singleton(ResourceMakeCommand::class, static function ($app) {
             return new ResourceMakeCommand($app['files']);
         });
     }
@@ -815,7 +815,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRuleMakeCommand()
     {
-        $this->app->singleton(RuleMakeCommand::class, function ($app) {
+        $this->app->singleton(RuleMakeCommand::class, static function ($app) {
             return new RuleMakeCommand($app['files']);
         });
     }
@@ -827,7 +827,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerScopeMakeCommand()
     {
-        $this->app->singleton(ScopeMakeCommand::class, function ($app) {
+        $this->app->singleton(ScopeMakeCommand::class, static function ($app) {
             return new ScopeMakeCommand($app['files']);
         });
     }
@@ -839,7 +839,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeederMakeCommand()
     {
-        $this->app->singleton(SeederMakeCommand::class, function ($app) {
+        $this->app->singleton(SeederMakeCommand::class, static function ($app) {
             return new SeederMakeCommand($app['files']);
         });
     }
@@ -851,7 +851,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSessionTableCommand()
     {
-        $this->app->singleton(SessionTableCommand::class, function ($app) {
+        $this->app->singleton(SessionTableCommand::class, static function ($app) {
             return new SessionTableCommand($app['files']);
         });
     }
@@ -863,7 +863,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteCacheCommand()
     {
-        $this->app->singleton(RouteCacheCommand::class, function ($app) {
+        $this->app->singleton(RouteCacheCommand::class, static function ($app) {
             return new RouteCacheCommand($app['files']);
         });
     }
@@ -875,7 +875,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteClearCommand()
     {
-        $this->app->singleton(RouteClearCommand::class, function ($app) {
+        $this->app->singleton(RouteClearCommand::class, static function ($app) {
             return new RouteClearCommand($app['files']);
         });
     }
@@ -887,7 +887,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteListCommand()
     {
-        $this->app->singleton(RouteListCommand::class, function ($app) {
+        $this->app->singleton(RouteListCommand::class, static function ($app) {
             return new RouteListCommand($app['router']);
         });
     }
@@ -899,7 +899,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeedCommand()
     {
-        $this->app->singleton(SeedCommand::class, function ($app) {
+        $this->app->singleton(SeedCommand::class, static function ($app) {
             return new SeedCommand($app['db']);
         });
     }
@@ -911,7 +911,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerTestMakeCommand()
     {
-        $this->app->singleton(TestMakeCommand::class, function ($app) {
+        $this->app->singleton(TestMakeCommand::class, static function ($app) {
             return new TestMakeCommand($app['files']);
         });
     }
@@ -923,7 +923,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerTraitMakeCommand()
     {
-        $this->app->singleton(TraitMakeCommand::class, function ($app) {
+        $this->app->singleton(TraitMakeCommand::class, static function ($app) {
             return new TraitMakeCommand($app['files']);
         });
     }
@@ -935,7 +935,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerVendorPublishCommand()
     {
-        $this->app->singleton(VendorPublishCommand::class, function ($app) {
+        $this->app->singleton(VendorPublishCommand::class, static function ($app) {
             return new VendorPublishCommand($app['files']);
         });
     }
@@ -947,7 +947,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewClearCommand()
     {
-        $this->app->singleton(ViewClearCommand::class, function ($app) {
+        $this->app->singleton(ViewClearCommand::class, static function ($app) {
             return new ViewClearCommand($app['files']);
         });
     }

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -15,7 +15,7 @@ class ComposerServiceProvider extends ServiceProvider implements DeferrableProvi
      */
     public function register()
     {
-        $this->app->singleton('composer', function ($app) {
+        $this->app->singleton('composer', static function ($app) {
             return new Composer($app['files'], $app->basePath());
         });
     }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -26,11 +26,11 @@ class FormRequestServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
+        $this->app->afterResolving(ValidatesWhenResolved::class, static function ($resolved) {
             $resolved->validateResolved();
         });
 
-        $this->app->resolving(FormRequest::class, function ($request, $app) {
+        $this->app->resolving(FormRequest::class, static function ($request, $app) {
             $request = FormRequest::createFrom($app['request'], $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -105,7 +105,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerConsoleSchedule()
     {
-        $this->app->singleton(Schedule::class, function ($app) {
+        $this->app->singleton(Schedule::class, static function ($app) {
             return $app->make(ConsoleKernel::class)->resolveConsoleSchedule();
         });
     }
@@ -200,7 +200,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     protected function registerUriUrlGeneration()
     {
-        Uri::setUrlGeneratorResolver(fn () => app('url'));
+        Uri::setUrlGeneratorResolver(static fn () => app('url'));
     }
 
     /**
@@ -212,16 +212,16 @@ class FoundationServiceProvider extends AggregateServiceProvider
     {
         $this->app->scoped(DeferredCallbackCollection::class);
 
-        $this->app['events']->listen(function (CommandFinished $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => app()->runningInConsole() && ($event->exitCode === 0 || $callback->always));
+        $this->app['events']->listen(static function (CommandFinished $event) {
+            app(DeferredCallbackCollection::class)->invokeWhen(static fn ($callback) => app()->runningInConsole() && ($event->exitCode === 0 || $callback->always));
         });
 
-        $this->app['events']->listen(function (JobAttempted $event) {
+        $this->app['events']->listen(static function (JobAttempted $event) {
             if (in_array($event->connectionName, ['sync', 'deferred'])) {
                 return;
             }
 
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => ($event->successful() || $callback->always));
+            app(DeferredCallbackCollection::class)->invokeWhen(static fn ($callback) => ($event->successful() || $callback->always));
         });
     }
 
@@ -264,7 +264,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/exceptions/renderer', 'laravel-exceptions-renderer');
 
-        $this->app->singleton(Renderer::class, function (Application $app) {
+        $this->app->singleton(Renderer::class, static function (Application $app) {
             $errorRenderer = new HtmlErrorRenderer(
                 $app['config']->get('app.debug'),
             );

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -146,10 +146,10 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return (new LazyCollection($this->discoverEventsWithin()))
-            ->flatMap(function ($directory) {
+            ->flatMap(static function ($directory) {
                 return glob($directory, GLOB_ONLYDIR);
             })
-            ->reject(function ($directory) {
+            ->reject(static function ($directory) {
                 return ! is_dir($directory);
             })
             ->pipe(fn ($directories) => DiscoverEvents::within(

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -232,7 +232,7 @@ trait InteractsWithContainer
             $this->originalMix = app(Mix::class);
         }
 
-        $this->swap(Mix::class, function () {
+        $this->swap(Mix::class, static function () {
             return new HtmlString('');
         });
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -33,7 +33,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, static fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseHas($table, $row, $connection);
             }
@@ -73,7 +73,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, static fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseMissing($table, $row, $connection);
             }
@@ -166,7 +166,7 @@ trait InteractsWithDatabase
             );
         }
 
-        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, static fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertSoftDeleted($table, $row, $connection, $deletedAtColumn);
             }
@@ -214,7 +214,7 @@ trait InteractsWithDatabase
             );
         }
 
-        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, static fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertNotSoftDeleted($table, $row, $connection, $deletedAtColumn);
             }
@@ -269,7 +269,7 @@ trait InteractsWithDatabase
 
         $actual = 0;
 
-        $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
+        $connectionInstance->listen(static function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
             if (is_null($connection) || $connectionInstance === $event->connection) {
                 $actual++;
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -37,7 +37,7 @@ trait InteractsWithDeprecationHandling
     protected function withoutDeprecationHandling()
     {
         if ($this->originalDeprecationHandler == null) {
-            $this->originalDeprecationHandler = set_error_handler(function ($level, $message, $file = '', $line = 0) {
+            $this->originalDeprecationHandler = set_error_handler(static function ($level, $message, $file = '', $line = 0) {
                 if (in_array($level, [E_DEPRECATED, E_USER_DEPRECATED]) || (error_reporting() & $level)) {
                     throw new ErrorException($message, 0, $level, $file, $line);
                 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -63,7 +63,7 @@ trait InteractsWithTime
         Carbon::setTestNow($date);
 
         if ($callback) {
-            return tap($callback($date), function () {
+            return tap($callback($date), static function () {
                 Carbon::setTestNow();
             });
         }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -734,7 +734,7 @@ trait MakesHttpRequests
         }
 
         return (new Collection($this->defaultCookies))
-            ->map(fn ($value, $key) => encrypt(CookieValuePrefix::create($key, app('encrypter')->getKey()).$value, false))
+            ->map(static fn ($value, $key) => encrypt(CookieValuePrefix::create($key, app('encrypter')->getKey()).$value, false))
             ->merge($this->unencryptedCookies)
             ->all();
     }

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -97,8 +97,8 @@ trait DatabaseTruncation
                     return $tables->reject(fn (array $table) => $this->tableExistsIn($table, $exceptTables));
                 }
             )
-            ->each(function (array $table) use ($connection) {
-                $connection->withoutTablePrefix(function ($connection) use ($table) {
+            ->each(static function (array $table) use ($connection) {
+                $connection->withoutTablePrefix(static function ($connection) use ($table) {
                     $table = $connection->table($table['schema_qualified_name']);
 
                     if ($table->exists()) {

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -42,7 +42,7 @@ trait LazilyRefreshDatabase
             $database->connection($connection)->beforeExecuting($callback);
         }
 
-        $this->beforeApplicationDestroyed(function () {
+        $this->beforeApplicationDestroyed(static function () {
             RefreshDatabaseState::$lazilyRefreshed = false;
         });
     }

--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -298,7 +298,7 @@ class Wormhole
     protected function handleCallback($callback)
     {
         if ($callback) {
-            return tap($callback(), function () {
+            return tap($callback(), static function () {
                 Carbon::setTestNow();
             });
         }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -274,7 +274,7 @@ class Vite implements Htmlable
     public function useScriptTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn () => $attributes;
+            $attributes = static fn () => $attributes;
         }
 
         $this->scriptTagAttributesResolvers[] = $attributes;
@@ -291,7 +291,7 @@ class Vite implements Htmlable
     public function useStyleTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn () => $attributes;
+            $attributes = static fn () => $attributes;
         }
 
         $this->styleTagAttributesResolvers[] = $attributes;
@@ -308,7 +308,7 @@ class Vite implements Htmlable
     public function usePreloadTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn () => $attributes;
+            $attributes = static fn () => $attributes;
         }
 
         $this->preloadTagAttributesResolvers[] = $attributes;
@@ -463,7 +463,7 @@ class Vite implements Htmlable
             }
         }
 
-        [$stylesheets, $scripts] = $tags->unique()->partition(fn ($tag) => str_starts_with($tag, '<link'));
+        [$stylesheets, $scripts] = $tags->unique()->partition(static fn ($tag) => str_starts_with($tag, '<link'));
 
         $preloads = $preloads->unique()
             ->sortByDesc(fn ($args) => $this->isCssPath($args[1]))
@@ -479,11 +479,11 @@ class Vite implements Htmlable
 
         return (new Collection($entrypoints))
             ->flatMap(fn ($entrypoint) => (new Collection($manifest[$entrypoint]['dynamicImports'] ?? []))
-                ->map(fn ($import) => $manifest[$import])
-                ->filter(fn ($chunk) => str_ends_with($chunk['file'], '.js') || str_ends_with($chunk['file'], '.css'))
-                ->flatMap($f = function ($chunk) use (&$f, $manifest, &$discoveredImports) {
+                ->map(static fn ($import) => $manifest[$import])
+                ->filter(static fn ($chunk) => str_ends_with($chunk['file'], '.js') || str_ends_with($chunk['file'], '.css'))
+                ->flatMap($f = static function ($chunk) use (&$f, $manifest, &$discoveredImports) {
                     return (new Collection([...$chunk['imports'] ?? [], ...$chunk['dynamicImports'] ?? []]))
-                        ->reject(function ($import) use (&$discoveredImports) {
+                        ->reject(static function ($import) use (&$discoveredImports) {
                             if (isset($discoveredImports[$import])) {
                                 return true;
                             }
@@ -491,11 +491,11 @@ class Vite implements Htmlable
                             return ! $discoveredImports[$import] = true;
                         })
                         ->reduce(
-                            fn ($chunks, $import) => $chunks->merge(
+                            static fn ($chunks, $import) => $chunks->merge(
                                 $f($manifest[$import])
                             ), new Collection([$chunk]))
                         ->merge((new Collection($chunk['css'] ?? []))->map(
-                            fn ($css) => (new Collection($manifest))->first(fn ($chunk) => $chunk['file'] === $css) ?? [
+                            static fn ($css) => (new Collection($manifest))->first(static fn ($chunk) => $chunk['file'] === $css) ?? [
                                 'file' => $css,
                             ],
                         ));
@@ -512,8 +512,8 @@ class Vite implements Htmlable
                         'fetchpriority' => 'low',
                         'href' => $url,
                     ]))->reject(
-                        fn ($value) => in_array($value, [null, false], true)
-                    )->mapWithKeys(fn ($value, $key) => [
+                        static fn ($value) => in_array($value, [null, false], true)
+                    )->mapWithKeys(static fn ($value, $key) => [
                         $key = (is_int($key) ? $value : $key) => $value === true ? $key : $value,
                     ])->all();
                 })
@@ -827,9 +827,9 @@ class Vite implements Htmlable
     protected function parseAttributes($attributes)
     {
         return (new Collection($attributes))
-            ->reject(fn ($value, $key) => in_array($value, [false, null], true))
-            ->flatMap(fn ($value, $key) => $value === true ? [$key] : [$key => $value])
-            ->map(fn ($value, $key) => is_int($key) ? $value : $key.'="'.$value.'"')
+            ->reject(static fn ($value, $key) => in_array($value, [false, null], true))
+            ->flatMap(static fn ($value, $key) => $value === true ? [$key] : [$key => $value])
+            ->map(static fn ($value, $key) => is_int($key) ? $value : $key.'="'.$value.'"')
             ->values()
             ->all();
     }
@@ -1090,7 +1090,7 @@ class Vite implements Htmlable
 
             $fonts->ensureValidFamilies($aliases, $manifest);
 
-            $preloads = array_filter($preloads, fn ($preload) => in_array($preload['alias'] ?? null, $aliases, true));
+            $preloads = array_filter($preloads, static fn ($preload) => in_array($preload['alias'] ?? null, $aliases, true));
         }
 
         $fonts->ensureValidPreloads($preloads, $isHot);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -523,7 +523,7 @@ if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
         $abstract = \Faker\Generator::class.':'.$locale;
 
         if (! app()->bound($abstract)) {
-            app()->singleton($abstract, fn () => \Faker\Factory::create($locale));
+            app()->singleton($abstract, static fn () => \Faker\Factory::create($locale));
         }
 
         return app()->make($abstract);
@@ -662,11 +662,11 @@ if (! function_exists('precognitive')) {
      */
     function precognitive($callable = null)
     {
-        $callable ??= function () {
+        $callable ??= static function () {
             //
         };
 
-        $payload = $callable(function ($default, $precognition = null) {
+        $payload = $callable(static function ($default, $precognition = null) {
             $response = request()->isPrecognitive()
                 ? ($precognition ?? $default)
                 : $default;

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -14,11 +14,11 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('hash', function ($app) {
+        $this->app->singleton('hash', static function ($app) {
             return new HashManager($app);
         });
 
-        $this->app->singleton('hash.driver', function ($app) {
+        $this->app->singleton('hash.driver', static function ($app) {
             return $app['hash']->driver();
         });
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -303,7 +303,7 @@ class Factory
      */
     public static function failedConnection($message = null)
     {
-        return function ($request) use ($message) {
+        return static function ($request) use ($message) {
             return Create::rejectionFor(new ConnectException(
                 $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
                 $request->toPsrRequest(),
@@ -335,7 +335,7 @@ class Factory
         $this->recorded = [];
 
         if (is_null($callback)) {
-            $callback = function () {
+            $callback = static function () {
                 return static::response();
             };
         }
@@ -349,7 +349,7 @@ class Factory
         }
 
         $this->stubCallbacks = $this->stubCallbacks->merge(new Collection([
-            function ($request, $options) use ($callback) {
+            static function ($request, $options) use ($callback) {
                 $response = $callback;
 
                 while ($response instanceof Closure) {
@@ -394,7 +394,7 @@ class Factory
      */
     public function stubUrl($url, $callback)
     {
-        return $this->fake(function ($request, $options) use ($url, $callback) {
+        return $this->fake(static function ($request, $options) use ($url, $callback) {
             if (! Str::is(Str::start($url, '*'), $request->url())) {
                 return;
             }
@@ -512,7 +512,7 @@ class Factory
         $this->assertSentCount(count($callbacks));
 
         foreach ($callbacks as $index => $url) {
-            $callback = is_callable($url) ? $url : function ($request) use ($url) {
+            $callback = is_callable($url) ? $url : static function ($request) use ($url) {
                 return $request->url() == $url;
             };
 
@@ -591,7 +591,7 @@ class Factory
         $collect = new Collection($this->recorded);
 
         if ($callback) {
-            return $collect->filter(fn ($pair) => $callback($pair[0], $pair[1]));
+            return $collect->filter(static fn ($pair) => $callback($pair[0], $pair[1]));
         }
 
         return $collect;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -271,7 +271,7 @@ class PendingRequest
             'timeout' => 30,
         ];
 
-        $this->beforeSendingCallbacks = new Collection([function (Request $request, array $options, PendingRequest $pendingRequest) {
+        $this->beforeSendingCallbacks = new Collection([static function (Request $request, array $options, PendingRequest $pendingRequest) {
             $pendingRequest->request = $request;
             $pendingRequest->cookies = $options['cookies'];
 
@@ -779,7 +779,7 @@ class PendingRequest
      */
     public function throw(?callable $callback = null)
     {
-        $this->throwCallback = $callback ?: fn () => null;
+        $this->throwCallback = $callback ?: static fn () => null;
 
         return $this;
     }
@@ -819,7 +819,7 @@ class PendingRequest
     {
         $values = func_get_args();
 
-        return $this->beforeSending(function (Request $request, array $options) use ($values) {
+        return $this->beforeSending(static function (Request $request, array $options) use ($values) {
             foreach (array_merge($values, [$request, $options]) as $value) {
                 VarDumper::dump($value);
             }
@@ -835,7 +835,7 @@ class PendingRequest
     {
         $values = func_get_args();
 
-        return $this->beforeSending(function (Request $request, array $options) use ($values) {
+        return $this->beforeSending(static function (Request $request, array $options) use ($values) {
             foreach (array_merge($values, [$request, $options]) as $value) {
                 VarDumper::dump($value);
             }
@@ -1011,10 +1011,10 @@ class PendingRequest
         };
 
         (new EachPromise($promiseGenerator(), [
-            'fulfilled' => function ($result, $key) use (&$results) {
+            'fulfilled' => static function ($result, $key) use (&$results) {
                 $results[$key] = $result;
             },
-            'rejected' => function ($reason, $key) use (&$results) {
+            'rejected' => static function ($reason, $key) use (&$results) {
                 $results[$key] = $reason;
             },
             'concurrency' => $concurrency,
@@ -1165,7 +1165,7 @@ class PendingRequest
         }
 
         return (new Collection($options))
-            ->map(function ($value, $key) {
+            ->map(static function ($value, $key) {
                 if ($key === 'json' && $value instanceof JsonSerializable) {
                     return $value;
                 }
@@ -1184,7 +1184,7 @@ class PendingRequest
     protected function parseMultipartBodyFormat(array $data)
     {
         return (new Collection($data))
-            ->map(function ($value, $key) {
+            ->map(static function ($value, $key) {
                 // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
                 if (is_array($value) && isset($value['name'], $value['contents'])) {
                     return $value;
@@ -1701,7 +1701,7 @@ class PendingRequest
     public function pushHandlers($handlerStack)
     {
         return tap($handlerStack, function ($stack) {
-            $this->middleware->each(function ($middleware) use ($stack) {
+            $this->middleware->each(static function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
 
@@ -1801,7 +1801,7 @@ class PendingRequest
      */
     protected function sinkStubHandler($sink)
     {
-        return function ($response) use ($sink) {
+        return static function ($response) use ($sink) {
             $body = $response->getBody()->getContents();
 
             if (is_string($sink)) {
@@ -1947,7 +1947,7 @@ class PendingRequest
             return true;
         }
 
-        return array_any($this->allowedStrayRequestUrls, fn ($pattern) => Str::is($pattern, $url));
+        return array_any($this->allowedStrayRequestUrls, static fn ($pattern) => Str::is($pattern, $url));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -155,7 +155,7 @@ class Request implements ArrayAccess
             return false;
         }
 
-        return (new Collection($this->data))->contains(function ($file) use ($name, $value, $filename) {
+        return (new Collection($this->data))->contains(static function ($file) use ($name, $value, $filename) {
             return $file['name'] == $name &&
                 (! $value || $file['contents'] == $value) &&
                 (! $filename || $file['filename'] == $filename);

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -256,7 +256,7 @@ trait InteractsWithInput
             return null;
         }
 
-        return new Image(fn () => $file->getContent(), $file);
+        return new Image(static fn () => $file->getContent(), $file);
     }
 
     /**

--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -29,11 +29,11 @@ class AddLinkHeadersForPreloadedAssets
      */
     public function handle($request, $next, $limit = null)
     {
-        return tap($next($request), function ($response) use ($limit) {
+        return tap($next($request), static function ($response) use ($limit) {
             if ($response instanceof Response && Vite::preloadedAssets() !== []) {
                 $response->header('Link', (new Collection(Vite::preloadedAssets()))
-                    ->when($limit, fn ($assets, $limit) => $assets->take($limit))
-                    ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
+                    ->when($limit, static fn ($assets, $limit) => $assets->take($limit))
+                    ->map(static fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
                     ->join(', '), false);
             }
         });

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -113,7 +113,7 @@ class HandleCors
     {
         $paths = $this->container['config']->get('cors.paths', []);
 
-        return $paths[$host] ?? array_filter($paths, function ($path) {
+        return $paths[$host] ?? array_filter($paths, static function ($path) {
             return is_string($path);
         });
     }

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -25,7 +25,7 @@ class SetCacheHeaders
         }
 
         return (new Collection($options))
-            ->map(function ($value, $key) {
+            ->map(static function ($value, $key) {
                 if (is_bool($value)) {
                     return $value ? $key : null;
                 }
@@ -33,8 +33,8 @@ class SetCacheHeaders
                 return is_int($key) ? $value : "{$key}={$value}";
             })
             ->filter()
-            ->map(fn ($value) => Str::finish($value, ';'))
-            ->pipe(fn ($options) => rtrim(static::class.':'.$options->implode(''), ';'));
+            ->map(static fn ($value) => Str::finish($value, ';'))
+            ->pipe(static fn ($options) => rtrim(static::class.':'.$options->implode(''), ';'));
     }
 
     /**
@@ -89,7 +89,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return (new Stringable(rtrim($options, ';')))->explode(';')->mapWithKeys(function ($option) {
+        return (new Stringable(rtrim($options, ';')))->explode(';')->mapWithKeys(static function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -102,7 +102,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddressesToSpecificIps(Request $request, array $trustedIps)
     {
-        $request->setTrustedProxies(array_reduce($trustedIps, function ($ips, $trustedIp) use ($request) {
+        $request->setTrustedProxies(array_reduce($trustedIps, static function ($ips, $trustedIp) use ($request) {
             $ips[] = $trustedIp === 'REMOTE_ADDR'
                 ? $request->server->get('REMOTE_ADDR')
                 : $trustedIp;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -221,7 +221,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $segments = explode('/', $this->decodedPath());
 
-        return array_values(array_filter($segments, function ($value) {
+        return array_values(array_filter($segments, static function ($value) {
             return $value !== '';
         }));
     }
@@ -391,7 +391,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         return tap($this, function (Request $request) use ($input) {
             $request->getInputSource()
                 ->replace((new Collection($input))->reduce(
-                    fn ($requestInput, $value, $key) => data_set($requestInput, $key, $value),
+                    static fn ($requestInput, $value, $key) => data_set($requestInput, $key, $value),
                     $this->getInputSource()->all()
                 ));
         });
@@ -730,7 +730,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getUserResolver()
     {
-        return $this->userResolver ?: function () {
+        return $this->userResolver ?: static function () {
             //
         };
     }
@@ -755,7 +755,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getRouteResolver()
     {
-        return $this->routeResolver ?: function () {
+        return $this->routeResolver ?: static function () {
             //
         };
     }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -87,7 +87,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return tap(static::newCollection($resource), function ($collection) {
+        return tap(static::newCollection($resource), static function ($collection) {
             if (! array_key_exists(static::class, static::$cachedPreserveKeysAttributes)) {
                 static::$cachedPreserveKeysAttributes[static::class] = (new ReflectionClass(static::class))->getAttributes(PreserveKeys::class) !== [];
             }

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -27,7 +27,7 @@ class PaginatedResourceResponse extends ResourceResponse
             [],
             $this->resource->jsonOptions()
         ), function ($response) use ($request) {
-            $response->original = $this->resource->resource->map(function ($item) {
+            $response->original = $this->resource->resource->map(static function ($item) {
                 if (is_array($item)) {
                     return Arr::get($item, 'resource');
                 } elseif (is_object($item)) {

--- a/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
@@ -23,10 +23,10 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
     {
         return array_filter([
             'included' => $this->collection
-                ->map(fn ($resource) => $resource->resolveIncludedResourceObjects($request))
+                ->map(static fn ($resource) => $resource->resolveIncludedResourceObjects($request))
                 ->flatten(depth: 1)
                 ->uniqueStrict('_uniqueKey')
-                ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
+                ->map(static fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
             ...($implementation = JsonApiResource::$jsonApiInformation)
@@ -45,7 +45,7 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
     public function toAttributes(Request $request)
     {
         return $this->collection
-            ->map(fn ($resource) => $resource->resolveResourceData($request))
+            ->map(static fn ($resource) => $resource->resolveResourceData($request))
             ->all();
     }
 

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -77,7 +77,7 @@ trait ResolvesJsonApiElements
                 'relationships' => $this->resolveResourceRelationshipIdentifiers($request),
                 'links' => $this->resolveResourceLinks($request),
                 'meta' => $this->resolveResourceMetaInformation($request),
-            ]))->filter()->map(fn ($value) => (object) $value),
+            ]))->filter()->map(static fn ($value) => (object) $value),
         ];
     }
 
@@ -150,8 +150,8 @@ trait ResolvesJsonApiElements
 
         $data = (new Collection($data))
             ->mapWithKeys(fn ($value, $key) => is_int($key) ? [$value => $this->resource->{$value}] : [$key => $value])
-            ->when($usesSparseFieldset, fn ($attributes) => $attributes->only($sparseFieldset))
-            ->transform(fn ($value) => value($value, $request))
+            ->when($usesSparseFieldset, static fn ($attributes) => $attributes->only($sparseFieldset))
+            ->transform(static fn ($value) => value($value, $request))
             ->all();
 
         return $this->filter($data);
@@ -174,7 +174,7 @@ trait ResolvesJsonApiElements
 
         return [
             ...(new Collection($this->filter($this->loadedRelationshipIdentifiers)))
-                ->map(function ($relation) {
+                ->map(static function ($relation) {
                     return ! is_null($relation) ? $relation : ['data' => null];
                 })->all(),
         ];
@@ -195,8 +195,8 @@ trait ResolvesJsonApiElements
         };
 
         $resourceRelationships = (new Collection($this->toRelationships($request)))
-            ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
-            ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
+            ->transform(static fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
+            ->mapWithKeys(static fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
             ->only($sparseIncluded);
 
         $resourceRelationshipKeys = $resourceRelationships->keys();
@@ -252,7 +252,7 @@ trait ResolvesJsonApiElements
             $isUnique = ! $relationship instanceof BelongsToMany;
 
             yield $relationName => ['data' => $relatedModels->map(function ($relatedModel) use ($request, $resourceClass, $isUnique) {
-                $relatedResource = rescue(fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
+                $relatedResource = rescue(static fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
 
                 return transform(
                     [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
@@ -284,7 +284,7 @@ trait ResolvesJsonApiElements
             return;
         }
 
-        $relatedResource = rescue(fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
+        $relatedResource = rescue(static fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
 
         yield $relationName => ['data' => transform(
             [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -25,7 +25,7 @@ class JsonApiRequest extends Request
     {
         if (is_null($this->cachedSparseFields)) {
             $this->cachedSparseFields = (new Collection($this->array('fields')))
-                ->transform(fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
+                ->transform(static fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
                 ->all();
         }
 
@@ -53,7 +53,7 @@ class JsonApiRequest extends Request
             $included = (string) $this->string('include', '');
 
             $this->cachedSparseIncluded = (new Collection(empty($included) ? [] : explode(',', $included)))
-                ->transform(function ($item) {
+                ->transform(static function ($item) {
                     $with = null;
 
                     if (str_contains($item, '.')) {
@@ -63,7 +63,7 @@ class JsonApiRequest extends Request
                     }
 
                     return ['relation' => $relation, 'with' => $with];
-                })->mapToGroups(fn ($item) => [$item['relation'] => $item['with']])
+                })->mapToGroups(static fn ($item) => [$item['relation'] => $item['with']])
                 ->toArray();
         }
 
@@ -71,9 +71,9 @@ class JsonApiRequest extends Request
             return array_keys($this->cachedSparseIncluded);
         }
 
-        return transform($this->cachedSparseIncluded[$key] ?? null, function ($value) {
+        return transform($this->cachedSparseIncluded[$key] ?? null, static function ($value) {
             return Collection::wrap($value)
-                ->transform(function ($item) {
+                ->transform(static function ($item) {
                     if (! is_string($item) || $item === '') {
                         return null;
                     }

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -135,7 +135,7 @@ class JsonApiResource extends JsonResource
         return array_filter([
             'included' => $this->resolveIncludedResourceObjects($request)
                 ->uniqueStrict('_uniqueKey')
-                ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
+                ->map(static fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
             ...($implementation = static::$jsonApiInformation)

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -46,7 +46,7 @@ class Response extends SymfonyResponse
     #[\Override]
     public function getContent(): string|false
     {
-        return transform(parent::getContent(), fn ($content) => $content, '');
+        return transform(parent::getContent(), static fn ($content) => $content, '');
     }
 
     /**

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -20,7 +20,7 @@ class FileFactory
             return $this->createWithContent($name, $kilobytes);
         }
 
-        return tap(new File($name, tmpfile()), function ($file) use ($kilobytes, $mimeType) {
+        return tap(new File($name, tmpfile()), static function ($file) use ($kilobytes, $mimeType) {
             $file->sizeToReport = $kilobytes * 1024;
             $file->mimeTypeToReport = $mimeType;
         });
@@ -39,7 +39,7 @@ class FileFactory
 
         fwrite($tmpfile, $content);
 
-        return tap(new File($name, $tmpfile), function ($file) use ($tmpfile) {
+        return tap(new File($name, $tmpfile), static function ($file) use ($tmpfile) {
             $file->sizeToReport = fstat($tmpfile)['size'];
         });
     }
@@ -77,7 +77,7 @@ class FileFactory
             throw new LogicException('GD extension is not installed.');
         }
 
-        return tap(tmpfile(), function ($temp) use ($width, $height, $extension) {
+        return tap(tmpfile(), static function ($temp) use ($width, $height, $extension) {
             ob_start();
 
             $extension = in_array($extension, ['jpeg', 'png', 'gif', 'webp', 'wbmp', 'bmp'])

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -213,7 +213,7 @@ class Image implements Responsable, Stringable
      */
     public function transform(Transformation $transformation): static
     {
-        return $this->withClone(fn (Image $image) => $image->pipeline->add($transformation));
+        return $this->withClone(static fn (Image $image) => $image->pipeline->add($transformation));
     }
 
     /**
@@ -233,7 +233,7 @@ class Image implements Responsable, Stringable
      */
     public function quality(int $quality): static
     {
-        return $this->withOutput(fn (ImageOutputOptions $output) => $output->quality = max(1, min(100, $quality)));
+        return $this->withOutput(static fn (ImageOutputOptions $output) => $output->quality = max(1, min(100, $quality)));
     }
 
     /**
@@ -313,7 +313,7 @@ class Image implements Responsable, Stringable
 
         $format = $format === 'heif' ? 'heic' : $format;
 
-        return $this->withOutput(fn (ImageOutputOptions $output) => $output->format = $format);
+        return $this->withOutput(static fn (ImageOutputOptions $output) => $output->format = $format);
     }
 
     /**
@@ -581,7 +581,7 @@ class Image implements Responsable, Stringable
      */
     protected function withOutput(Closure $callback): static
     {
-        return $this->withClone(fn (Image $image) => $callback($image->pipeline->output));
+        return $this->withClone(static fn (Image $image) => $callback($image->pipeline->output));
     }
 
     /**

--- a/src/Illuminate/Image/ImageManager.php
+++ b/src/Illuminate/Image/ImageManager.php
@@ -40,7 +40,7 @@ class ImageManager extends Manager
     public function fromStream(mixed $stream): Image
     {
         return new Image(
-            fn () => stream_get_contents($stream) ?: throw new ImageException('Invalid stream image data.'),
+            static fn () => stream_get_contents($stream) ?: throw new ImageException('Invalid stream image data.'),
         );
     }
 
@@ -50,7 +50,7 @@ class ImageManager extends Manager
     public function fromBase64(string $base64): Image
     {
         return new Image(
-            fn () => base64_decode($base64, true) ?: throw new ImageException('Invalid base64 image data.'),
+            static fn () => base64_decode($base64, true) ?: throw new ImageException('Invalid base64 image data.'),
         );
     }
 
@@ -81,7 +81,7 @@ class ImageManager extends Manager
      */
     public function fromUpload(UploadedFile $file): Image
     {
-        return new Image(fn () => $file->getContent(), $file);
+        return new Image(static fn () => $file->getContent(), $file);
     }
 
     /**

--- a/src/Illuminate/Image/ImageServiceProvider.php
+++ b/src/Illuminate/Image/ImageServiceProvider.php
@@ -12,7 +12,7 @@ class ImageServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register(): void
     {
-        $this->app->scoped('image', function ($app) {
+        $this->app->scoped('image', static function ($app) {
             return new ImageManager($app);
         });
     }

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -21,7 +21,7 @@ class ContextServiceProvider extends ServiceProvider
         $this->app->scoped(Repository::class);
 
         if ($this->app->runningInConsole()) {
-            $this->app->resolving(Repository::class, function (Repository $repository) {
+            $this->app->resolving(Repository::class, static function (Repository $repository) {
                 $context = Env::get('__LARAVEL_CONTEXT');
 
                 if ($context && $context = json_decode($context, associative: true)) {
@@ -30,7 +30,7 @@ class ContextServiceProvider extends ServiceProvider
             });
         }
 
-        $this->app->bind(ContextLogProcessorContract::class, fn () => new ContextLogProcessor());
+        $this->app->bind(ContextLogProcessorContract::class, static fn () => new ContextLogProcessor());
     }
 
     /**
@@ -40,7 +40,7 @@ class ContextServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+        Queue::createPayloadUsing(static function ($connection, $queue, $payload) {
             /** @phpstan-ignore staticMethod.notFound */
             $context = Context::dehydrate();
 
@@ -50,7 +50,7 @@ class ContextServiceProvider extends ServiceProvider
             ];
         });
 
-        $this->app['events']->listen(function (JobProcessing $event) {
+        $this->app['events']->listen(static function (JobProcessing $event) {
             /** @phpstan-ignore staticMethod.notFound */
             Context::hydrate($event->job->payload()['illuminate:log:context'] ?? null);
         });

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -585,7 +585,7 @@ class Repository
      */
     public function dehydrating($callback)
     {
-        $this->events->listen(fn (Dehydrating $event) => $callback($event->context));
+        $this->events->listen(static fn (Dehydrating $event) => $callback($event->context));
 
         return $this;
     }
@@ -598,7 +598,7 @@ class Repository
      */
     public function hydrated($callback)
     {
-        $this->events->listen(fn (Hydrated $event) => $callback($event->context));
+        $this->events->listen(static fn (Hydrated $event) => $callback($event->context));
 
         return $this;
     }
@@ -644,7 +644,7 @@ class Repository
 
         $instance->events->dispatch(new Dehydrating($instance));
 
-        $serialize = fn ($value) => serialize($instance->getSerializedPropertyValue($value, withRelations: false));
+        $serialize = static fn ($value) => serialize($instance->getSerializedPropertyValue($value, withRelations: false));
 
         return $instance->isEmpty() ? null : [
             'data' => array_map($serialize, $instance->all()),
@@ -666,7 +666,7 @@ class Repository
     {
         $unserialize = function ($value, $key, $hidden) {
             try {
-                return tap($this->getRestoredPropertyValue(unserialize($value)), function ($value) {
+                return tap($this->getRestoredPropertyValue(unserialize($value)), static function ($value) {
                     if ($value instanceof __PHP_Incomplete_Class) {
                         throw new RuntimeException('Value is incomplete class: '.json_encode($value));
                     }
@@ -689,8 +689,8 @@ class Repository
         };
 
         [$data, $hidden] = [
-            (new Collection($context['data'] ?? []))->map(fn ($value, $key) => $unserialize($value, $key, false))->all(),
-            (new Collection($context['hidden'] ?? []))->map(fn ($value, $key) => $unserialize($value, $key, true))->all(),
+            (new Collection($context['data'] ?? []))->map(static fn ($value, $key) => $unserialize($value, $key, false))->all(),
+            (new Collection($context['hidden'] ?? []))->map(static fn ($value, $key) => $unserialize($value, $key, true))->all(),
         ];
 
         $this->events->dispatch(new Hydrated(

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -153,7 +153,7 @@ class LogManager implements LoggerInterface
                 return $this->channels[$name] = $loggerWithContext;
             });
         } catch (Throwable $e) {
-            return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
+            return tap($this->createEmergencyLogger(), static function ($logger) use ($e) {
                 $logger->emergency('Unable to create configured logger. Using emergency logger.', [
                     'exception' => $e,
                 ]);
@@ -438,7 +438,7 @@ class LogManager implements LoggerInterface
             );
         }
 
-        (new Collection($config['processors'] ?? []))->each(function ($processor) {
+        (new Collection($config['processors'] ?? []))->each(static function ($processor) {
             $processor = $processor['processor'] ?? $processor;
 
             if (! is_a($processor, ProcessorInterface::class, true)) {

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -13,6 +13,6 @@ class LogServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('log', fn ($app) => new LogManager($app));
+        $this->app->singleton('log', static fn ($app) => new LogManager($app));
     }
 }

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -55,7 +55,7 @@ class Attachment
      */
     public static function fromPath($path)
     {
-        return new static(fn ($attachment, $pathStrategy) => $pathStrategy($path, $attachment));
+        return new static(static fn ($attachment, $pathStrategy) => $pathStrategy($path, $attachment));
     }
 
     /**
@@ -83,7 +83,7 @@ class Attachment
     public static function fromData(Closure $data, $name = null)
     {
         return (new static(
-            fn ($attachment, $pathStrategy, $dataStrategy) => $dataStrategy($data, $attachment)
+            static fn ($attachment, $pathStrategy, $dataStrategy) => $dataStrategy($data, $attachment)
         ))->as($name);
     }
 
@@ -95,12 +95,12 @@ class Attachment
      */
     public static function fromUploadedFile(UploadedFile $file)
     {
-        return new static(function ($attachment, $pathStrategy, $dataStrategy) use ($file) {
+        return new static(static function ($attachment, $pathStrategy, $dataStrategy) use ($file) {
             $attachment
                 ->as($file->getClientOriginalName())
                 ->withMime($file->getMimeType() ?? $file->getClientMimeType());
 
-            return $dataStrategy(fn () => $file->get(), $attachment);
+            return $dataStrategy(static fn () => $file->get(), $attachment);
         });
     }
 
@@ -124,7 +124,7 @@ class Attachment
      */
     public static function fromStorageDisk($disk, $path)
     {
-        return new static(function ($attachment, $pathStrategy, $dataStrategy) use ($disk, $path) {
+        return new static(static function ($attachment, $pathStrategy, $dataStrategy) use ($disk, $path) {
             $storage = Container::getInstance()->make(
                 FilesystemFactory::class
             )->disk($disk);
@@ -133,7 +133,7 @@ class Attachment
                 ->as($attachment->as ?? basename($path))
                 ->withMime($attachment->mime ?? $storage->mimeType($path));
 
-            return $dataStrategy(fn () => $storage->get($path), $attachment);
+            return $dataStrategy(static fn () => $storage->get($path), $attachment);
         });
     }
 
@@ -235,8 +235,8 @@ class Attachment
             fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
             fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
         ) === $attachment->attachWith(
-            fn ($path) => [$path, $newOptions],
-            fn ($data) => [$data(), $newOptions],
+            static fn ($path) => [$path, $newOptions],
+            static fn ($data) => [$data(), $newOptions],
         );
     }
 }

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -25,11 +25,11 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerIlluminateMailer()
     {
-        $this->app->singleton('mail.manager', function ($app) {
+        $this->app->singleton('mail.manager', static function ($app) {
             return new MailManager($app);
         });
 
-        $this->app->bind('mailer', function ($app) {
+        $this->app->bind('mailer', static function ($app) {
             return $app->make('mail.manager')->mailer();
         });
     }
@@ -47,7 +47,7 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
             ], 'laravel-mail');
         }
 
-        $this->app->singleton(Markdown::class, function ($app) {
+        $this->app->singleton(Markdown::class, static function ($app) {
             $config = $app->make('config');
 
             return new Markdown($app->make('view'), [

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -616,7 +616,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function priority($level = 3)
     {
-        $this->callbacks[] = function ($message) use ($level) {
+        $this->callbacks[] = static function ($message) use ($level) {
             $message->priority($level);
         };
 
@@ -808,7 +808,7 @@ class Mailable implements MailableContract, Renderable
     {
         if (is_array($recipient)) {
             if (array_values($recipient) === $recipient) {
-                return (object) array_map(function ($email) {
+                return (object) array_map(static function ($email) {
                     return ['email' => $email];
                 }, $recipient);
             }
@@ -852,7 +852,7 @@ class Mailable implements MailableContract, Renderable
             return true;
         }
 
-        return (new Collection($this->{$property}))->contains(function ($actual) use ($expected) {
+        return (new Collection($this->{$property}))->contains(static function ($actual) use ($expected) {
             if (! isset($expected['name'])) {
                 return $actual['address'] == $expected['address'];
             }
@@ -1044,7 +1044,7 @@ class Mailable implements MailableContract, Renderable
 
         if ($file instanceof Attachment) {
             $parts = $file->attachWith(
-                fn ($path) => [$path, [
+                static fn ($path) => [$path, [
                     'as' => $options['as'] ?? $file->as,
                     'mime' => $options['mime'] ?? $file->mime,
                 ]],
@@ -1061,7 +1061,7 @@ class Mailable implements MailableContract, Renderable
         }
 
         return (new Collection($this->attachments))->contains(
-            fn ($attachment) => $attachment['file'] === $file && array_filter($attachment['options']) === array_filter($options)
+            static fn ($attachment) => $attachment['file'] === $file && array_filter($attachment['options']) === array_filter($options)
         );
     }
 
@@ -1081,8 +1081,8 @@ class Mailable implements MailableContract, Renderable
         $attachments = $this->attachments();
 
         return (new Collection(is_object($attachments) ? [$attachments] : $attachments))
-            ->map(fn ($attached) => $attached instanceof Attachable ? $attached->toMailAttachment() : $attached)
-            ->contains(fn ($attached) => $attached->isEquivalent($attachment, $options));
+            ->map(static fn ($attached) => $attached instanceof Attachable ? $attached->toMailAttachment() : $attached)
+            ->contains(static fn ($attached) => $attached->isEquivalent($attachment, $options));
     }
 
     /**
@@ -1115,7 +1115,7 @@ class Mailable implements MailableContract, Renderable
             'name' => $name ?? basename($path),
             'options' => $options,
         ])
-            ->unique(fn ($file) => $file['name'].$file['disk'].$file['path'])
+            ->unique(static fn ($file) => $file['name'].$file['disk'].$file['path'])
             ->all();
 
         return $this;
@@ -1146,7 +1146,7 @@ class Mailable implements MailableContract, Renderable
     public function hasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
     {
         return (new Collection($this->diskAttachments))->contains(
-            fn ($attachment) => $attachment['disk'] === $disk
+            static fn ($attachment) => $attachment['disk'] === $disk
                 && $attachment['path'] === $path
                 && $attachment['name'] === ($name ?? basename($path))
                 && $attachment['options'] === $options
@@ -1165,7 +1165,7 @@ class Mailable implements MailableContract, Renderable
     {
         $this->rawAttachments = (new Collection($this->rawAttachments))
             ->push(['data' => $data, 'name' => $name, 'options' => $options])
-            ->unique(fn ($file) => $file['name'].$file['data'])
+            ->unique(static fn ($file) => $file['name'].$file['data'])
             ->all();
 
         return $this;
@@ -1182,7 +1182,7 @@ class Mailable implements MailableContract, Renderable
     public function hasAttachedData($data, $name, array $options = [])
     {
         return (new Collection($this->rawAttachments))->contains(
-            fn ($attachment) => $attachment['data'] === $data
+            static fn ($attachment) => $attachment['data'] === $data
                 && $attachment['name'] === $name
                 && array_filter($attachment['options']) === array_filter($options)
         );
@@ -1398,7 +1398,7 @@ class Mailable implements MailableContract, Renderable
             return 'none';
         }
 
-        return (new Collection($recipients))->map(function ($recipient) {
+        return (new Collection($recipients))->map(static function ($recipient) {
             $formatted = $recipient['address'];
             if (! empty($recipient['name'])) {
                 $formatted .= ' ('.$recipient['name'].')';
@@ -1481,7 +1481,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInOrderInHtml($strings, $escape = true)
     {
-        $strings = $escape ? array_map(function ($string) {
+        $strings = $escape ? array_map(static function ($string) {
             return EncodedHtmlString::convert($string, withQuote: true);
         }, $strings) : $strings;
 
@@ -1755,7 +1755,7 @@ class Mailable implements MailableContract, Renderable
 
         $headers = $this->headers();
 
-        $this->withSymfonyMessage(function ($message) use ($headers) {
+        $this->withSymfonyMessage(static function ($message) use ($headers) {
             if ($headers->messageId) {
                 $message->getHeaders()->addIdHeader('Message-Id', $headers->messageId);
             }

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -111,7 +111,7 @@ class Envelope
     protected function normalizeAddresses($addresses)
     {
         return (new Collection($addresses))
-            ->map(fn ($address) => is_string($address) ? new Address($address) : $address)
+            ->map(static fn ($address) => is_string($address) ? new Address($address) : $address)
             ->all();
     }
 
@@ -334,7 +334,7 @@ class Envelope
      */
     protected function hasRecipient(array $recipients, string $address, ?string $name = null)
     {
-        return (new Collection($recipients))->contains(function ($recipient) use ($address, $name) {
+        return (new Collection($recipients))->contains(static function ($recipient) use ($address, $name) {
             if (is_null($name)) {
                 return $recipient->address === $address;
             }

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -94,7 +94,7 @@ class Headers
     public function referencesString(): string
     {
         return (new Collection($this->references))
-            ->map(fn ($messageId) => (new Stringable($messageId))->start('<')->finish('>')->value())
+            ->map(static fn ($messageId) => (new Stringable($messageId))->start('<')->finish('>')->value())
             ->implode(' ');
     }
 }

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -85,7 +85,7 @@ class Markdown
             'new \Illuminate\Support\EncodedHtmlString(%s)',
             function () use ($view, $data) {
                 if (static::$withSecuredEncoding === true) {
-                    EncodedHtmlString::encodeUsing(function ($value) {
+                    EncodedHtmlString::encodeUsing(static function ($value) {
                         $replacements = [
                             '[' => '\[',
                             '<' => '&lt;',
@@ -155,7 +155,7 @@ class Markdown
         }
 
         if (static::$withSecuredEncoding === true || $encoded === true) {
-            EncodedHtmlString::encodeUsing(function ($value) {
+            EncodedHtmlString::encodeUsing(static function ($value) {
                 $replacements = [
                     '[' => '\[',
                     '<' => '\<',
@@ -211,7 +211,7 @@ class Markdown
      */
     public function htmlComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/html';
         }, $this->componentPaths());
     }
@@ -223,7 +223,7 @@ class Markdown
      */
     public function textComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/text';
         }, $this->componentPaths());
     }

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -304,7 +304,7 @@ class Message
     {
         $this->message->getHeaders()->addTextHeader(
             $header,
-            implode(', ', array_map(fn ($a) => $a->toString(), $addresses)),
+            implode(', ', array_map(static fn ($a) => $a->toString(), $addresses)),
         );
 
         return $this;

--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -89,7 +89,7 @@ class CloudflareTransport extends AbstractTransport
             'text' => $email->getTextBody(),
             'headers' => $this->getCustomHeaders($email),
             'attachments' => $this->getAttachments($email),
-        ], fn ($value) => $value !== null && $value !== [] && $value !== '');
+        ], static fn ($value) => $value !== null && $value !== [] && $value !== '');
     }
 
     /**
@@ -97,7 +97,7 @@ class CloudflareTransport extends AbstractTransport
      */
     protected function getRecipients(Email $email, Envelope $envelope): array
     {
-        return array_filter($envelope->getRecipients(), function (Address $address) use ($email) {
+        return array_filter($envelope->getRecipients(), static function (Address $address) use ($email) {
             return in_array($address, array_merge($email->getCc(), $email->getBcc()), true) === false;
         });
     }
@@ -173,7 +173,7 @@ class CloudflareTransport extends AbstractTransport
      */
     protected function stringifyAddresses(array $addresses): array
     {
-        return array_map(fn (Address $a) => $a->getAddress(), $addresses);
+        return array_map(static fn (Address $a) => $a->getAddress(), $addresses);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -134,7 +134,7 @@ class ResendTransport extends AbstractTransport
      */
     protected function getRecipients(Email $email, Envelope $envelope): array
     {
-        return array_filter($envelope->getRecipients(), function (Address $address) use ($email) {
+        return array_filter($envelope->getRecipients(), static function (Address $address) use ($email) {
             return in_array($address, array_merge($email->getCc(), $email->getBcc()), true) === false;
         });
     }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -105,7 +105,7 @@ class SesTransport extends AbstractTransport implements Stringable
     {
         if ($header = $message->getOriginalMessage()->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
             if (preg_match("/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix", $header->getBodyAsString(), $listManagementOptions)) {
-                return array_filter($listManagementOptions, fn ($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
+                return array_filter($listManagementOptions, static fn ($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
             }
         }
     }

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -113,7 +113,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
     {
         if ($header = $message->getOriginalMessage()->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
             if (preg_match("/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix", $header->getBodyAsString(), $listManagementOptions)) {
-                return array_filter($listManagementOptions, fn ($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
+                return array_filter($listManagementOptions, static fn ($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
             }
         }
     }

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -263,7 +263,7 @@ class MailChannel
         }
 
         return (new Collection($recipients))
-            ->mapWithKeys(function ($recipient, $email) {
+            ->mapWithKeys(static function ($recipient, $email) {
                 return is_numeric($email)
                     ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
                     : [$email => $recipient];

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -51,7 +51,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         }
 
         return (new Collection($channels))
-            ->map(fn ($channel) => new PrivateChannel($channel))
+            ->map(static fn ($channel) => new PrivateChannel($channel))
             ->all();
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -410,7 +410,7 @@ class MailMessage extends SimpleMessage implements Renderable
     protected function parseAddresses($value)
     {
         return (new Collection($value))
-            ->map(fn ($address, $name) => [$address, is_numeric($name) ? null : $name])
+            ->map(static fn ($address, $name) => [$address, is_numeric($name) ? null : $name])
             ->values()
             ->all();
     }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -133,7 +133,7 @@ class NotificationSender
      */
     protected function preferredLocale($notifiable, $notification)
     {
-        return $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+        return $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
             if ($notifiable instanceof HasLocalePreference) {
                 return $notifiable->preferredLocale();
             }

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -31,7 +31,7 @@ class NotificationServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ChannelManager::class, fn ($app) => new ChannelManager($app));
+        $this->app->singleton(ChannelManager::class, static fn ($app) => new ChannelManager($app));
 
         $this->app->alias(
             ChannelManager::class, DispatcherContract::class

--- a/src/Illuminate/Pagination/PaginationState.php
+++ b/src/Illuminate/Pagination/PaginationState.php
@@ -12,11 +12,11 @@ class PaginationState
      */
     public static function resolveUsing($app)
     {
-        Paginator::viewFactoryResolver(fn () => $app['view']);
+        Paginator::viewFactoryResolver(static fn () => $app['view']);
 
-        Paginator::currentPathResolver(fn () => $app['request']->url());
+        Paginator::currentPathResolver(static fn () => $app['request']->url());
 
-        Paginator::currentPageResolver(function ($pageName = 'page') use ($app) {
+        Paginator::currentPageResolver(static function ($pageName = 'page') use ($app) {
             $page = $app['request']->input($pageName);
 
             if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
@@ -26,9 +26,9 @@ class PaginationState
             return 1;
         });
 
-        Paginator::queryStringResolver(fn () => $app['request']->query());
+        Paginator::queryStringResolver(static fn () => $app['request']->query());
 
-        CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') use ($app) {
+        CursorPaginator::currentCursorResolver(static function ($cursorName = 'cursor') use ($app) {
             return Cursor::fromEncoded($app['request']->input($cursorName));
         });
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -149,7 +149,7 @@ class Pipeline implements PipelineContract
      */
     public function thenReturn()
     {
-        return $this->then(function ($passable) {
+        return $this->then(static function ($passable) {
             return $passable;
         });
     }

--- a/src/Illuminate/Pipeline/PipelineServiceProvider.php
+++ b/src/Illuminate/Pipeline/PipelineServiceProvider.php
@@ -20,7 +20,7 @@ class PipelineServiceProvider extends ServiceProvider implements DeferrableProvi
             Hub::class
         );
 
-        $this->app->bind('pipeline', fn ($app) => new Pipeline($app));
+        $this->app->bind('pipeline', static fn ($app) => new Pipeline($app));
     }
 
     /**

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -91,7 +91,7 @@ class Factory
         $this->recording = true;
 
         if (is_null($callback)) {
-            $this->fakeHandlers = ['*' => fn () => new FakeProcessResult];
+            $this->fakeHandlers = ['*' => static fn () => new FakeProcessResult];
 
             return $this;
         }
@@ -105,7 +105,7 @@ class Factory
         foreach ($callback as $command => $handler) {
             $this->fakeHandlers[is_numeric($command) ? '*' : $command] = $handler instanceof Closure
                 ? $handler
-                : fn () => $handler;
+                : static fn () => $handler;
         }
 
         return $this;
@@ -182,10 +182,10 @@ class Factory
      */
     public function assertRan(Closure|string $callback)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = is_string($callback) ? static fn ($process) => $process->command === $callback : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($this->recorded))->contains(function ($pair) use ($callback) {
+            (new Collection($this->recorded))->contains(static function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
             }),
             'An expected process was not invoked.'
@@ -203,10 +203,10 @@ class Factory
      */
     public function assertRanTimes(Closure|string $callback, int $times = 1)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = is_string($callback) ? static fn ($process) => $process->command === $callback : $callback;
 
         $count = (new Collection($this->recorded))
-            ->filter(fn ($pair) => $callback($pair[0], $pair[1]))
+            ->filter(static fn ($pair) => $callback($pair[0], $pair[1]))
             ->count();
 
         PHPUnit::assertSame(
@@ -225,10 +225,10 @@ class Factory
      */
     public function assertNotRan(Closure|string $callback)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = is_string($callback) ? static fn ($process) => $process->command === $callback : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($this->recorded))->doesntContain(function ($pair) use ($callback) {
+            (new Collection($this->recorded))->doesntContain(static function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
             }),
             'An unexpected process was invoked.'
@@ -283,8 +283,8 @@ class Factory
     public function pipe(callable|array $callback, ?callable $output = null)
     {
         return is_array($callback)
-            ? (new Pipe($this, fn ($pipe) => (new Collection($callback))->each(
-                fn ($command) => $pipe->command($command)
+            ? (new Pipe($this, static fn ($pipe) => (new Collection($callback))->each(
+                static fn ($command) => $pipe->command($command)
             )))->run(output: $output)
             : (new Pipe($this, $callback))->run(output: $output);
     }

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -297,7 +297,7 @@ class FakeInvokedProcess implements InvokedProcessContract
         $shouldStop = false;
 
         $this->outputHandler = $output
-            ? function ($type, $buffer) use ($output, &$shouldStop) {
+            ? static function ($type, $buffer) use ($output, &$shouldStop) {
                 $shouldStop = call_user_func($output, $type, $buffer);
             }
         : $this->outputHandler;

--- a/src/Illuminate/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Process/FakeProcessDescription.php
@@ -95,7 +95,7 @@ class FakeProcessDescription
     public function replaceOutput(string $output)
     {
         $this->output = (new Collection($this->output))
-            ->reject(fn ($output) => $output['type'] === 'out')
+            ->reject(static fn ($output) => $output['type'] === 'out')
             ->values()
             ->all();
 
@@ -118,7 +118,7 @@ class FakeProcessDescription
     public function replaceErrorOutput(string $output)
     {
         $this->output = (new Collection($this->output))
-            ->reject(fn ($output) => $output['type'] === 'err')
+            ->reject(static fn ($output) => $output['type'] === 'err')
             ->values()
             ->all();
 
@@ -204,7 +204,7 @@ class FakeProcessDescription
     protected function resolveOutput()
     {
         $output = (new Collection($this->output))
-            ->filter(fn ($output) => $output['type'] === 'out');
+            ->filter(static fn ($output) => $output['type'] === 'out');
 
         return $output->isNotEmpty()
             ? rtrim($output->map->buffer->implode(''), "\n")."\n"
@@ -219,7 +219,7 @@ class FakeProcessDescription
     protected function resolveErrorOutput()
     {
         $output = (new Collection($this->output))
-            ->filter(fn ($output) => $output['type'] === 'err');
+            ->filter(static fn ($output) => $output['type'] === 'err');
 
         return $output->isNotEmpty()
             ? rtrim($output->map->buffer->implode(''), "\n")."\n"

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -67,7 +67,7 @@ class FakeProcessResult implements ProcessResultContract
         } elseif (is_array($output)) {
             return rtrim(
                 (new Collection($output))
-                    ->map(fn ($line) => rtrim($line, "\n")."\n")
+                    ->map(static fn ($line) => rtrim($line, "\n")."\n")
                     ->implode(''),
                 "\n"
             );

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -361,7 +361,7 @@ class PendingProcess
     protected function fakeFor(string $command)
     {
         return (new Collection($this->fakeHandlers))
-            ->first(fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
+            ->first(static fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
     }
 
     /**
@@ -390,7 +390,7 @@ class PendingProcess
             $result instanceof ProcessResult => $result,
             $result instanceof FakeProcessResult => $result->withCommand($command),
             $result instanceof FakeProcessDescription => $result->toProcessResult($command),
-            $result instanceof FakeProcessSequence => $this->resolveSynchronousFake($command, fn () => $result()),
+            $result instanceof FakeProcessSequence => $this->resolveSynchronousFake($command, static fn () => $result()),
             $result instanceof \Throwable => throw $result,
             default => throw new LogicException('Unsupported synchronous process fake result provided.'),
         };
@@ -435,7 +435,7 @@ class PendingProcess
         } elseif ($result instanceof FakeProcessDescription) {
             return (new FakeInvokedProcess($command, $result))->withOutputHandler($output);
         } elseif ($result instanceof FakeProcessSequence) {
-            return $this->resolveAsynchronousFake($command, $output, fn () => $result());
+            return $this->resolveAsynchronousFake($command, $output, static fn () => $result());
         }
 
         throw new LogicException('Unsupported asynchronous process fake result provided.');

--- a/src/Illuminate/Process/Pipe.php
+++ b/src/Illuminate/Process/Pipe.php
@@ -70,7 +70,7 @@ class Pipe
         call_user_func($this->callback, $this);
 
         return (new Collection($this->pendingProcesses))
-            ->reduce(function ($previousProcessResult, $pendingProcess, $key) use ($output) {
+            ->reduce(static function ($previousProcessResult, $pendingProcess, $key) use ($output) {
                 if (! $pendingProcess instanceof PendingProcess) {
                     throw new InvalidArgumentException('Process pipe must only contain pending processes.');
                 }
@@ -81,8 +81,8 @@ class Pipe
 
                 return $pendingProcess->when(
                     $previousProcessResult,
-                    fn () => $pendingProcess->input($previousProcessResult->output())
-                )->run(output: $output ? function ($type, $buffer) use ($key, $output) {
+                    static fn () => $pendingProcess->input($previousProcessResult->output())
+                )->run(output: $output ? static function ($type, $buffer) use ($key, $output) {
                     $output($type, $buffer, $key);
                 } : null);
             });

--- a/src/Illuminate/Process/Pool.php
+++ b/src/Illuminate/Process/Pool.php
@@ -71,13 +71,13 @@ class Pool
 
         return new InvokedProcessPool(
             (new Collection($this->pendingProcesses))
-                ->each(function ($pendingProcess) {
+                ->each(static function ($pendingProcess) {
                     if (! $pendingProcess instanceof PendingProcess) {
                         throw new InvalidArgumentException('Process pool must only contain pending processes.');
                     }
                 })
-                ->mapWithKeys(function ($pendingProcess, $key) use ($output) {
-                    return [$key => $pendingProcess->start(output: $output ? function ($type, $buffer) use ($key, $output) {
+                ->mapWithKeys(static function ($pendingProcess, $key) use ($output) {
+                    return [$key => $pendingProcess->start(output: $output ? static function ($type, $buffer) use ($key, $output) {
                         $output($type, $buffer, $key);
                     } : null)];
                 })

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -31,7 +31,7 @@ class ProcessPoolResults implements ArrayAccess
      */
     public function successful()
     {
-        return $this->collect()->every(fn ($p) => $p->successful());
+        return $this->collect()->every(static fn ($p) => $p->successful());
     }
 
     /**

--- a/src/Illuminate/Queue/BackgroundQueue.php
+++ b/src/Illuminate/Queue/BackgroundQueue.php
@@ -19,7 +19,7 @@ class BackgroundQueue extends SyncQueue
     public function push($job, $data = '', $queue = null)
     {
         Concurrency::driver('process')->defer(
-            fn () => \Illuminate\Support\Facades\Queue::connection('sync')->push($job, $data, $queue)
+            static fn () => \Illuminate\Support\Facades\Queue::connection('sync')->push($job, $data, $queue)
         );
     }
 }

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -64,11 +64,11 @@ class ClearCommand extends Command
         }
 
         $queues = (new Stringable($queueName))->explode(',')
-            ->map(fn ($queue) => trim($queue))
+            ->map(static fn ($queue) => trim($queue))
             ->filter()
             ->unique();
 
-        $count = $queues->reduce(fn ($carry, $name) => $carry + $queue->clear($name), 0);
+        $count = $queues->reduce(static fn ($carry, $name) => $carry + $queue->clear($name), 0);
 
         $this->components->info(
             sprintf('Cleared %s %s from the [%s] %s', $count, Str::plural('job', $count), $queues->implode(', '), Str::plural('queue', $queues->count()))

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -146,7 +146,7 @@ class ListFailedCommand extends Command
      */
     protected function displayFailedJobsAsJson(array $jobs)
     {
-        $this->output->writeln((new Collection($jobs))->values()->map(fn ($job) => [
+        $this->output->writeln((new Collection($jobs))->values()->map(static fn ($job) => [
             'id' => $job[0],
             'connection' => $job[1],
             'queue' => $job[2],

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -69,7 +69,7 @@ class MonitorCommand extends Command
         $queues = $this->parseQueues($this->argument('queues'));
 
         if ($this->option('json')) {
-            $this->output->writeln((new Collection($queues))->map(function ($queue) {
+            $this->output->writeln((new Collection($queues))->map(static function ($queue) {
                 return array_merge($queue, [
                     'status' => str_contains($queue['status'], 'ALERT') ? 'ALERT' : 'OK',
                 ]);

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -148,7 +148,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -164,7 +164,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '>', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -179,7 +179,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->where('queue', $this->getQueue($queue))
             ->whereNotNull('reserved_at')
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -193,7 +193,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -207,7 +207,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '>', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -220,7 +220,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         return $this->database->table($this->table)
             ->whereNotNull('reserved_at')
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
+            ->map(static fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -528,7 +528,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     {
         $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
 
-        $query->orWhere(function ($query) use ($expiration) {
+        $query->orWhere(static function ($query) use ($expiration) {
             $query->where('reserved_at', '<=', $expiration);
         });
     }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -72,7 +72,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     public function ids($queue = null)
     {
         return $this->getTable()
-            ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
+            ->when(! is_null($queue), static fn ($query) => $query->where('queue', $queue))
             ->orderBy('id', 'desc')
             ->pluck('id')
             ->all();
@@ -118,7 +118,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
      */
     public function flush($hours = null)
     {
-        $this->getTable()->when($hours, function ($query, $hours) {
+        $this->getTable()->when($hours, static function ($query, $hours) {
             $query->where('failed_at', '<=', Date::now()->subHours($hours));
         })->delete();
     }
@@ -154,8 +154,8 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     public function count($connection = null, $queue = null)
     {
         return $this->getTable()
-            ->when($connection, fn ($builder) => $builder->whereConnection($connection))
-            ->when($queue, fn ($builder) => $builder->whereQueue($queue))
+            ->when($connection, static fn ($builder) => $builder->whereConnection($connection))
+            ->when($queue, static fn ($builder) => $builder->whereQueue($queue))
             ->count();
     }
 

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -75,7 +75,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function ids($queue = null)
     {
         return $this->getTable()
-            ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
+            ->when(! is_null($queue), static fn ($query) => $query->where('queue', $queue))
             ->orderBy('id', 'desc')
             ->pluck('uuid')
             ->all();
@@ -88,7 +88,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->map(function ($record) {
+        return $this->getTable()->orderBy('id', 'desc')->get()->map(static function ($record) {
             $record->id = $record->uuid;
             unset($record->uuid);
 
@@ -131,7 +131,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      */
     public function flush($hours = null)
     {
-        $this->getTable()->when($hours, function ($query, $hours) {
+        $this->getTable()->when($hours, static function ($query, $hours) {
             $query->where('failed_at', '<=', Date::now()->subHours($hours));
         })->delete();
     }
@@ -167,8 +167,8 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function count($connection = null, $queue = null)
     {
         return $this->getTable()
-            ->when($connection, fn ($builder) => $builder->whereConnection($connection))
-            ->when($queue, fn ($builder) => $builder->whereQueue($queue))
+            ->when($connection, static fn ($builder) => $builder->whereConnection($connection))
+            ->when($queue, static fn ($builder) => $builder->whereQueue($queue))
             ->count();
     }
 

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -87,7 +87,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     public function ids($queue = null)
     {
         return (new Collection($this->all()))
-            ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))
+            ->when(! is_null($queue), static fn ($collect) => $collect->where('queue', $queue))
             ->pluck('id')
             ->all();
     }
@@ -110,8 +110,8 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
         ]);
 
         return (new Collection($results['Items']))
-            ->sortByDesc(fn ($result) => (int) $result['failed_at']['N'])
-            ->map(function ($result) {
+            ->sortByDesc(static fn ($result) => (int) $result['failed_at']['N'])
+            ->map(static function ($result) {
                 return (object) [
                     'id' => $result['uuid']['S'],
                     'connection' => $result['connection']['S'],

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -87,7 +87,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function ids($queue = null)
     {
         return (new Collection($this->all()))
-            ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))
+            ->when(! is_null($queue), static fn ($collect) => $collect->where('queue', $queue))
             ->pluck('id')
             ->all();
     }
@@ -111,7 +111,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function find($id)
     {
         return (new Collection($this->read()))
-            ->first(fn ($job) => $job->id === $id);
+            ->first(static fn ($job) => $job->id === $id);
     }
 
     /**
@@ -124,7 +124,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     {
         return $this->lock(function () use ($id) {
             $this->write($pruned = (new Collection($jobs = $this->read()))
-                ->reject(fn ($job) => $job->id === $id)
+                ->reject(static fn ($job) => $job->id === $id)
                 ->values()
                 ->all());
 
@@ -155,7 +155,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
             $jobs = $this->read();
 
             $this->write($prunedJobs = (new Collection($jobs))
-                ->reject(fn ($job) => $job->failed_at_timestamp <= $before->getTimestamp())
+                ->reject(static fn ($job) => $job->failed_at_timestamp <= $before->getTimestamp())
                 ->values()
                 ->all()
             );
@@ -180,7 +180,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
 
         return ($this->lockProviderResolver)()
             ->lock('laravel-failed-jobs', 5)
-            ->block(10, function () use ($callback) {
+            ->block(10, static function () use ($callback) {
                 return $callback();
             });
     }
@@ -235,7 +235,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
         }
 
         return (new Collection($this->read()))
-            ->filter(fn ($job) => $job->connection === ($connection ?? $job->connection) && $job->queue === ($queue ?? $job->queue))
+            ->filter(static fn ($job) => $job->connection === ($connection ?? $job->connection) && $job->queue === ($queue ?? $job->queue))
             ->count();
     }
 }

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -35,7 +35,7 @@ class FakeJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return once(fn () => (string) Str::uuid());
+        return once(static fn () => (string) Str::uuid());
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -163,7 +163,7 @@ class Listener
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
             $options->force ? '--force' : null,
-        ], function ($value) {
+        ], static function ($value) {
             return ! is_null($value);
         });
     }

--- a/src/Illuminate/Queue/MaxAttemptsExceededException.php
+++ b/src/Illuminate/Queue/MaxAttemptsExceededException.php
@@ -21,7 +21,7 @@ class MaxAttemptsExceededException extends RuntimeException
      */
     public static function forJob($job)
     {
-        return tap(new static($job->resolveName().' has been attempted too many times.'), function ($e) use ($job) {
+        return tap(new static($job->resolveName().' has been attempted too many times.'), static function ($e) use ($job) {
             $e->job = $job;
         });
     }

--- a/src/Illuminate/Queue/Middleware/FailOnException.php
+++ b/src/Illuminate/Queue/Middleware/FailOnException.php
@@ -37,7 +37,7 @@ class FailOnException
     protected function failForExceptions(array $exceptions)
     {
         return static function (Throwable $throwable) use ($exceptions) {
-            return array_any($exceptions, fn ($exception) => $throwable instanceof $exception);
+            return array_any($exceptions, static fn ($exception) => $throwable instanceof $exception);
         };
     }
 

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -164,7 +164,7 @@ class ThrottlesExceptions
     public function deleteWhen(callable|string $callback)
     {
         $this->deleteWhenCallbacks[] = is_string($callback)
-            ? fn (Throwable $e) => $e instanceof $callback
+            ? static fn (Throwable $e) => $e instanceof $callback
             : $callback;
 
         return $this;
@@ -179,7 +179,7 @@ class ThrottlesExceptions
     public function failWhen(callable|string $callback)
     {
         $this->failWhenCallbacks[] = is_string($callback)
-            ? fn (Throwable $e) => $e instanceof $callback
+            ? static fn (Throwable $e) => $e instanceof $callback
             : $callback;
 
         return $this;
@@ -193,7 +193,7 @@ class ThrottlesExceptions
      */
     protected function shouldDelete(Throwable $throwable): bool
     {
-        return array_any($this->deleteWhenCallbacks, fn ($callback) => call_user_func($callback, $throwable));
+        return array_any($this->deleteWhenCallbacks, static fn ($callback) => call_user_func($callback, $throwable));
     }
 
     /**
@@ -204,7 +204,7 @@ class ThrottlesExceptions
      */
     protected function shouldFail(Throwable $throwable): bool
     {
-        return array_any($this->failWhenCallbacks, fn ($callback) => call_user_func($callback, $throwable));
+        return array_any($this->failWhenCallbacks, static fn ($callback) => call_user_func($callback, $throwable));
     }
 
     /**
@@ -302,7 +302,7 @@ class ThrottlesExceptions
      */
     public function report(?callable $callback = null)
     {
-        $this->reportCallback = $callback ?? fn () => true;
+        $this->reportCallback = $callback ?? static fn () => true;
 
         return $this;
     }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -420,7 +420,7 @@ abstract class Queue
 
         return (new Collection($jobs))
             ->partition(fn ($job) => $this->shouldDispatchAfterCommit($job))
-            ->map(fn ($jobs) => $jobs->values()->all())
+            ->map(static fn ($jobs) => $jobs->values()->all())
             ->all();
     }
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -335,11 +335,11 @@ class QueueManager implements FactoryContract, MonitorContract
         }
 
         $states = $cache->many(
-            array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues)
+            array_map(static fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues)
         );
 
         return array_values(array_filter(
-            $queues, fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false
+            $queues, static fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false
         ));
     }
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -94,7 +94,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerConnection()
     {
-        $this->app->singleton('queue.connection', function ($app) {
+        $this->app->singleton('queue.connection', static function ($app) {
             return $app['queue']->connection();
         });
     }
@@ -120,7 +120,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerNullConnector($manager)
     {
-        $manager->addConnector('null', function () {
+        $manager->addConnector('null', static function () {
             return new NullConnector;
         });
     }
@@ -133,7 +133,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSyncConnector($manager)
     {
-        $manager->addConnector('sync', function () {
+        $manager->addConnector('sync', static function () {
             return new SyncConnector;
         });
     }
@@ -146,7 +146,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerDeferredConnector($manager)
     {
-        $manager->addConnector('deferred', function () {
+        $manager->addConnector('deferred', static function () {
             return new DeferredConnector;
         });
     }
@@ -159,7 +159,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerBackgroundConnector($manager)
     {
-        $manager->addConnector('background', function () {
+        $manager->addConnector('background', static function () {
             return new BackgroundConnector;
         });
     }
@@ -214,7 +214,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerBeanstalkdConnector($manager)
     {
-        $manager->addConnector('beanstalkd', function () {
+        $manager->addConnector('beanstalkd', static function () {
             return new BeanstalkdConnector;
         });
     }
@@ -227,7 +227,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSqsConnector($manager)
     {
-        $manager->addConnector('sqs', function () {
+        $manager->addConnector('sqs', static function () {
             return new SqsConnector;
         });
     }
@@ -244,7 +244,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return $this->app->isDownForMaintenance();
             };
 
-            $resetScope = function () use ($app) {
+            $resetScope = static function () use ($app) {
                 if (method_exists($app['log'], 'flushSharedContext')) {
                     $app['log']->flushSharedContext();
                 }
@@ -284,7 +284,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerListener()
     {
-        $this->app->singleton('queue.listener', function ($app) {
+        $this->app->singleton('queue.listener', static function ($app) {
             return new Listener($app->basePath());
         });
     }
@@ -296,7 +296,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerRoutes()
     {
-        $this->app->singleton('queue.routes', function () {
+        $this->app->singleton('queue.routes', static function () {
             return new QueueRoutes;
         });
     }
@@ -320,7 +320,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return new FileFailedJobProvider(
                     $config['path'] ?? $this->app->storagePath('framework/cache/failed-jobs.json'),
                     $config['limit'] ?? 100,
-                    fn () => $app['cache']->store('file'),
+                    static fn () => $app['cache']->store('file'),
                 );
             } elseif (isset($config['driver']) && $config['driver'] === 'dynamodb') {
                 return $this->dynamoFailedJobProvider($config);

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -166,7 +166,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->lrange($this->getQueueRedisKey($queue), 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
+            ->map(static fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -180,7 +180,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':delayed', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
+            ->map(static fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -194,7 +194,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $name = enum_value($queue) ?: $this->default;
 
         return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':reserved', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
+            ->map(static fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -236,7 +236,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         return (new Collection($this->getConnection()->keys('queues:*')))
             // Trim to ensure clusters get their braces removed...
-            ->map(fn ($key) => trim(Str::between($key, 'queues:', ':'), '{}'))
+            ->map(static fn ($key) => trim(Str::between($key, 'queues:', ':'), '{}'))
             ->unique()
             ->values();
     }
@@ -289,7 +289,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         } elseif ($connection instanceof PredisClusterConnection) {
             $connection->pipeline($bulk);
         } else {
-            $connection->pipeline(fn () => $connection->transaction($bulk));
+            $connection->pipeline(static fn () => $connection->transaction($bulk));
         }
     }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -94,7 +94,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         return (new $collectionClass(
             (new Collection($value->id))
-                ->map(fn ($id) => $collection[$id] ?? null)
+                ->map(static fn ($id) => $collection[$id] ?? null)
                 ->filter()
         ))->loadMissing($value->relations ?? []);
     }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -556,7 +556,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             return $options;
         }
 
-        $transformToString = fn ($value) => (string) $value;
+        $transformToString = static fn ($value) => (string) $value;
 
         // The message group ID is required for FIFO queues and is optional for
         // standard queues. Job objects contain a group ID. With string jobs

--- a/src/Illuminate/Queue/TimeoutExceededException.php
+++ b/src/Illuminate/Queue/TimeoutExceededException.php
@@ -12,7 +12,7 @@ class TimeoutExceededException extends MaxAttemptsExceededException
      */
     public static function forJob($job)
     {
-        return tap(new static($job->resolveName().' has timed out.'), function ($e) use ($job) {
+        return tap(new static($job->resolveName().' has timed out.'), static function ($e) use ($job) {
             $e->job = $job;
         });
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -431,7 +431,7 @@ class Worker
      */
     protected function getNextJob($connection, $queue)
     {
-        $popJobCallback = function ($queue, $index = 0) use ($connection) {
+        $popJobCallback = static function ($queue, $index = 0) use ($connection) {
             return $connection->pop($queue, $index);
         };
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -64,7 +64,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function mget(array $keys)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             return $value !== false ? $value : null;
         }, $this->command('mget', [$keys]));
     }
@@ -457,7 +457,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function subscribe($channels, Closure $callback)
     {
-        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
+        $this->client->subscribe((array) $channels, static function ($redis, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }
@@ -471,7 +471,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function psubscribe($channels, Closure $callback)
     {
-        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
+        $this->client->psubscribe((array) $channels, static function ($redis, $pattern, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -61,7 +61,7 @@ class PredisConnection extends Connection implements ConnectionContract
     protected function parseParametersForEvent(array $parameters)
     {
         return (new Collection($parameters))
-            ->transform(function ($parameter) {
+            ->transform(static function ($parameter) {
                 return $parameter instanceof ArrayableArgument
                     ? $parameter->toArray()
                     : $parameter;

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -111,7 +111,7 @@ class ConcurrencyLimiter
     {
         $prefix = $this->getPrefix();
 
-        $slots = array_map(function ($i) use ($prefix) {
+        $slots = array_map(static function ($i) use ($prefix) {
             return $prefix.$i;
         }, range(1, $this->maxLocks));
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -193,7 +193,7 @@ class RedisManager implements Factory
             $parsed['scheme'] = $driver;
         }
 
-        return array_filter($parsed, function ($key) {
+        return array_filter($parsed, static function ($key) {
             return $key !== 'driver';
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -15,13 +15,13 @@ class RedisServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('redis', function ($app) {
+        $this->app->singleton('redis', static function ($app) {
             $config = $app->make('config')->get('database.redis', []);
 
             return new RedisManager($app, Arr::pull($config, 'client', 'phpredis'), $config);
         });
 
-        $this->app->bind('redis.connection', function ($app) {
+        $this->app->bind('redis.connection', static function ($app) {
             return $app['redis']->connection();
         });
     }

--- a/src/Illuminate/Reflection/Reflector.php
+++ b/src/Illuminate/Reflection/Reflector.php
@@ -93,7 +93,7 @@ class Reflector
 
         do {
             $attributes[$reflectionClass->name] = new Collection(array_map(
-                fn (ReflectionAttribute $reflectionAttribute) => $reflectionAttribute->newInstance(),
+                static fn (ReflectionAttribute $reflectionAttribute) => $reflectionAttribute->newInstance(),
                 $reflectionClass->getAttributes($attribute)
             ));
         } while ($includeParents && false !== $reflectionClass = $reflectionClass->getParentClass());

--- a/src/Illuminate/Reflection/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Reflection/Traits/ReflectsClosures.php
@@ -50,7 +50,7 @@ trait ReflectsClosures
         $reflection = new ReflectionFunction($closure);
 
         $types = (new Collection($reflection->getParameters()))
-            ->mapWithKeys(function ($parameter) {
+            ->mapWithKeys(static function ($parameter) {
                 if ($parameter->isVariadic()) {
                     return [$parameter->getName() => null];
                 }
@@ -85,7 +85,7 @@ trait ReflectsClosures
         $reflection = new ReflectionFunction($closure);
 
         return (new Collection($reflection->getParameters()))
-            ->mapWithKeys(function ($parameter) {
+            ->mapWithKeys(static function ($parameter) {
                 if ($parameter->isVariadic()) {
                     return [$parameter->getName() => null];
                 }
@@ -117,8 +117,8 @@ trait ReflectsClosures
             : [$reflection->getReturnType()];
 
         return (new Collection($types))
-            ->reject(fn ($type) => $type->isBuiltin() || in_array($type->getName(), ['static', 'self']))
-            ->map(fn ($type) => $type->getName())
+            ->reject(static fn ($type) => $type->isBuiltin() || in_array($type->getName(), ['static', 'self']))
+            ->map(static fn ($type) => $type->getName())
             ->values()
             ->all();
     }

--- a/src/Illuminate/Reflection/helpers.php
+++ b/src/Illuminate/Reflection/helpers.php
@@ -36,7 +36,7 @@ if (! function_exists('lazy')) {
 
         $reflectionClass = new ReflectionClass($class);
 
-        $instance = $reflectionClass->newLazyGhost(function ($instance) use ($callback) {
+        $instance = $reflectionClass->newLazyGhost(static function ($instance) use ($callback) {
             $result = $callback($instance);
 
             if (is_array($result)) {
@@ -86,7 +86,7 @@ if (! function_exists('proxy')) {
 
         $reflectionClass = new ReflectionClass($class);
 
-        $proxy = $reflectionClass->newLazyProxy(function () use ($callback, $eager, &$proxy) {
+        $proxy = $reflectionClass->newLazyProxy(static function () use ($callback, $eager, &$proxy) {
             $instance = $callback($proxy, $eager);
 
             return $instance;

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -107,7 +107,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function getRouteForMethods($request, array $methods)
     {
         if ($request->isMethod('OPTIONS')) {
-            return (new Route('OPTIONS', $request->path(), function () use ($methods) {
+            return (new Route('OPTIONS', $request->path(), static function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
             }))->bind($request);
         }

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -291,7 +291,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
     public function getRoutesByName()
     {
         return (new Collection($this->getRoutes()))
-            ->keyBy(function (Route $route) {
+            ->keyBy(static function (Route $route) {
                 return $route->getName();
             })
             ->all();
@@ -309,8 +309,8 @@ class CompiledRouteCollection extends AbstractRouteCollection
         }
 
         return $this->routeNamesByMethod = (new Collection($this->attributes))
-            ->groupBy(fn (array $attributes) => $attributes['methods'], preserveKeys: true)
-            ->map(fn (Collection $group) => $group->keys()->all())
+            ->groupBy(static fn (array $attributes) => $attributes['methods'], preserveKeys: true)
+            ->map(static fn (Collection $group) => $group->keys()->all())
             ->all();
     }
 
@@ -326,10 +326,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
         }
 
         return $this->routeNameByAction = (new Collection($this->attributes))
-            ->map(fn (array $attributes) => isset($attributes['action']['controller'])
+            ->map(static fn (array $attributes) => isset($attributes['action']['controller'])
                 ? trim($attributes['action']['controller'], '\\')
                 : ($attributes['action']['uses'] ?? null))
-            ->filter(fn ($action) => is_string($action))
+            ->filter(static fn ($action) => is_string($action))
             ->reverse()
             ->flip()
             ->all();

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -75,7 +75,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
         }
 
         return (new Collection($controller->getMiddleware()))
-            ->reject(fn ($data) => static::methodExcludedByOptions($method, $data['options']))
+            ->reject(static fn ($data) => static::methodExcludedByOptions($method, $data['options']))
             ->pluck('middleware')
             ->all();
     }

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -75,7 +75,7 @@ trait CreatesRegularExpressionRouteConstraints
         return $this->assignExpressionToParameters(
             $parameters,
             (new Collection($values))
-                ->map(fn ($value) => enum_value($value))
+                ->map(static fn ($value) => enum_value($value))
                 ->implode('|')
         );
     }
@@ -90,7 +90,7 @@ trait CreatesRegularExpressionRouteConstraints
     protected function assignExpressionToParameters($parameters, $expression)
     {
         return $this->where(Collection::wrap($parameters)
-            ->mapWithKeys(fn ($parameter) => [$parameter => $expression])
+            ->mapWithKeys(static fn ($parameter) => [$parameter => $expression])
             ->all());
     }
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -129,7 +129,7 @@ class ThrottleRequests
         return $this->handleRequest(
             $request,
             $next,
-            Collection::wrap($limiterResponse)->map(function ($limit) use ($limiterName) {
+            Collection::wrap($limiterResponse)->map(static function ($limit) use ($limiterName) {
                 return (object) [
                     'key' => self::$shouldHashKeys ? md5($limiterName.$limit->key) : $limiterName.':'.$limit->key,
                     'maxAttempts' => $limit->maxAttempts,

--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -104,7 +104,7 @@ trait ResolvesRouteDependencies
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return ! is_null(Arr::first($parameters, fn ($value) => $value instanceof $class));
+        return ! is_null(Arr::first($parameters, static fn ($value) => $value instanceof $class));
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -213,7 +213,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route parameters, which should be the base resources.
-        $callback = function ($me) use ($name, $controller, $options) {
+        $callback = static function ($me) use ($name, $controller, $options) {
             $me->resource($name, $controller, $options);
         };
 
@@ -235,7 +235,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route parameters, which should be the base resources.
-        $callback = function ($me) use ($name, $controller, $options) {
+        $callback = static function ($me) use ($name, $controller, $options) {
             $me->singleton($name, $controller, $options);
         };
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -130,7 +130,7 @@ class ResponseFactory implements FactoryContract
      */
     public function eventStream(Closure $callback, array $headers = [], StreamedEvent|string|null $endStreamWith = '</stream>')
     {
-        return $this->stream(function () use ($callback, $endStreamWith) {
+        return $this->stream(static function () use ($callback, $endStreamWith) {
             try {
                 foreach ($callback() as $message) {
                     if (connection_aborted()) {
@@ -204,10 +204,10 @@ class ResponseFactory implements FactoryContract
                 ))->setCallback($callback);
             }
 
-            return new StreamedResponse(function () use ($callback) {
+            return new StreamedResponse(static function () use ($callback) {
                 foreach ($callback() as $chunk) {
                     echo $chunk;
-                    when(ob_get_level() > 0, fn () => ob_flush());
+                    when(ob_get_level() > 0, static fn () => ob_flush());
                     flush();
                 }
             }, $status, array_merge($headers, ['X-Accel-Buffering' => 'no']));
@@ -243,7 +243,7 @@ class ResponseFactory implements FactoryContract
      */
     public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
     {
-        $withWrappedException = function () use ($callback) {
+        $withWrappedException = static function () use ($callback) {
             try {
                 $callback();
             } catch (Throwable $e) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -512,7 +512,7 @@ class Route
      */
     public function parametersWithoutNulls()
     {
-        return array_filter($this->parameters(), fn ($p) => ! is_null($p));
+        return array_filter($this->parameters(), static fn ($p) => ! is_null($p));
     }
 
     /**
@@ -534,7 +534,7 @@ class Route
     {
         preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
 
-        return array_map(fn ($m) => trim($m, '?'), $matches[1]);
+        return array_map(static fn ($m) => trim($m, '?'), $matches[1]);
     }
 
     /**
@@ -923,7 +923,7 @@ class Route
             return false;
         }
 
-        return array_any($patterns, fn ($pattern) => Str::is($pattern, $routeName));
+        return array_any($patterns, static fn ($pattern) => Str::is($pattern, $routeName));
     }
 
     /**
@@ -1154,12 +1154,12 @@ class Route
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
     {
         return (new Collection($class::middleware()))
-            ->map(function ($middleware) {
+            ->map(static function ($middleware) {
                 return $middleware instanceof Middleware
                     ? $middleware
                     : new Middleware($middleware);
             })
-            ->reject(function ($middleware) use ($method) {
+            ->reject(static function ($middleware) use ($method) {
                 return static::methodExcludedByOptions(
                     $method, ['only' => $middleware->only, 'except' => $middleware->except],
                 );
@@ -1203,7 +1203,7 @@ class Route
 
         return $attributes->merge(
             $reflectionMethod->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF)
-        )->map(function (ReflectionAttribute $attribute) use ($method) {
+        )->map(static function (ReflectionAttribute $attribute) use ($method) {
             $instance = $attribute->newInstance();
 
             return static::methodExcludedByOptions(
@@ -1268,7 +1268,7 @@ class Route
 
         return $attributes->merge(
             $reflectionMethod->getAttributes(WithoutMiddleware::class, ReflectionAttribute::IS_INSTANCEOF)
-        )->map(function (ReflectionAttribute $attribute) use ($method) {
+        )->map(static function (ReflectionAttribute $attribute) use ($method) {
             $instance = $attribute->newInstance();
 
             return static::methodExcludedByOptions(

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -60,7 +60,7 @@ class RouteAction
      */
     protected static function missingAction($uri)
     {
-        return ['uses' => function () use ($uri) {
+        return ['uses' => static function () use ($uri) {
             throw new LogicException("Route for [{$uri}] has no action.");
         }];
     }
@@ -73,7 +73,7 @@ class RouteAction
      */
     protected static function findCallable(array $action)
     {
-        return Arr::first($action, function ($value, $key) {
+        return Arr::first($action, static function ($value, $key) {
             return Reflector::isCallable($value) && is_numeric($key);
         });
     }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -33,7 +33,7 @@ class RouteBinding
      */
     protected static function createClassBinding($container, $binding)
     {
-        return function ($value, $route) use ($container, $binding) {
+        return static function ($value, $route) use ($container, $binding) {
             // If the binding has an @ sign, we will assume it's being used to delimit
             // the class name from the bind method name. This allows for bindings
             // to run multiple bind methods in a single class for convenience.
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value, $route = null) use ($container, $class, $callback) {
+        return static function ($value, $route = null) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -88,7 +88,7 @@ class RouteParameterBinder
 
         $parameters = array_intersect_key($matches, array_flip($parameterNames));
 
-        return array_filter($parameters, function ($value) {
+        return array_filter($parameters, static function ($value) {
             return is_string($value) && $value !== '';
         });
     }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -33,8 +33,8 @@ class RouteSignatureParameters
             : (new ReflectionFunction($callback))->getParameters();
 
         return match (true) {
-            ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
+            ! empty($conditions['subClass']) => array_filter($parameters, static fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, static fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -293,13 +293,13 @@ class RouteUrlGenerator
         // Any remaining values in $parameters are unnamed query string parameters...
         $parameters = array_merge($namedParameters, $namedQueryParameters, $parameters);
 
-        $parameters = Collection::wrap($parameters)->map(function ($value, $key) use ($route) {
+        $parameters = Collection::wrap($parameters)->map(static function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;
         })->all();
 
-        array_walk_recursive($parameters, function (&$item) {
+        array_walk_recursive($parameters, static function (&$item) {
             $item = enum_value($item);
         });
 
@@ -334,7 +334,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/\{.*?\}/', static function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -792,7 +792,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function runRoute(Request $request, Route $route)
     {
-        $request->setRouteResolver(fn () => $route);
+        $request->setRouteResolver(static fn () => $route);
 
         $this->events->dispatch(new RouteMatched($route, $request));
 
@@ -856,7 +856,7 @@ class Router implements BindingRegistrar, RegistrarContract
             ->flatten()
             ->when(
                 ! empty($excluded),
-                fn ($collection) => $collection->reject(function ($name) use ($excluded) {
+                static fn ($collection) => $collection->reject(static function ($name) use ($excluded) {
                     if ($name instanceof Closure) {
                         return false;
                     }
@@ -872,7 +872,7 @@ class Router implements BindingRegistrar, RegistrarContract
                     $reflection = new ReflectionClass($name);
 
                     return (new Collection($excluded))->contains(
-                        fn ($exclude) => class_exists($exclude) && $reflection->isSubclassOf($exclude)
+                        static fn ($exclude) => class_exists($exclude) && $reflection->isSubclassOf($exclude)
                     );
                 })
             )

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -40,7 +40,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRouter()
     {
-        $this->app->singleton('router', function ($app) {
+        $this->app->singleton('router', static function ($app) {
             return new Router($app['events'], $app);
         });
     }
@@ -84,7 +84,7 @@ class RoutingServiceProvider extends ServiceProvider
             // If the route collection is "rebound", for example, when the routes stay
             // cached for the application, we will need to rebind the routes on the
             // URL generator instance so it has the latest version of the routes.
-            $app->rebinding('routes', function ($app, $routes) {
+            $app->rebinding('routes', static function ($app, $routes) {
                 $app['url']->setRoutes($routes);
             });
 
@@ -99,7 +99,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function requestRebinder()
     {
-        return function ($app, $request) {
+        return static function ($app, $request) {
             $app['url']->setRequest($request);
         };
     }
@@ -111,7 +111,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRedirector()
     {
-        $this->app->singleton('redirect', function ($app) {
+        $this->app->singleton('redirect', static function ($app) {
             $redirector = new Redirector($app['url']);
 
             // If the session is set on the application instance, we'll inject it into
@@ -134,7 +134,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind(ServerRequestInterface::class, function ($app) {
+        $this->app->bind(ServerRequestInterface::class, static function ($app) {
             if (class_exists(PsrHttpFactory::class)) {
                 $illuminateRequest = $app->make('request');
                 $request = (new PsrHttpFactory)->createRequest($illuminateRequest);
@@ -161,7 +161,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrResponse()
     {
-        $this->app->bind(ResponseInterface::class, function () {
+        $this->app->bind(ResponseInterface::class, static function () {
             if (class_exists(PsrHttpFactory::class)) {
                 return (new PsrHttpFactory)->createResponse(new Response);
             }
@@ -177,7 +177,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton(ResponseFactoryContract::class, function ($app) {
+        $this->app->singleton(ResponseFactoryContract::class, static function ($app) {
             return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
         });
     }
@@ -189,7 +189,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerCallableDispatcher()
     {
-        $this->app->singleton(CallableDispatcherContract::class, function ($app) {
+        $this->app->singleton(CallableDispatcherContract::class, static function ($app) {
             return new CallableDispatcher($app);
         });
     }
@@ -201,7 +201,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerControllerDispatcher()
     {
-        $this->app->singleton(ControllerDispatcherContract::class, function ($app) {
+        $this->app->singleton(ControllerDispatcherContract::class, static function ($app) {
             return new ControllerDispatcher($app);
         });
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -470,7 +470,7 @@ class UrlGenerator implements UrlGeneratorContract
             : '/'.$request->path();
 
         $queryString = (new Stringable((string) ($request->server->get('VAPOR_RAW_QUERY_STRING') ?? $request->server->get('QUERY_STRING'))))->explode('&')
-            ->reject(function ($parameter) use ($ignoreQuery) {
+            ->reject(static function ($parameter) use ($ignoreQuery) {
                 $parameter = Str::before($parameter, '=');
 
                 if ($parameter === 'signature') {
@@ -491,7 +491,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $keys = is_array($keys) ? $keys : [$keys];
 
-        return array_any($keys, fn ($key) => hash_equals(
+        return array_any($keys, static fn ($key) => hash_equals(
             hash_hmac('sha256', $original, $key),
             $signature
         ));
@@ -825,7 +825,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function pathFormatter()
     {
-        return $this->formatPathUsing ?: function ($path) {
+        return $this->formatPathUsing ?: static function ($path) {
             return $path;
         };
     }

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -31,7 +31,7 @@ class ViewController extends Controller
      */
     public function __invoke(...$args)
     {
-        $routeParameters = array_filter($args, function ($key) {
+        $routeParameters = array_filter($args, static function ($key) {
             return ! in_array($key, ['view', 'data', 'status', 'headers']);
         }, ARRAY_FILTER_USE_KEY);
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -140,7 +140,7 @@ class StartSession
      */
     protected function startSession(Request $request, $session)
     {
-        return tap($session, function ($session) use ($request) {
+        return tap($session, static function ($session) use ($request) {
             $session->setRequestOnHandler($request);
 
             $session->start();
@@ -155,7 +155,7 @@ class StartSession
      */
     public function getSession(Request $request)
     {
-        return tap($this->manager->driver(), function ($session) use ($request) {
+        return tap($this->manager->driver(), static function ($session) use ($request) {
             $session->setId($request->cookies->get($session->getName()));
         });
     }

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -19,8 +19,8 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton(StartSession::class, function ($app) {
-            return new StartSession($app->make(SessionManager::class), function () use ($app) {
+        $this->app->singleton(StartSession::class, static function ($app) {
+            return new StartSession($app->make(SessionManager::class), static function () use ($app) {
                 return $app->make(CacheFactory::class);
             });
         });
@@ -33,7 +33,7 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionManager()
     {
-        $this->app->singleton('session', function ($app) {
+        $this->app->singleton('session', static function ($app) {
             return new SessionManager($app);
         });
     }
@@ -45,7 +45,7 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionDriver()
     {
-        $this->app->singleton('session.store', function ($app) {
+        $this->app->singleton('session.store', static function ($app) {
             // First, we will create the session manager which is responsible for the
             // creation of the various session drivers when they are needed by the
             // application instance, and will resolve them on a lazy load basis.

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -584,7 +584,7 @@ class Store implements Session
      */
     public function forget($keys)
     {
-        Arr::forget($this->attributes, (new Collection((array) $keys))->map(fn ($key) => enum_value($key))->all());
+        Arr::forget($this->attributes, (new Collection((array) $keys))->map(static fn ($key) => enum_value($key))->all());
     }
 
     /**

--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -18,8 +18,8 @@ class Benchmark
      */
     public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|float
     {
-        return Collection::wrap($benchmarkables)->map(function ($callback) use ($iterations) {
-            return Collection::range(1, $iterations)->map(function () use ($callback) {
+        return Collection::wrap($benchmarkables)->map(static function ($callback) use ($iterations) {
+            return Collection::range(1, $iterations)->map(static function () use ($callback) {
                 gc_collect_cycles();
 
                 $start = hrtime(true);
@@ -30,8 +30,8 @@ class Benchmark
             })->average();
         })->when(
             $benchmarkables instanceof Closure,
-            fn ($c) => $c->first(),
-            fn ($c) => $c->all(),
+            static fn ($c) => $c->first(),
+            static fn ($c) => $c->all(),
         );
     }
 
@@ -64,8 +64,8 @@ class Benchmark
     public static function dd(Closure|array $benchmarkables, int $iterations = 1): never
     {
         $result = (new Collection(static::measure(Arr::wrap($benchmarkables), $iterations)))
-            ->map(fn ($average) => number_format($average, 3).'ms')
-            ->when($benchmarkables instanceof Closure, fn ($c) => $c->first(), fn ($c) => $c->all());
+            ->map(static fn ($average) => number_format($average, 3).'ms')
+            ->when($benchmarkables instanceof Closure, static fn ($c) => $c->first(), static fn ($c) => $c->all());
 
         dd($result);
     }

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -68,14 +68,14 @@ class Composer
             'require',
             ...$packages,
         ]))
-            ->when($dev, function ($command) {
+            ->when($dev, static function ($command) {
                 $command->push('--dev');
             })->all();
 
         return 0 === $this->getProcess($command, ['COMPOSER_MEMORY_LIMIT' => '-1'])
             ->run(
                 $output instanceof OutputInterface
-                    ? function ($type, $line) use ($output) {
+                    ? static function ($type, $line) use ($output) {
                         $output->write('    '.$line);
                     } : $output
             );
@@ -97,14 +97,14 @@ class Composer
             'remove',
             ...$packages,
         ]))
-            ->when($dev, function ($command) {
+            ->when($dev, static function ($command) {
                 $command->push('--dev');
             })->all();
 
         return 0 === $this->getProcess($command, ['COMPOSER_MEMORY_LIMIT' => '-1'])
             ->run(
                 $output instanceof OutputInterface
-                    ? function ($type, $line) use ($output) {
+                    ? static function ($type, $line) use ($output) {
                         $output->write('    '.$line);
                     } : $output
             );

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -67,7 +67,7 @@ class ConfigurationUrlParser
             'port' => $url['port'] ?? null,
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
-        ], fn ($value) => ! is_null($value));
+        ], static fn ($value) => ! is_null($value));
     }
 
     /**

--- a/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
@@ -33,7 +33,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
      */
     public function invoke(): void
     {
-        $this->invokeWhen(fn () => true);
+        $this->invokeWhen(static fn () => true);
     }
 
     /**
@@ -44,7 +44,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
      */
     public function invokeWhen(?Closure $when = null): void
     {
-        $when ??= fn () => true;
+        $when ??= static fn () => true;
 
         $this->forgetDuplicates();
 
@@ -66,7 +66,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     public function forget(string $name): void
     {
         $this->callbacks = (new Collection($this->callbacks))
-            ->reject(fn ($callback) => $callback->name === $name)
+            ->reject(static fn ($callback) => $callback->name === $name)
             ->values()
             ->all();
     }
@@ -80,7 +80,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     {
         $this->callbacks = (new Collection($this->callbacks))
             ->reverse()
-            ->unique(fn ($c) => $c->name)
+            ->unique(static fn ($c) => $c->name)
             ->reverse()
             ->values()
             ->all();

--- a/src/Illuminate/Support/EncodedHtmlString.php
+++ b/src/Illuminate/Support/EncodedHtmlString.php
@@ -72,7 +72,7 @@ class EncodedHtmlString extends HtmlString
             $value = $value->value;
         }
 
-        return (static::$encodeUsingFactory ?? function ($value, $doubleEncode) {
+        return (static::$encodeUsingFactory ?? static function ($value, $doubleEncode) {
             return static::convert($value, doubleEncode: $doubleEncode);
         })($value, $this->doubleEncode);
     }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -101,7 +101,7 @@ class Env
      */
     public static function get($key, $default = null)
     {
-        return self::getOption($key)->getOrCall(fn () => value($default));
+        return self::getOption($key)->getOrCall(static fn () => value($default));
     }
 
     /**
@@ -252,7 +252,7 @@ class Env
     protected static function getOption($key)
     {
         return Option::fromValue(static::getRepository()->get($key))
-            ->map(function ($value) {
+            ->map(static function ($value) {
                 switch (strtolower($value)) {
                     case 'true':
                     case '(true)':

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -75,7 +75,7 @@ class Bus extends Facade
             ? static::getFacadeRoot()->dispatcher
             : static::getFacadeRoot();
 
-        return tap(new BusFake($actualDispatcher, $jobsToFake, $batchRepository), function ($fake) {
+        return tap(new BusFake($actualDispatcher, $jobsToFake, $batchRepository), static function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -98,12 +98,12 @@ class Cache extends Facade
             $instance = static::getFacadeRoot();
 
             if ($class && $instance) {
-                return tap(Mockery::spy($instance)->makePartial(), function ($spy) {
+                return tap(Mockery::spy($instance)->makePartial(), static function ($spy) {
                     static::swap($spy);
                 });
             }
 
-            return tap($class ? Mockery::spy($class) : Mockery::spy(), function ($spy) {
+            return tap($class ? Mockery::spy($class) : Mockery::spy(), static function ($spy) {
                 static::swap($spy);
             });
         }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -57,7 +57,7 @@ class Event extends Facade
             ? static::getFacadeRoot()->dispatcher
             : static::getFacadeRoot();
 
-        return tap(new EventFake($actualDispatcher, $eventsToFake), function ($fake) {
+        return tap(new EventFake($actualDispatcher, $eventsToFake), static function ($fake) {
             static::swap($fake);
 
             Model::setEventDispatcher($fake);
@@ -74,7 +74,7 @@ class Event extends Facade
     public static function fakeExcept($eventsToAllow)
     {
         return static::fake([
-            function ($eventName) use ($eventsToAllow) {
+            static function ($eventName) use ($eventsToAllow) {
                 return ! in_array($eventName, (array) $eventsToAllow);
             },
         ]);

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -58,7 +58,7 @@ class Exceptions extends Facade
             ? static::getFacadeRoot()->handler()
             : static::getFacadeRoot();
 
-        return tap(new ExceptionHandlerFake($exceptionHandler, Arr::wrap($exceptions)), function ($fake) {
+        return tap(new ExceptionHandlerFake($exceptionHandler, Arr::wrap($exceptions)), static function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -53,7 +53,7 @@ abstract class Facade
             $callback(static::getFacadeRoot(), static::$app);
         }
 
-        static::$app->afterResolving($accessor, function ($service, $app) use ($callback) {
+        static::$app->afterResolving($accessor, static function ($service, $app) use ($callback) {
             $callback($service, $app);
         });
     }
@@ -68,7 +68,7 @@ abstract class Facade
         if (! static::isMock()) {
             $class = static::getMockableClass();
 
-            return tap($class ? Mockery::spy($class) : Mockery::spy(), function ($spy) {
+            return tap($class ? Mockery::spy($class) : Mockery::spy(), static function ($spy) {
                 static::swap($spy);
             });
         }
@@ -129,7 +129,7 @@ abstract class Facade
      */
     protected static function createFreshMockInstance()
     {
-        return tap(static::createMock(), function ($mock) {
+        return tap(static::createMock(), static function ($mock) {
             static::swap($mock);
 
             $mock->shouldAllowMockingProtectedMethods();

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -127,7 +127,7 @@ class Http extends Facade
      */
     public static function fake($callback = null)
     {
-        return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
+        return tap(static::getFacadeRoot(), static function ($fake) use ($callback) {
             static::swap($fake->fake($callback));
         });
     }
@@ -140,7 +140,7 @@ class Http extends Facade
      */
     public static function fakeSequence(string $urlPattern = '*')
     {
-        $fake = tap(static::getFacadeRoot(), function ($fake) {
+        $fake = tap(static::getFacadeRoot(), static function ($fake) {
             static::swap($fake);
         });
 
@@ -155,7 +155,7 @@ class Http extends Facade
      */
     public static function preventStrayRequests($prevent = true)
     {
-        return tap(static::getFacadeRoot(), function ($fake) use ($prevent) {
+        return tap(static::getFacadeRoot(), static function ($fake) use ($prevent) {
             static::swap($fake->preventStrayRequests($prevent));
         });
     }
@@ -169,7 +169,7 @@ class Http extends Facade
      */
     public static function stubUrl($url, $callback)
     {
-        return tap(static::getFacadeRoot(), function ($fake) use ($url, $callback) {
+        return tap(static::getFacadeRoot(), static function ($fake) use ($url, $callback) {
             static::swap($fake->stubUrl($url, $callback));
         });
     }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -76,7 +76,7 @@ class Mail extends Facade
             ? static::getFacadeRoot()->manager
             : static::getFacadeRoot();
 
-        return tap(new MailFake($actualMailManager), function ($fake) {
+        return tap(new MailFake($actualMailManager), static function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -52,7 +52,7 @@ class Notification extends Facade
      */
     public static function fake()
     {
-        return tap(new NotificationFake, function ($fake) {
+        return tap(new NotificationFake, static function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -68,7 +68,7 @@ class Process extends Facade
      */
     public static function fake(Closure|array|null $callback = null)
     {
-        return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
+        return tap(static::getFacadeRoot(), static function ($fake) use ($callback) {
             static::swap($fake->fake($callback));
         });
     }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -114,10 +114,10 @@ class Queue extends Facade
     public static function fake($jobsToFake = [])
     {
         $actualQueueManager = static::isFake()
-            ? tap(static::getFacadeRoot(), fn ($fake) => $fake->releaseUniqueJobLocks())->queue
+            ? tap(static::getFacadeRoot(), static fn ($fake) => $fake->releaseUniqueJobLocks())->queue
             : static::getFacadeRoot();
 
-        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), function ($fake) {
+        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), static function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -114,12 +114,12 @@ class Storage extends Facade
             self::buildDiskConfiguration($disk, $config, root: $root)
         ));
 
-        return tap($fake, function ($fake) {
-            $fake->buildTemporaryUrlsUsing(function ($path, $expiration) {
+        return tap($fake, static function ($fake) {
+            $fake->buildTemporaryUrlsUsing(static function ($path, $expiration) {
                 return URL::to($path.'?expiration='.$expiration->getTimestamp());
             });
 
-            $fake->buildTemporaryUploadUrlsUsing(function ($path, $expiration) {
+            $fake->buildTemporaryUploadUrlsUsing(static function ($path, $expiration) {
                 return ['url' => URL::to($path.'?expiration='.$expiration->getTimestamp()), 'headers' => []];
             });
         });

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -143,8 +143,8 @@ class Lottery
     protected function runCallback(...$args)
     {
         return $this->wins()
-            ? ($this->winner ?? fn () => true)(...$args)
-            : ($this->loser ?? fn () => false)(...$args);
+            ? ($this->winner ?? static fn () => true)(...$args)
+            : ($this->loser ?? static fn () => false)(...$args);
     }
 
     /**
@@ -164,7 +164,7 @@ class Lottery
      */
     protected static function resultFactory()
     {
-        return static::$resultFactory ?? fn ($chances, $outOf) => $outOf === null
+        return static::$resultFactory ?? static fn ($chances, $outOf) => $outOf === null
             ? random_int(0, PHP_INT_MAX) / PHP_INT_MAX <= $chances
             : random_int(1, $outOf) <= $chances;
     }
@@ -177,7 +177,7 @@ class Lottery
      */
     public static function alwaysWin($callback = null)
     {
-        self::setResultFactory(fn () => true);
+        self::setResultFactory(static fn () => true);
 
         if ($callback === null) {
             return;
@@ -196,7 +196,7 @@ class Lottery
      */
     public static function alwaysLose($callback = null)
     {
-        self::setResultFactory(fn () => false);
+        self::setResultFactory(static fn () => false);
 
         if ($callback === null) {
             return;
@@ -230,7 +230,7 @@ class Lottery
     {
         $next = 0;
 
-        $whenMissing ??= function ($chances, $outOf) use (&$next) {
+        $whenMissing ??= static function ($chances, $outOf) use (&$next) {
             $factoryCache = static::$resultFactory;
 
             static::$resultFactory = null;
@@ -244,7 +244,7 @@ class Lottery
             return $result;
         };
 
-        static::setResultFactory(function ($chances, $outOf) use (&$next, $sequence, $whenMissing) {
+        static::setResultFactory(static function ($chances, $outOf) use (&$next, $sequence, $whenMissing) {
             if (array_key_exists($next, $sequence)) {
                 return $sequence[$next++];
             }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -211,7 +211,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     protected function getMessagesForWildcardKey($key, $format)
     {
         return (new Collection($this->messages))
-            ->filter(fn ($messages, $messageKey) => Str::is($key, $messageKey))
+            ->filter(static fn ($messages, $messageKey) => Str::is($key, $messageKey))
             ->map(function ($messages, $messageKey) use ($format) {
                 return $this->transform($messages, $this->checkFormat($format), $messageKey);
             })
@@ -276,7 +276,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
         }
 
         return (new Collection((array) $messages))
-            ->map(function ($message) use ($format, $messageKey) {
+            ->map(static function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -13,7 +13,7 @@ class Bun implements NodePackageManager
      */
     public static function matches(): bool
     {
-        return array_any(['bun.lock', 'bun.lockb'], fn ($lockFile) => file_exists(getcwd().'/'.$lockFile));
+        return array_any(['bun.lock', 'bun.lockb'], static fn ($lockFile) => file_exists(getcwd().'/'.$lockFile));
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -234,7 +234,7 @@ abstract class ServiceProvider
      */
     protected function loadViewComponentsAs($prefix, array $components)
     {
-        $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
+        $this->callAfterResolving(BladeCompiler::class, static function ($blade) use ($prefix, $components) {
             foreach ($components as $alias => $component) {
                 $blade->component($component, is_string($alias) ? $alias : null, $prefix);
             }
@@ -250,7 +250,7 @@ abstract class ServiceProvider
      */
     protected function loadTranslationsFrom($path, $namespace = null)
     {
-        $this->callAfterResolving('translator', fn ($translator) => is_null($namespace)
+        $this->callAfterResolving('translator', static fn ($translator) => is_null($namespace)
             ? $translator->addPath($path)
             : $translator->addNamespace($namespace, $path));
     }
@@ -263,7 +263,7 @@ abstract class ServiceProvider
      */
     protected function loadJsonTranslationsFrom($path)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path) {
+        $this->callAfterResolving('translator', static function ($translator) use ($path) {
             $translator->addJsonPath($path);
         });
     }
@@ -276,7 +276,7 @@ abstract class ServiceProvider
      */
     protected function loadMigrationsFrom($paths)
     {
-        $this->callAfterResolving('migrator', function ($migrator) use ($paths) {
+        $this->callAfterResolving('migrator', static function ($migrator) use ($paths) {
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
             }
@@ -293,7 +293,7 @@ abstract class ServiceProvider
      */
     protected function loadFactoriesFrom($paths)
     {
-        $this->callAfterResolving(ModelFactory::class, function ($factory) use ($paths) {
+        $this->callAfterResolving(ModelFactory::class, static function ($factory) use ($paths) {
             foreach ((array) $paths as $path) {
                 $factory->load($path);
             }
@@ -394,7 +394,7 @@ abstract class ServiceProvider
             return $paths;
         }
 
-        return (new Collection(static::$publishes))->reduce(function ($paths, $p) {
+        return (new Collection(static::$publishes))->reduce(static function ($paths, $p) {
             return array_merge($paths, $p);
         }, []);
     }
@@ -475,7 +475,7 @@ abstract class ServiceProvider
     {
         $commands = is_array($commands) ? $commands : func_get_args();
 
-        Artisan::starting(function ($artisan) use ($commands) {
+        Artisan::starting(static function ($artisan) use ($commands) {
             $artisan->resolveCommands($commands);
         });
     }
@@ -602,7 +602,7 @@ abstract class ServiceProvider
             ->unique()
             ->sort()
             ->values()
-            ->map(fn ($p) => '    '.$p.'::class,')
+            ->map(static fn ($p) => '    '.$p.'::class,')
             ->implode(PHP_EOL);
 
         $content = '<?php
@@ -645,9 +645,9 @@ return [
             ->when(
                 $strict,
                 static fn (Collection $providerCollection) => $providerCollection->diff($providersToRemove),
-                static fn (Collection $providerCollection) => $providerCollection->reject(fn (string $p) => Str::contains($p, $providersToRemove))
+                static fn (Collection $providerCollection) => $providerCollection->reject(static fn (string $p) => Str::contains($p, $providersToRemove))
             )
-            ->map(fn ($p) => '    '.$p.'::class,')
+            ->map(static fn ($p) => '    '.$p.'::class,')
             ->implode(PHP_EOL);
 
         $content = '<?php

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -334,7 +334,7 @@ class Sleep
 
         $seconds = (int) $remaining->totalSeconds;
 
-        $while = $this->while ?: function () {
+        $while = $this->while ?: static function () {
             static $return = [true, false];
 
             return array_shift($return);
@@ -437,7 +437,7 @@ class Sleep
 
             (new Collection($sequence))
                 ->zip(static::$sequence)
-                ->eachSpread(function (?Sleep $expected, CarbonInterval $actual) {
+                ->eachSpread(static function (?Sleep $expected, CarbonInterval $actual) {
                     if ($expected === null) {
                         return;
                     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -406,7 +406,7 @@ class Str
 
         return array_reduce(
             $characters,
-            fn ($carry, $character) => preg_replace('/'.preg_quote($character, '/').'+/u', $character, $carry),
+            static fn ($carry, $character) => preg_replace('/'.preg_quote($character, '/').'+/u', $character, $carry),
             $string
         );
     }
@@ -471,15 +471,15 @@ class Str
         $start = ltrim($matches[1]);
 
         $start = (new Stringable(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8')))->ltrim()->unless(
-            fn ($startWithRadius) => $startWithRadius->exactly($start),
-            fn ($startWithRadius) => $startWithRadius->prepend($omission),
+            static fn ($startWithRadius) => $startWithRadius->exactly($start),
+            static fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
         $end = (new Stringable(mb_substr($end, 0, $radius, 'UTF-8')))->rtrim()->unless(
-            fn ($endWithRadius) => $endWithRadius->exactly($end),
-            fn ($endWithRadius) => $endWithRadius->append($omission),
+            static fn ($endWithRadius) => $endWithRadius->exactly($end),
+            static fn ($endWithRadius) => $endWithRadius->append($omission),
         );
 
         return $start->append($matches[2], $end)->toString();
@@ -1104,13 +1104,13 @@ class Str
             'spaces' => $spaces === true ? [' '] : null,
         ]))
             ->filter()
-            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
+            ->each(static fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
             ->flatten();
 
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
+            static fn ($c) => Collection::times($length, static fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
@@ -1136,7 +1136,7 @@ class Str
      */
     public static function random($length = 16)
     {
-        return (static::$randomStringFactory ?? function ($length) {
+        return (static::$randomStringFactory ?? static function ($length) {
             $string = '';
 
             while (($len = strlen($string)) < $length) {
@@ -1175,7 +1175,7 @@ class Str
     {
         $next = 0;
 
-        $whenMissing ??= function ($length) use (&$next) {
+        $whenMissing ??= static function ($length) use (&$next) {
             $factoryCache = static::$randomStringFactory;
 
             static::$randomStringFactory = null;
@@ -1189,7 +1189,7 @@ class Str
             return $randomString;
         };
 
-        static::createRandomStringsUsing(function ($length) use (&$next, $sequence, $whenMissing) {
+        static::createRandomStringsUsing(static function ($length) use (&$next, $sequence, $whenMissing) {
             if (array_key_exists($next, $sequence)) {
                 return $sequence[$next++];
             }
@@ -1330,7 +1330,7 @@ class Str
 
             $subject = static::isAscii($term)
                 ? str_ireplace($term, $replacement, $subject)
-                : preg_replace_callback('/'.preg_quote($term, '/').'/iu', fn () => $replacement, $subject);
+                : preg_replace_callback('/'.preg_quote($term, '/').'/iu', static fn () => $replacement, $subject);
         }
 
         return $subject;
@@ -1546,7 +1546,7 @@ class Str
     {
         $parts = preg_split('/\s+/u', $value, -1, PREG_SPLIT_NO_EMPTY);
 
-        $parts = array_map(fn ($part) => mb_substr($part, 0, 1), $parts);
+        $parts = array_map(static fn ($part) => mb_substr($part, 0, 1), $parts);
 
         $initials = implode('', $parts);
 
@@ -1584,7 +1584,7 @@ class Str
             if (str_contains($lowercaseWord, '-')) {
                 $hyphenatedWords = explode('-', $lowercaseWord);
 
-                $hyphenatedWords = array_map(function ($part) use ($minorWords) {
+                $hyphenatedWords = array_map(static function ($part) use ($minorWords) {
                     return (in_array($part, $minorWords) && mb_strlen($part) <= 3)
                         ? $part
                         : mb_strtoupper(mb_substr($part, 0, 1)).mb_substr($part, 1);
@@ -1793,7 +1793,7 @@ class Str
         if ($normalize) {
             $value = preg_replace_callback(
                 '/(^|[-_ \s])([A-Z]+)(?=[-_ \s]|$)/u',
-                fn ($m) => $m[1].static::lower($m[2]),
+                static fn ($m) => $m[1].static::lower($m[2]),
                 $value
             );
         }
@@ -1806,7 +1806,7 @@ class Str
 
         $words = preg_split('/\s+/u', static::replace(['-', '_'], ' ', $value), -1, PREG_SPLIT_NO_EMPTY);
 
-        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(static fn ($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode('', $studlyWords);
     }
@@ -1870,7 +1870,7 @@ class Str
             return substr_replace($string, $replace, $offset, $length);
         }
 
-        $replaceSubstring = function ($string, $replace, $offset, $length) {
+        $replaceSubstring = static function ($string, $replace, $offset, $length) {
             if ($length === null) {
                 $length = static::length($string);
             }
@@ -1994,7 +1994,7 @@ class Str
     {
         $pattern = '/(^|['.preg_quote($separators, '/').'])(\p{Ll})/u';
 
-        return preg_replace_callback($pattern, function ($matches) {
+        return preg_replace_callback($pattern, static function ($matches) {
             return $matches[1].mb_strtoupper($matches[2]);
         }, $string);
     }
@@ -2043,7 +2043,7 @@ class Str
 
         $replaced = [];
 
-        $skeleton = preg_replace_callback('/[\x80-\xFF][\x80-\xBF]*|\x1A/', function ($match) use (&$replaced) {
+        $skeleton = preg_replace_callback('/[\x80-\xFF][\x80-\xBF]*|\x1A/', static function ($match) use (&$replaced) {
             $replaced[] = $match[0];
 
             return "\x1A";
@@ -2057,8 +2057,8 @@ class Str
 
         $index = 0;
 
-        return implode($break, array_map(function ($segment) use (&$replaced, &$index) {
-            return preg_replace_callback('/\x1A/', function () use (&$replaced, &$index) {
+        return implode($break, array_map(static function ($segment) use (&$replaced, &$index) {
+            return preg_replace_callback('/\x1A/', static function () use (&$replaced, &$index) {
                 return $replaced[$index++];
             }, $segment);
         }, explode($breakToken, wordwrap($skeleton, $characters, $breakToken, $cutLongWords))));
@@ -2136,7 +2136,7 @@ class Str
     {
         $next = 0;
 
-        $whenMissing ??= function () use (&$next) {
+        $whenMissing ??= static function () use (&$next) {
             $factoryCache = static::$uuidFactory;
 
             static::$uuidFactory = null;
@@ -2150,7 +2150,7 @@ class Str
             return $uuid;
         };
 
-        static::createUuidsUsing(function () use (&$next, $sequence, $whenMissing) {
+        static::createUuidsUsing(static function () use (&$next, $sequence, $whenMissing) {
             if (array_key_exists($next, $sequence)) {
                 return $sequence[$next++];
             }
@@ -2169,7 +2169,7 @@ class Str
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(fn () => $uuid);
+        Str::createUuidsUsing(static fn () => $uuid);
 
         if ($callback !== null) {
             try {
@@ -2243,7 +2243,7 @@ class Str
     {
         $next = 0;
 
-        $whenMissing ??= function () use (&$next) {
+        $whenMissing ??= static function () use (&$next) {
             $factoryCache = static::$ulidFactory;
 
             static::$ulidFactory = null;
@@ -2257,7 +2257,7 @@ class Str
             return $ulid;
         };
 
-        static::createUlidsUsing(function () use (&$next, $sequence, $whenMissing) {
+        static::createUlidsUsing(static function () use (&$next, $sequence, $whenMissing) {
             if (array_key_exists($next, $sequence)) {
                 return $sequence[$next++];
             }
@@ -2276,7 +2276,7 @@ class Str
     {
         $ulid = Str::ulid();
 
-        Str::createUlidsUsing(fn () => $ulid);
+        Str::createUlidsUsing(static fn () => $ulid);
 
         if ($callback !== null) {
             try {

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -367,7 +367,7 @@ class BusFake implements Fake, QueueingDispatcher
 
             $command = ChainedBatch::class;
 
-            $callback = fn ($job) => $instance($job->toPendingBatch());
+            $callback = static fn ($job) => $instance($job->toPendingBatch());
         } elseif (! is_string($command)) {
             $instance = $command;
 
@@ -404,7 +404,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     protected function resetChainPropertiesToDefaults($job)
     {
-        return tap(clone $job, function ($job) {
+        return tap(clone $job, static function ($job) {
             $job->chainConnection = null;
             $job->chainQueue = null;
             $job->chainCatchCallbacks = null;
@@ -507,7 +507,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function assertBatched(callable|array $callback)
     {
-        $callback = is_array($callback) ? fn (PendingBatchFake $batch) => $batch->hasJobs($callback) : $callback;
+        $callback = is_array($callback) ? static fn (PendingBatchFake $batch) => $batch->hasJobs($callback) : $callback;
 
         PHPUnit::assertTrue(
             $this->batched($callback)->isNotEmpty(),
@@ -536,7 +536,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function assertNothingBatched()
     {
         $jobNames = (new Collection($this->batches))
-            ->map(fn ($batch) => $batch->jobs->map(fn ($job) => get_class($job)))
+            ->map(static fn ($batch) => $batch->jobs->map(static fn ($job) => get_class($job)))
             ->flatten()
             ->join("\n- ");
 
@@ -567,9 +567,9 @@ class BusFake implements Fake, QueueingDispatcher
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
-        return (new Collection($this->commands[$command]))->filter(fn ($command) => $callback($command));
+        return (new Collection($this->commands[$command]))->filter(static fn ($command) => $callback($command));
     }
 
     /**
@@ -585,9 +585,9 @@ class BusFake implements Fake, QueueingDispatcher
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
-        return (new Collection($this->commandsSync[$command]))->filter(fn ($command) => $callback($command));
+        return (new Collection($this->commandsSync[$command]))->filter(static fn ($command) => $callback($command));
     }
 
     /**
@@ -603,9 +603,9 @@ class BusFake implements Fake, QueueingDispatcher
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
-        return (new Collection($this->commandsAfterResponse[$command]))->filter(fn ($command) => $callback($command));
+        return (new Collection($this->commandsAfterResponse[$command]))->filter(static fn ($command) => $callback($command));
     }
 
     /**
@@ -620,7 +620,7 @@ class BusFake implements Fake, QueueingDispatcher
             return new Collection;
         }
 
-        return (new Collection($this->batches))->filter(fn ($batch) => $callback($batch));
+        return (new Collection($this->batches))->filter(static fn ($batch) => $callback($batch));
     }
 
     /**
@@ -826,7 +826,7 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         return (new Collection($this->jobsToFake))
-            ->contains(function ($job) use ($command) {
+            ->contains(static function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
                     : $job === get_class($command);
@@ -842,7 +842,7 @@ class BusFake implements Fake, QueueingDispatcher
     protected function shouldDispatchCommand($command)
     {
         return (new Collection($this->jobsToDispatch))
-            ->contains(function ($job) use ($command) {
+            ->contains(static function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
                     : $job === get_class($command);

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -208,7 +208,7 @@ class EventFake implements Dispatcher, Fake
         $count = count(Arr::flatten($this->events));
 
         $eventNames = (new Collection($this->events))
-            ->map(fn ($events, $eventName) => sprintf(
+            ->map(static fn ($events, $eventName) => sprintf(
                 '%s dispatched %s %s',
                 $eventName,
                 count($events),
@@ -235,10 +235,10 @@ class EventFake implements Dispatcher, Fake
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
         return (new Collection($this->events[$event]))->filter(
-            fn ($arguments) => $callback(...$arguments)
+            static fn ($arguments) => $callback(...$arguments)
         );
     }
 
@@ -347,7 +347,7 @@ class EventFake implements Dispatcher, Fake
         }
 
         return (new Collection($this->eventsToFake))
-            ->contains(function ($event) use ($eventName, $payload) {
+            ->contains(static function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                     ? $event($eventName, $payload)
                     : $event === $eventName;
@@ -386,7 +386,7 @@ class EventFake implements Dispatcher, Fake
         }
 
         return (new Collection($this->eventsToDispatch))
-            ->contains(function ($event) use ($eventName, $payload) {
+            ->contains(static function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                     ? $event($eventName, $payload)
                     : $event === $eventName;

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -79,7 +79,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
 
         if (is_array($callback) || is_string($callback)) {
             foreach (Arr::wrap($callback) as $address) {
-                $callback = fn ($mail) => $mail->hasTo($address);
+                $callback = static fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertTrue(
                     $this->sent($mailable, $callback)->isNotEmpty(),
@@ -141,7 +141,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     {
         if (is_string($callback) || is_array($callback)) {
             foreach (Arr::wrap($callback) as $address) {
-                $callback = fn ($mail) => $mail->hasTo($address);
+                $callback = static fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertCount(
                     0, $this->sent($mailable, $callback),
@@ -179,7 +179,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingSent()
     {
         $mailableNames = (new Collection($this->mailables))->map(
-            fn ($mailable) => get_class($mailable)
+            static fn ($mailable) => get_class($mailable)
         )->join("\n- ");
 
         PHPUnit::assertEmpty($this->mailables, "The following mailables were sent unexpectedly:\n\n- $mailableNames\n");
@@ -202,7 +202,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
 
         if (is_string($callback) || is_array($callback)) {
             foreach (Arr::wrap($callback) as $address) {
-                $callback = fn ($mail) => $mail->hasTo($address);
+                $callback = static fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertTrue(
                     $this->queued($mailable, $callback)->isNotEmpty(),
@@ -251,7 +251,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     {
         if (is_string($callback) || is_array($callback)) {
             foreach (Arr::wrap($callback) as $address) {
-                $callback = fn ($mail) => $mail->hasTo($address);
+                $callback = static fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertCount(
                     0, $this->queued($mailable, $callback),
@@ -278,7 +278,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingQueued()
     {
         $mailableNames = (new Collection($this->queuedMailables))->map(
-            fn ($mailable) => get_class($mailable)
+            static fn ($mailable) => get_class($mailable)
         )->join("\n- ");
 
         PHPUnit::assertEmpty($this->queuedMailables, "The following mailables were queued unexpectedly:\n\n- $mailableNames\n");
@@ -349,9 +349,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
-        return $this->mailablesOf($mailable)->filter(fn ($mailable) => $callback($mailable));
+        return $this->mailablesOf($mailable)->filter(static fn ($mailable) => $callback($mailable));
     }
 
     /**
@@ -380,9 +380,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
-        return $this->queuedMailablesOf($mailable)->filter(fn ($mailable) => $callback($mailable));
+        return $this->queuedMailablesOf($mailable)->filter(static fn ($mailable) => $callback($mailable));
     }
 
     /**
@@ -404,7 +404,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     protected function mailablesOf($type)
     {
-        return (new Collection($this->mailables))->filter(fn ($mailable) => $mailable instanceof $type);
+        return (new Collection($this->mailables))->filter(static fn ($mailable) => $mailable instanceof $type);
     }
 
     /**
@@ -415,7 +415,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     protected function queuedMailablesOf($type)
     {
-        return (new Collection($this->queuedMailables))->filter(fn ($mailable) => $mailable instanceof $type);
+        return (new Collection($this->queuedMailables))->filter(static fn ($mailable) => $mailable instanceof $type);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -164,8 +164,8 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     public function assertNothingSent()
     {
         $notificationNames = (new Collection($this->notifications))
-            ->map(fn ($notifiableModels) => (new Collection($notifiableModels))
-                ->map(fn ($notifiables) => (new Collection($notifiables))->keys())
+            ->map(static fn ($notifiableModels) => (new Collection($notifiableModels))
+                ->map(static fn ($notifiables) => (new Collection($notifiables))->keys())
             )
             ->flatten()->join("\n- ");
 
@@ -211,7 +211,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     {
         $actualCount = (new Collection($this->notifications))
             ->flatten(1)
-            ->reduce(fn ($count, $sent) => $count + count($sent[$notification] ?? []), 0);
+            ->reduce(static fn ($count, $sent) => $count + count($sent[$notification] ?? []), 0);
 
         PHPUnit::assertSame(
             $expectedCount, $actualCount,
@@ -253,12 +253,12 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
         $notifications = new Collection($this->notificationsFor($notifiable, $notification));
 
         return $notifications->filter(
-            fn ($arguments) => $callback(...array_values($arguments))
+            static fn ($arguments) => $callback(...array_values($arguments))
         )->pluck('notification');
     }
 
@@ -322,7 +322,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             if (method_exists($notification, 'shouldSend')) {
                 $notifiableChannels = array_filter(
                     $notifiableChannels,
-                    fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
+                    static fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
                 );
             }
 
@@ -336,7 +336,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                     : $notification,
                 'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,
-                'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+                'locale' => $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {
                         return $notifiable->preferredLocale();
                     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -206,7 +206,7 @@ class QueueFake extends QueueManager implements Fake, Queue
 
         $queue = enum_value($queue);
 
-        $this->assertPushed($job, function ($job, $pushedQueue) use ($callback, $queue) {
+        $this->assertPushed($job, static function ($job, $pushedQueue) use ($callback, $queue) {
             if (enum_value($pushedQueue) !== $queue) {
                 return false;
             }
@@ -267,10 +267,10 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
     {
-        $chain = (new Collection($expectedChain))->map(fn ($job) => serialize($job))->all();
+        $chain = (new Collection($expectedChain))->map(static fn ($job) => serialize($job))->all();
 
         PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->contains(fn ($job) => $job->chained == $chain),
+            $this->pushed($job, $callback)->contains(static fn ($job) => $job->chained == $chain),
             'The expected chain was not pushed.'
         );
     }
@@ -285,8 +285,8 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     protected function assertPushedWithChainOfClasses($job, $expectedChain, $callback)
     {
-        $matching = $this->pushed($job, $callback)->contains(function ($pushedJob) use ($expectedChain) {
-            return (new Collection($pushedJob->chained))->map(function ($job) {
+        $matching = $this->pushed($job, $callback)->contains(static function ($pushedJob) use ($expectedChain) {
+            return (new Collection($pushedJob->chained))->map(static function ($job) {
                 return get_class(unserialize($job));
             })->all() === $expectedChain;
         });
@@ -326,7 +326,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return (new Collection($chain))->doesntContain(fn ($job) => ! is_object($job));
+        return (new Collection($chain))->doesntContain(static fn ($job) => ! is_object($job));
     }
 
     /**
@@ -389,10 +389,10 @@ class QueueFake extends QueueManager implements Fake, Queue
             return new Collection;
         }
 
-        $callback = $callback ?: fn () => true;
+        $callback = $callback ?: static fn () => true;
 
         return (new Collection($this->jobs[$job]))->filter(
-            fn ($data) => $callback($data['job'], $data['queue'], $data['data'])
+            static fn ($data) => $callback($data['job'], $data['queue'], $data['data'])
         )->pluck('job');
     }
 
@@ -406,7 +406,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $callback ??= static fn () => true;
 
-        return (new Collection($this->rawPushes))->filter(fn ($data) => $callback($data['payload'], $data['queue'], $data['options']));
+        return (new Collection($this->rawPushes))->filter(static fn ($data) => $callback($data['payload'], $data['queue'], $data['options']));
     }
 
     /**
@@ -423,10 +423,10 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         $collection = (new Collection($this->jobs[CallQueuedListener::class]))
-            ->filter(fn ($data) => $data['job']->class === $listenerClass);
+            ->filter(static fn ($data) => $data['job']->class === $listenerClass);
 
         if ($callback) {
-            $collection = $collection->filter(fn ($data) => $callback($data['job']->data[0] ?? null, $data['job'], $data['queue'], $data['data']));
+            $collection = $collection->filter(static fn ($data) => $callback($data['job']->data[0] ?? null, $data['job'], $data['queue'], $data['data']));
         }
 
         return $collection->pluck('job');
@@ -466,7 +466,7 @@ class QueueFake extends QueueManager implements Fake, Queue
 
         return (new Collection($this->jobs))
             ->flatten(1)
-            ->filter(fn ($job) => $job['queue'] === $queue)
+            ->filter(static fn ($job) => $job['queue'] === $queue)
             ->count();
     }
 
@@ -566,7 +566,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         return (new Collection($jobs))
             ->flatten(1)
-            ->map(fn ($data) => new InspectedJob(
+            ->map(static fn ($data) => new InspectedJob(
                 uuid: $data['uuid'] ?? null,
                 queue: $data['queue'],
                 name: is_object($data['job'])
@@ -662,7 +662,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         return $this->jobsToFake->contains(
-            fn ($jobToFake) => $job instanceof ((string) $jobToFake) || $job === (string) $jobToFake
+            static fn ($jobToFake) => $job instanceof ((string) $jobToFake) || $job === (string) $jobToFake
         );
     }
 
@@ -679,7 +679,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         return $this->jobsToBeQueued->contains(
-            fn ($jobToQueue) => $job instanceof ((string) $jobToQueue)
+            static fn ($jobToQueue) => $job instanceof ((string) $jobToQueue)
         );
     }
 

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -55,7 +55,7 @@ trait InteractsWithData
 
         $data = $this->all();
 
-        return array_all($keys, fn ($value) => Arr::has($data, $value));
+        return array_all($keys, static fn ($value) => Arr::has($data, $value));
     }
 
     /**
@@ -401,7 +401,7 @@ trait InteractsWithData
         }
 
         return $this->collect($key)
-            ->map(fn ($value) => $enumClass::tryFrom($value))
+            ->map(static fn ($value) => $enumClass::tryFrom($value))
             ->filter()
             ->all();
     }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -26,7 +26,7 @@ if (! function_exists('Illuminate\Support\defer')) {
 
         return tap(
             new DeferredCallback($callback, $name, $always),
-            fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
+            static fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
         );
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,7 +288,7 @@ if (! function_exists('preg_replace_array')) {
      */
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
-        return preg_replace_callback($pattern, function () use (&$replacements) {
+        return preg_replace_callback($pattern, static function () use (&$replacements) {
             return array_shift($replacements);
         }, $subject);
     }

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -281,7 +281,7 @@ class AssertableJsonString implements ArrayAccess, Countable
         if ($exact) {
             PHPUnit::assertIsArray($this->decoded);
 
-            $keys = (new Collection($structure))->map(fn ($value, $key) => is_array($value) ? $key : $value)->values();
+            $keys = (new Collection($structure))->map(static fn ($value, $key) => is_array($value) ? $key : $value)->values();
 
             if ($keys->all() !== ['*']) {
                 PHPUnit::assertEquals($keys->sort()->values()->all(), (new Collection($this->decoded))->keys()->sort()->values()->all());

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -63,7 +63,7 @@ trait RunsInParallel
             $output = new ParallelConsoleOutput($output);
         }
 
-        $runnerResolver = static::$runnerResolver ?: function ($options, OutputInterface $output) {
+        $runnerResolver = static::$runnerResolver ?: static function ($options, OutputInterface $output) {
             $wrapperRunnerClass = class_exists(\ParaTest\WrapperRunner\WrapperRunner::class)
                 ? \ParaTest\WrapperRunner\WrapperRunner::class
                 : \ParaTest\Runners\PHPUnit\WrapperRunner::class;
@@ -109,14 +109,14 @@ trait RunsInParallel
 
         (new PhpHandler())->handle($configuration->php());
 
-        $this->forEachProcess(function () {
+        $this->forEachProcess(static function () {
             ParallelTesting::callSetUpProcessCallbacks();
         });
 
         try {
             $potentialExitCode = $this->runner->run();
         } finally {
-            $this->forEachProcess(function () {
+            $this->forEachProcess(static function () {
                 ParallelTesting::callTearDownProcessCallbacks();
             });
         }
@@ -147,8 +147,8 @@ trait RunsInParallel
             : $this->options->processes();
 
         Collection::range(1, $processes)->each(function ($token) use ($callback) {
-            tap($this->createApplication(), function ($app) use ($callback, $token) {
-                ParallelTesting::resolveTokenUsing(fn () => $token);
+            tap($this->createApplication(), static function ($app) use ($callback, $token) {
+                ParallelTesting::resolveTokenUsing(static fn () => $token);
 
                 $callback($app);
             })->flush();

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -96,11 +96,11 @@ trait TestDatabases
         $testDatabase = $this->testDatabase($database);
 
         try {
-            $this->usingDatabase($testDatabase, function () {
+            $this->usingDatabase($testDatabase, static function () {
                 Schema::hasTable('dummy');
             });
         } catch (QueryException) {
-            $this->usingDatabase($database, function () use ($testDatabase) {
+            $this->usingDatabase($database, static function () use ($testDatabase) {
                 Schema::dropDatabaseIfExists($testDatabase);
                 Schema::createDatabase($testDatabase);
             });

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -96,9 +96,9 @@ trait Has
         $this->interactsWith($key);
 
         if (! is_null($callback)) {
-            return $this->has($key, function (self $scope) use ($length, $callback) {
+            return $this->has($key, static function (self $scope) use ($length, $callback) {
                 return $scope
-                    ->tap(function (self $scope) use ($length) {
+                    ->tap(static function (self $scope) use ($length) {
                         if (! is_null($length)) {
                             $scope->count($length);
                         }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -208,8 +208,8 @@ trait Matching
         );
 
         $missing = (new Collection($expected))
-            ->map(fn ($search) => enum_value($search))
-            ->reject(function ($search) use ($key, $actual) {
+            ->map(static fn ($search) => enum_value($search))
+            ->reject(static function ($search) use ($key, $actual) {
                 if ($actual->containsStrict($key, $search)) {
                     return true;
                 }
@@ -217,7 +217,7 @@ trait Matching
                 return $actual->containsStrict($search);
             });
 
-        if ($missing->contains(fn ($search) => $search instanceof Closure)) {
+        if ($missing->contains(static fn ($search) => $search instanceof Closure)) {
             PHPUnit::assertEmpty(
                 $missing->toArray(),
                 sprintf(

--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -280,7 +280,7 @@ class ParallelTesting
      */
     public function option($option)
     {
-        $optionsResolver = $this->optionsResolver ?: function ($option) {
+        $optionsResolver = $this->optionsResolver ?: static function ($option) {
             $option = 'LARAVEL_PARALLEL_TESTING_'.Str::upper($option);
 
             return $_SERVER[$option] ?? false;

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -572,7 +572,7 @@ class PendingCommand
                 });
         }
 
-        $this->app->bind(OutputStyle::class, function () use ($mock) {
+        $this->app->bind(OutputStyle::class, static function () use ($mock) {
             return $mock;
         });
 
@@ -616,7 +616,7 @@ class PendingCommand
             $mock->shouldReceive('doWrite')
                 ->atLeast()
                 ->times(0)
-                ->withArgs(fn ($output) => str_contains($output, $text))
+                ->withArgs(static fn ($output) => str_contains($output, $text))
                 ->andReturnUsing(function () use ($i) {
                     unset($this->test->expectedOutputSubstrings[$i]);
                 });
@@ -637,7 +637,7 @@ class PendingCommand
             $mock->shouldReceive('doWrite')
                 ->atLeast()
                 ->times(0)
-                ->withArgs(fn ($output) => str_contains($output, $text))
+                ->withArgs(static fn ($output) => str_contains($output, $text))
                 ->andReturnUsing(function () use ($text) {
                     $this->test->unexpectedOutputSubstrings[$text] = true;
                 });

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1141,14 +1141,14 @@ class TestResponse implements ArrayAccess
         $jsonErrors = Arr::get($this->json(), $responseKey) ?? [];
 
         $expectedErrorKeys = (new Collection($errors))
-            ->map(fn ($value, $key) => is_int($key) ? $value : $key)
+            ->map(static fn ($value, $key) => is_int($key) ? $value : $key)
             ->all();
 
         $unexpectedErrorKeys = Arr::except($jsonErrors, $expectedErrorKeys);
 
         PHPUnit::withResponse($this)->assertTrue(
             count($unexpectedErrorKeys) === 0,
-            'Response has unexpected validation errors: '.(new Collection($unexpectedErrorKeys))->keys()->map(fn ($key) => "'{$key}'")->join(', ')
+            'Response has unexpected validation errors: '.(new Collection($unexpectedErrorKeys))->keys()->map(static fn ($key) => "'{$key}'")->join(', ')
         );
 
         return $this;
@@ -1565,14 +1565,14 @@ class TestResponse implements ArrayAccess
             ->getMessages();
 
         $expectedErrorKeys = (new Collection($errors))
-            ->map(fn ($value, $key) => is_int($key) ? $value : $key)
+            ->map(static fn ($value, $key) => is_int($key) ? $value : $key)
             ->all();
 
         $unexpectedErrorKeys = Arr::except($sessionErrors, $expectedErrorKeys);
 
         PHPUnit::withResponse($this)->assertTrue(
             count($unexpectedErrorKeys) === 0,
-            'Response has unexpected validation errors: '.(new Collection($unexpectedErrorKeys))->keys()->map(fn ($key) => "'{$key}'")->join(', ')
+            'Response has unexpected validation errors: '.(new Collection($unexpectedErrorKeys))->keys()->map(static fn ($key) => "'{$key}'")->join(', ')
         );
 
         return $this;

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -67,7 +67,7 @@ class TestView implements Stringable
             PHPUnit::assertInstanceOf(EloquentCollection::class, $actual);
             PHPUnit::assertSameSize($value, $actual);
 
-            $value->each(fn ($item, $index) => PHPUnit::assertTrue($actual->get($index)->is($item)));
+            $value->each(static fn ($item, $index) => PHPUnit::assertTrue($actual->get($index)->is($item)));
         } else {
             PHPUnit::assertEquals($value, Arr::get($this->view->gatherData(), $key));
         }

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -92,7 +92,7 @@ class MessageSelector
     private function stripConditions($segments)
     {
         return (new Collection($segments))
-            ->map(fn ($part) => preg_replace('/^[\{\[][-?\d|*,\.*]*[\}\]]/', '', $part))
+            ->map(static fn ($part) => preg_replace('/^[\{\[][-?\d|*,\.*]*[\}\]]/', '', $part))
             ->all();
     }
 

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -16,7 +16,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
     {
         $this->registerLoader();
 
-        $this->app->singleton('translator', function ($app) {
+        $this->app->singleton('translator', static function ($app) {
             $loader = $app['translation.loader'];
 
             // When registering the translator component, we'll need to set the default
@@ -39,7 +39,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
      */
     protected function registerLoader()
     {
-        $this->app->singleton('translation.loader', function ($app) {
+        $this->app->singleton('translation.loader', static function ($app) {
             return new FileLoader($app['files'], [__DIR__.'/lang', $app['path.lang']]);
         });
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -318,7 +318,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             if ($value instanceof Closure) {
                 $line = preg_replace_callback(
                     '/<'.$key.'>(.*?)<\/'.$key.'>/',
-                    fn ($args) => $value($args[1]),
+                    static fn ($args) => $value($args[1]),
                     $line
                 );
 
@@ -494,7 +494,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locales = array_filter([$locale ?: $this->locale, $this->fallback]);
 
-        $determined = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+        $determined = call_user_func($this->determineLocalesUsing ?: static fn () => $locales, $locales);
 
         return array_values(array_unique($determined));
     }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -389,7 +389,7 @@ trait FormatsMessages
     protected function replacePositionPlaceholder($message, $attribute)
     {
         return $this->replaceIndexOrPositionPlaceholder(
-            $message, $attribute, 'position', fn ($segment) => $segment + 1
+            $message, $attribute, 'position', static fn ($segment) => $segment + 1
         );
     }
 
@@ -407,7 +407,7 @@ trait FormatsMessages
         }
 
         return $this->replaceIndexOrPositionPlaceholder(
-            $message, $attribute, 'ordinal-position', fn ($segment) => Number::ordinal($segment + 1)
+            $message, $attribute, 'ordinal-position', static fn ($segment) => Number::ordinal($segment + 1)
         );
     }
 
@@ -429,7 +429,7 @@ trait FormatsMessages
 
         $segments = explode('.', $attribute);
 
-        $modifier ??= fn ($value) => $value;
+        $modifier ??= static fn ($value) => $value;
 
         $numericIndex = 1;
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -979,17 +979,17 @@ trait ReplacesAttributes
      */
     private function replaceWhileKeepingCase(string $message, array $mapping): string
     {
-        $fn = [fn ($v) => $v, Str::upper(...), Str::ucfirst(...)];
+        $fn = [static fn ($v) => $v, Str::upper(...), Str::ucfirst(...)];
 
         $cases = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), $fn)],
+            static fn (array $carry, string $placeholder) => [...$carry, ...array_map(static fn (callable $fn) => ':'.$fn($placeholder), $fn)],
             [],
         );
 
         $replacements = array_reduce(
             array_values($mapping),
-            fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],
+            static fn (array $carry, string $parameter) => [...$carry, ...array_map(static fn (callable $fn) => $fn($parameter), $fn)],
             [],
         );
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -501,7 +501,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($param) => Arr::exists($value, $param));
+        return array_all($parameters, static fn ($param) => Arr::exists($value, $param));
     }
 
     /**
@@ -571,7 +571,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($parameter) => in_array($parameter, $value));
+        return array_all($parameters, static fn ($parameter) => in_array($parameter, $value));
     }
 
     /**
@@ -588,7 +588,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value));
+        return array_all($parameters, static fn ($parameter) => ! in_array($parameter, $value));
     }
 
     /**
@@ -962,7 +962,7 @@ trait ValidatesAttributes
 
         $pattern = str_replace('\*', '[^.]+', preg_quote($attribute, '#'));
 
-        return Arr::where(Arr::dot($attributeData), function ($value, $key) use ($pattern) {
+        return Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($pattern) {
             return (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
     }
@@ -1578,7 +1578,7 @@ trait ValidatesAttributes
 
         $attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
 
-        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+        $otherValues = Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($parameters) {
             return Str::is($parameters[0], $key);
         });
 
@@ -1603,7 +1603,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_any($parameters, fn ($param) => Arr::exists($value, $param));
+        return array_any($parameters, static fn ($param) => Arr::exists($value, $param));
     }
 
     /**
@@ -2497,7 +2497,7 @@ trait ValidatesAttributes
      */
     protected function convertValuesToBoolean($values)
     {
-        return array_map(fn ($value) => match ($value) {
+        return array_map(static fn ($value) => match ($value) {
             'true' => true,
             'false' => false,
             default => $value,
@@ -2512,7 +2512,7 @@ trait ValidatesAttributes
      */
     protected function convertValuesToNull($values)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             return Str::lower($value) === 'null' ? null : $value;
         }, $values);
     }
@@ -2870,7 +2870,7 @@ trait ValidatesAttributes
      */
     public function parseNamedParameters($parameters)
     {
-        return array_reduce($parameters, function ($result, $item) {
+        return array_reduce($parameters, static function ($result, $item) {
             [$key, $value] = array_pad(explode('=', $item, 2), 2, null);
 
             $result[$key] = $value;
@@ -2955,7 +2955,7 @@ trait ValidatesAttributes
             : Str::after($stringValue, 'E'));
 
         $withinRange = (
-            $this->ensureExponentWithinAllowedRangeUsing ?? fn ($scale) => $scale <= 1000 && $scale >= -1000
+            $this->ensureExponentWithinAllowedRangeUsing ?? static fn ($scale) => $scale <= 1000 && $scale >= -1000
         )($scale, $attribute, $value);
 
         if (! $withinRange) {

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -80,7 +80,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
     {
         foreach ($conditions as $key => $value) {
             if ($value instanceof Closure) {
-                $query->where(function ($query) use ($value) {
+                $query->where(static function ($query) use ($value) {
                     $value($query);
                 });
             } else {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -68,7 +68,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
+            {
             };
         }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -52,7 +52,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
         [$hash, $hashPrefix] = $this->getHash($value);
 
         return ! $this->search($hashPrefix)
-            ->contains(function ($line) use ($hash, $hashPrefix, $threshold) {
+            ->contains(static function ($line) use ($hash, $hashPrefix, $threshold) {
                 [$hashSuffix, $count] = explode(':', $line);
 
                 return $hashPrefix.$hashSuffix === $hash && $count > $threshold;
@@ -96,7 +96,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ? $response->body()
             : '';
 
-        return (new Stringable($body))->trim()->explode("\n")->filter(function ($line) {
+        return (new Stringable($body))->trim()->explode("\n")->filter(static function ($line) {
             return str_contains($line, ':');
         });
     }

--- a/src/Illuminate/Validation/Rules/Contains.php
+++ b/src/Illuminate/Validation/Rules/Contains.php
@@ -37,7 +37,7 @@ class Contains implements Stringable
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             $value = enum_value($value);
 
             return '"'.str_replace('"', '""', (string) $value).'"';

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -71,7 +71,7 @@ trait DatabaseRule
                 return $table;
             }
 
-            return implode('.', array_map(function (string $part) {
+            return implode('.', array_map(static function (string $part) {
                 return trim($part, '.');
             }, array_filter([$model->getConnectionName(), $model->getTable()])));
         }
@@ -156,7 +156,7 @@ trait DatabaseRule
      */
     public function whereIn($column, $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
             $query->whereIn($column, $values);
         });
     }
@@ -170,7 +170,7 @@ trait DatabaseRule
      */
     public function whereNotIn($column, $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
             $query->whereNotIn($column, $values);
         });
     }
@@ -232,7 +232,7 @@ trait DatabaseRule
     protected function formatWheres()
     {
         return (new Collection($this->wheres))
-            ->map(fn ($where) => $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"')
+            ->map(static fn ($where) => $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"')
             ->implode(',');
     }
 }

--- a/src/Illuminate/Validation/Rules/DoesntContain.php
+++ b/src/Illuminate/Validation/Rules/DoesntContain.php
@@ -37,7 +37,7 @@ class DoesntContain implements Stringable
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             $value = enum_value($value);
 
             return '"'.str_replace('"', '""', (string) $value).'"';

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -159,7 +159,7 @@ class Enum implements Rule, ValidatorAwareRule, Stringable
             ? $this->only
             : array_filter($this->type::cases(), fn ($case) => ! in_array($case, $this->except, true));
 
-        $values = array_map(function ($case) {
+        $values = array_map(static function ($case) {
             $value = enum_value($case);
 
             return '"'.str_replace('"', '""', (string) $value).'"';

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -142,7 +142,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public static function types($mimetypes)
     {
-        return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+        return tap(new static(), static fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
     }
 
     /**
@@ -336,7 +336,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
 
         $mimetypes = array_filter(
             $this->allowedMimetypes,
-            fn ($type) => str_contains($type, '/')
+            static fn ($type) => str_contains($type, '/')
         );
 
         $mimes = array_diff($this->allowedMimetypes, $mimetypes);

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -46,7 +46,7 @@ class In implements Stringable
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             $value = enum_value($value);
 
             return '"'.str_replace('"', '""', (string) $value).'"';

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -44,7 +44,7 @@ class NotIn implements Stringable
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             $value = enum_value($value);
 
             return '"'.str_replace('"', '""', (string) $value).'"';

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -67,7 +67,7 @@ class ValidationException extends Exception
      */
     public static function withMessages(array $messages)
     {
-        return new static(tap(ValidatorFacade::make([], []), function ($validator) use ($messages) {
+        return new static(tap(ValidatorFacade::make([], []), static function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
                 foreach (Arr::wrap($value) as $message) {
                     $validator->errors()->add($key, $message);

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -349,7 +349,7 @@ class ValidationRuleParser
      */
     public static function filterConditionalRules($rules, array $data = [])
     {
-        return (new Collection($rules))->mapWithKeys(function ($attributeRules, $attribute) use ($data) {
+        return (new Collection($rules))->mapWithKeys(static function ($attributeRules, $attribute) use ($data) {
             if (! is_array($attributeRules) &&
                 ! $attributeRules instanceof ConditionalRules) {
                 return [$attribute => $attributeRules];
@@ -361,7 +361,7 @@ class ValidationRuleParser
                     : array_filter($attributeRules->defaultRules($data)), ];
             }
 
-            return [$attribute => (new Collection($attributeRules))->map(function ($rule) use ($data) {
+            return [$attribute => (new Collection($attributeRules))->map(static function ($rule) use ($data) {
                 if (! $rule instanceof ConditionalRules) {
                     return [$rule];
                 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -28,7 +28,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerValidationFactory()
     {
-        $this->app->singleton('validator', function ($app) {
+        $this->app->singleton('validator', static function ($app) {
             $validator = new Factory($app['translator'], $app);
 
             // The validation presence verifier is responsible for determining the existence of
@@ -49,7 +49,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerPresenceVerifier()
     {
-        $this->app->singleton('validation.presence', function ($app) {
+        $this->app->singleton('validation.presence', static function ($app) {
             return new DatabasePresenceVerifier($app['db']);
         });
     }
@@ -61,7 +61,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerUncompromisedVerifier()
     {
-        $this->app->singleton(UncompromisedVerifier::class, function ($app) {
+        $this->app->singleton(UncompromisedVerifier::class, static function ($app) {
             return new NotPwnedVerifier($app[HttpFactory::class]);
         });
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -433,7 +433,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceDotPlaceholderInParameters(array $parameters)
     {
-        return array_map(function ($field) {
+        return array_map(static function ($field) {
             return str_replace('__dot__'.static::$placeholderHash, '.', $field);
         }, $parameters);
     }
@@ -571,7 +571,7 @@ class Validator implements ValidatorContract
      */
     protected function shouldBeExcluded($attribute)
     {
-        return array_any($this->excludeAttributes, fn ($excludeAttribute) => $attribute === $excludeAttribute ||
+        return array_any($this->excludeAttributes, static fn ($excludeAttribute) => $attribute === $excludeAttribute ||
             Str::startsWith($attribute, $excludeAttribute.'.'));
     }
 
@@ -794,7 +794,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceDotInParameters(array $parameters)
     {
-        return array_map(function ($field) {
+        return array_map(static function ($field) {
             return static::encodeAttributeWithPlaceholder((string) ($field ?? ''));
         }, $parameters);
     }
@@ -808,7 +808,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceAsterisksInParameters(array $parameters, array $keys)
     {
-        return array_map(function ($field) use ($keys) {
+        return array_map(static function ($field) use ($keys) {
             return vsprintf(str_replace('*', '%s', $field), $keys);
         }, $parameters);
     }
@@ -1090,7 +1090,7 @@ class Validator implements ValidatorContract
     protected function attributesThatHaveMessages()
     {
         return (new Collection($this->messages()->toArray()))
-            ->map(fn ($message, $key) => explode('.', $key)[0])
+            ->map(static fn ($message, $key) => explode('.', $key)[0])
             ->unique()
             ->flip()
             ->all();
@@ -1252,7 +1252,7 @@ class Validator implements ValidatorContract
     public function getRulesWithoutPlaceholders()
     {
         return (new Collection($this->rules))
-            ->mapWithKeys(fn ($value, $key) => [
+            ->mapWithKeys(static fn ($value, $key) => [
                 static::decodeAttributeWithPlaceholder($key) => $value,
             ])
             ->all();
@@ -1267,7 +1267,7 @@ class Validator implements ValidatorContract
     public function setRules(array $rules)
     {
         $rules = (new Collection($rules))
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(static function ($value, $key) {
                 return [static::encodeAttributeWithPlaceholder($key) => $value];
             })
             ->toArray();
@@ -1290,7 +1290,7 @@ class Validator implements ValidatorContract
     public function appendRules(array $rules)
     {
         $rules = (new Collection($rules))
-            ->map(function ($value) {
+            ->map(static function ($value) {
                 return is_string($value) ? explode('|', $value) : $value;
             })
             ->all();

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -358,7 +358,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             ->make(ViewFactory::class)
             ->make($component->resolveView(), $data);
 
-        return tap($view->render(), function () use ($view, $deleteCachedView) {
+        return tap($view->render(), static function () use ($view, $deleteCachedView) {
             if ($deleteCachedView) {
                 @unlink($view->getPath());
             }
@@ -739,25 +739,25 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $this->conditions[$name] = $callback;
 
-        $this->directive($name, function ($expression) use ($name) {
+        $this->directive($name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('unless'.$name, function ($expression) use ($name) {
+        $this->directive('unless'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('else'.$name, function ($expression) use ($name) {
+        $this->directive('else'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('end'.$name, function () {
+        $this->directive('end'.$name, static function () {
             return '<?php endif; ?>';
         });
     }
@@ -791,7 +791,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         if (is_null($alias)) {
             $alias = str_contains($class, '\\View\\Components\\')
                 ? (new Stringable($class))->after('\\View\\Components\\')->explode('\\')
-                    ->map(fn ($segment) => Str::kebab($segment))
+                    ->map(static fn ($segment) => Str::kebab($segment))
                     ->implode(':')
                 : Str::kebab(class_basename($class));
         }
@@ -923,13 +923,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $alias = $alias ?: Arr::last(explode('.', $path));
 
-        $this->directive($alias, function ($expression) use ($path) {
+        $this->directive($alias, static function ($expression) use ($path) {
             return $expression
                 ? "<?php \$__env->startComponent('{$path}', {$expression}); ?>"
                 : "<?php \$__env->startComponent('{$path}'); ?>";
         });
 
-        $this->directive('end'.$alias, function ($expression) {
+        $this->directive('end'.$alias, static function ($expression) {
             return '<?php echo $__env->renderComponent(); ?>';
         });
     }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -236,7 +236,7 @@ class ComponentTagCompiler
 
         [$data, $attributes] = $this->partitionDataAndAttributes($class, $attributes);
 
-        $data = $data->mapWithKeys(function ($value, $key) {
+        $data = $data->mapWithKeys(static function ($value, $key) {
             return [Str::camel($key) => $value];
         });
 
@@ -363,7 +363,7 @@ class ComponentTagCompiler
     protected function guessAnonymousComponentUsingNamespaces(Factory $viewFactory, string $component)
     {
         return (new Collection($this->blade->getAnonymousComponentNamespaces()))
-            ->filter(function ($directory, $prefix) use ($component) {
+            ->filter(static function ($directory, $prefix) use ($component) {
                 return Str::startsWith($component, $prefix.'::');
             })
             ->prepend('components', $component)
@@ -440,7 +440,7 @@ class ComponentTagCompiler
      */
     public function formatClassName(string $component)
     {
-        $componentPieces = array_map(function ($componentPiece) {
+        $componentPieces = array_map(static function ($componentPiece) {
             return ucfirst(Str::camel($componentPiece));
         }, explode('.', $component));
 
@@ -492,7 +492,7 @@ class ComponentTagCompiler
             : [];
 
         return (new Collection($attributes))
-            ->partition(fn ($value, $key) => in_array(Str::camel($key), $parameterNames))
+            ->partition(static fn ($value, $key) => in_array(Str::camel($key), $parameterNames))
             ->all();
     }
 
@@ -660,7 +660,7 @@ class ComponentTagCompiler
     {
         $pattern = "/\s\:\\\$(\w+)/x";
 
-        return preg_replace_callback($pattern, function (array $matches) {
+        return preg_replace_callback($pattern, static function (array $matches) {
             return " :{$matches[1]}=\"\${$matches[1]}\"";
         }, $value);
     }
@@ -690,7 +690,7 @@ class ComponentTagCompiler
     protected function parseComponentTagClassStatements(string $attributeString)
     {
         return preg_replace_callback(
-            '/@(class)(\( ( (?>[^()]+) | (?2) )* \))/x', function ($match) {
+            '/@(class)(\( ( (?>[^()]+) | (?2) )* \))/x', static function ($match) {
                 if ($match[1] === 'class') {
                     $match[2] = str_replace('"', "'", $match[2]);
 
@@ -711,7 +711,7 @@ class ComponentTagCompiler
     protected function parseComponentTagStyleStatements(string $attributeString)
     {
         return preg_replace_callback(
-            '/@(style)(\( ( (?>[^()]+) | (?2) )* \))/x', function ($match) {
+            '/@(style)(\( ( (?>[^()]+) | (?2) )* \))/x', static function ($match) {
                 if ($match[1] === 'style') {
                     $match[2] = str_replace('"', "'", $match[2]);
 
@@ -769,7 +769,7 @@ class ComponentTagCompiler
      */
     protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value)
     {
-        return (new Collection(token_get_all($value)))->map(function ($token) {
+        return (new Collection(token_get_all($value)))->map(static function ($token) {
             if (! is_array($token)) {
                 return $token;
             }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -143,7 +143,7 @@ trait CompilesEchos
     {
         $value = (new Stringable($value))
             ->trim()
-            ->when(str_ends_with($value, ';'), function ($str) {
+            ->when(str_ends_with($value, ';'), static function ($str) {
                 return $str->beforeLast(';');
             });
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -159,7 +159,7 @@ abstract class Component
             return $this->extractBladeViewFromString($view);
         };
 
-        return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {
+        return $view instanceof Closure ? static function (array $data = []) use ($view, $resolver) {
             return $resolver($view($data));
         }
         : $resolver($view);
@@ -242,7 +242,7 @@ abstract class Component
 
             static::$propertyCache[$class] = (new Collection($reflection->getProperties(ReflectionProperty::IS_PUBLIC)))
                 ->reject(fn (ReflectionProperty $property) => $property->isStatic() || $this->shouldIgnore($property->getName()))
-                ->map(fn (ReflectionProperty $property) => $property->getName())
+                ->map(static fn (ReflectionProperty $property) => $property->getName())
                 ->all();
         }
 
@@ -269,7 +269,7 @@ abstract class Component
 
             static::$methodCache[$class] = (new Collection($reflection->getMethods(ReflectionMethod::IS_PUBLIC)))
                 ->reject(fn (ReflectionMethod $method) => $this->shouldIgnore($method->getName()))
-                ->map(fn (ReflectionMethod $method) => $method->getName());
+                ->map(static fn (ReflectionMethod $method) => $method->getName());
         }
 
         $values = [];

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -150,7 +150,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function whereStartsWith($needles)
     {
-        return $this->filter(function ($value, $key) use ($needles) {
+        return $this->filter(static function ($value, $key) use ($needles) {
             return Str::startsWith($key, $needles);
         });
     }
@@ -163,7 +163,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function whereDoesntStartWith($needles)
     {
-        return $this->filter(function ($value, $key) use ($needles) {
+        return $this->filter(static function ($value, $key) use ($needles) {
             return ! Str::startsWith($key, $needles);
         });
     }
@@ -243,7 +243,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
         }, $attributeDefaults);
 
         [$appendableAttributes, $nonAppendableAttributes] = (new Collection($this->attributes))
-            ->partition(function ($value, $key) use ($attributeDefaults) {
+            ->partition(static function ($value, $key) use ($attributeDefaults) {
                 return $key === 'class' || $key === 'style' || (
                     isset($attributeDefaults[$key]) &&
                     $attributeDefaults[$key] instanceof AppendableAttributeValue

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -95,7 +95,7 @@ class ComponentSlot implements Htmlable, Stringable
         return filter_var(
             $this->contents,
             FILTER_CALLBACK,
-            ['options' => $callable ?? fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input))]
+            ['options' => $callable ?? static fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input))]
         ) !== '';
     }
 

--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -158,7 +158,7 @@ trait ManagesEvents
     protected function addEventListener($name, $callback)
     {
         if (str_contains($name, '*')) {
-            $callback = function ($name, array $data) use ($callback) {
+            $callback = static function ($name, array $data) use ($callback) {
                 return $callback($data[0]);
             };
         }

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -96,7 +96,7 @@ EOF;
             return '';
         }
 
-        return '@props('.'[\''.implode('\',\'', (new Collection($bindings))->map(function ($dataKey) {
+        return '@props('.'[\''.implode('\',\'', (new Collection($bindings))->map(static function ($dataKey) {
             return Str::camel($dataKey);
         })->all()).'\']'.')';
     }
@@ -110,7 +110,7 @@ EOF;
     protected function compileBindings(array $bindings)
     {
         return (new Collection($bindings))
-            ->map(fn ($key) => ':'.$key.'="$'.Str::camel(str_replace([':', '.'], ' ', $key)).'"')
+            ->map(static fn ($key) => ':'.$key.'="$'.Str::camel(str_replace([':', '.'], ' ', $key)).'"')
             ->implode(' ');
     }
 
@@ -123,8 +123,8 @@ EOF;
     protected function compileSlots(array $slots)
     {
         return (new Collection($slots))
-            ->reject(fn ($slot, $name) => $name === '__default')
-            ->map(fn ($slot, $name) => '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>')
+            ->reject(static fn ($slot, $name) => $name === '__default')
+            ->map(static fn ($slot, $name) => '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>')
             ->implode(PHP_EOL);
     }
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -337,7 +337,7 @@ class Factory implements FactoryContract
     {
         $extensions = array_keys($this->extensions);
 
-        return Arr::first($extensions, function ($value) use ($path) {
+        return Arr::first($extensions, static function ($value) use ($path) {
             return str_ends_with($path, '.'.$value);
         });
     }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -146,7 +146,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(fn ($extension) => str_replace('.', '/', $name).'.'.$extension, $this->extensions);
+        return array_map(static fn ($extension) => str_replace('.', '/', $name).'.'.$extension, $this->extensions);
     }
 
     /**

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -81,7 +81,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerViewFinder()
     {
-        $this->app->bind('view.finder', function ($app) {
+        $this->app->bind('view.finder', static function ($app) {
             return new FileViewFinder($app['files'], $app['config']['view.paths']);
         });
     }
@@ -93,7 +93,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeCompiler()
     {
-        $this->app->singleton('blade.compiler', function ($app) {
+        $this->app->singleton('blade.compiler', static function ($app) {
             return tap(new BladeCompiler(
                 $app['files'],
                 $app['config']['view.compiled'],
@@ -101,7 +101,7 @@ class ViewServiceProvider extends ServiceProvider
                 $app['config']->get('view.cache', true),
                 $app['config']->get('view.compiled_extension', 'php'),
                 $app['config']->get('view.check_cache_timestamps', true),
-            ), function ($blade) {
+            ), static function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });
         });
@@ -136,7 +136,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFileEngine($resolver)
     {
-        $resolver->register('file', function () {
+        $resolver->register('file', static function () {
             return new FileEngine(Container::getInstance()->make('files'));
         });
     }
@@ -149,7 +149,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerPhpEngine($resolver)
     {
-        $resolver->register('php', function () {
+        $resolver->register('php', static function () {
             return new PhpEngine(Container::getInstance()->make('files'));
         });
     }
@@ -162,7 +162,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeEngine($resolver)
     {
-        $resolver->register('blade', function () {
+        $resolver->register('blade', static function () {
             $app = Container::getInstance();
 
             $compiler = new CompilerEngine(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Inspired by https://wiki.php.net/rfc/closure-optimizations, this PR aims to mark all closures not using `$this` as static. This comes with some small performance benefits, as such closures do not require PHP to bind `$this` to it.

Moreover, per this RFC, such closures will be cached from PHP 8.6 onwards for further performance benefits.

This was achieved by adding `"static_lambda": true,` to `pint.json` and the running the autocorrect, after which some occurences were removed:
- some that were causing issues, e.g. the `states` closures in the `Factory` class, due to manual binding later
- all occurences inside `tests`, to not cause even more noise, given that benefits here as less relevant
- all occurences inside `types`, given there is no benefit there

Still, this remains a large changeset; potentially a more targeted approach would be preferable. On the other hand, adding this to the permanent Pint configuration may also be considered.

Note that the original RFC intended to infer this 'static'ness, however the detection was dropped in implementation due to compatibility issues. As such, manually adding this remains relevant.