### PR TITLE
[13.x] Add managedQueues() to the Cloud queue

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -528,6 +528,18 @@ class Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the names of the managed queues configured for this connection.
+     *
+     * @return array<int, string>
+     */
+    public function managedQueues()
+    {
+        $queues = $this->config['queues'] ?? [];
+
+        return array_is_list($queues) ? $queues : array_keys($queues);
+    }
+
+    /**
      * Dynamically pass method calls to the underlying queue.
      *
      * @param  string  $method

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -1539,6 +1539,27 @@ class QueueTest extends TestCase
         $this->assertSame('orders.fifo', $eventsFake->emitted[0]['queue']);
     }
 
+    public function testManagedQueuesReturnsTheConfiguredQueueNames()
+    {
+        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
+        $this->fakeEvents();
+        [$queue] = $this->mockedQueue();
+
+        $this->assertSame(['default', 'emails'], $queue->managedQueues());
+    }
+
+    public function testManagedQueuesReturnsTheKeysWhenConfiguredAsAMap()
+    {
+        config(['queue.connections.cloud.queues' => [
+            'default' => ['timeout' => 10],
+            'emails' => ['timeout' => 1],
+        ]]);
+        $this->fakeEvents();
+        [$queue] = $this->mockedQueue();
+
+        $this->assertSame(['default', 'emails'], $queue->managedQueues());
+    }
+
     /**
      * @return array{Queue, MockInterface<SqsClient>}
      */

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -42,6 +42,7 @@ use InvalidArgumentException;
 use Mockery\MockInterface;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use Throwable;
@@ -1539,21 +1540,11 @@ class QueueTest extends TestCase
         $this->assertSame('orders.fifo', $eventsFake->emitted[0]['queue']);
     }
 
-    public function testManagedQueuesReturnsTheConfiguredQueueNames()
+    #[TestWith([['default', 'emails']], 'standard list')]
+    #[TestWith([['default' => ['timeout' => 10], 'emails' => ['timeout' => 1]]], 'map keyed by name')]
+    public function testManagedQueuesReturnsTheConfiguredQueueNames($queues)
     {
-        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
-        $this->fakeEvents();
-        [$queue] = $this->mockedQueue();
-
-        $this->assertSame(['default', 'emails'], $queue->managedQueues());
-    }
-
-    public function testManagedQueuesReturnsTheKeysWhenConfiguredAsAMap()
-    {
-        config(['queue.connections.cloud.queues' => [
-            'default' => ['timeout' => 10],
-            'emails' => ['timeout' => 1],
-        ]]);
+        config(['queue.connections.cloud.queues' => $queues]);
         $this->fakeEvents();
         [$queue] = $this->mockedQueue();
 


### PR DESCRIPTION
Currently, if you used managed queues between envs and queue drivers, you have to have code to handle it... ie:

  <details>
  
  
  <summary>Before / After</summary>

  ```php
  if (Feature::active('a')) { // Here's we're basically guessing that some-queue is actually a managed queue...
      laravel_cloud() && config('queue.connections.cloud.driver') === 'cloud'
          ? Queue::reservedSize('cloud', 'some-queue')
          : Queue::reservedSize('some-queue');
  }
```
  This PR simplifies the pain greatly.. and becomes just..
  ```php
  if (Feature::active('a')) {
      laravel_cloud() && in_array('some-queue', Queue::connection('cloud')->managedQueues(), true)
          ? Queue::reservedSize('cloud', 'some-queue')
          : Queue::reservedSize('some-queue');
  }
``` 

These are just examples, and we could use helpers here, but the idea being we can access it via any call site etc so we can be sure the jobs are going to the right places when we need em to.
  </details>
  


  
This PR adds a simple `managedQueues()` method, so end users can tap in and see what queues are being managed rather than re-deriving it from the config or env directly. 
 
I've also made it handle maps, just incase it's altered in the future to contain extra settings.. >:) 

I also imagine this could be useful for the team internally, but not sure on the use case. 

Ideally i'd love a Cloud facade, but y'all will need to cook that, I'm just some random fella.

If you have any questions, or need anything from me lmk 🫡  