### PR TITLE
[13.x] feat: add closure support to wherePivot and orWherePivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -375,7 +375,7 @@ class BelongsToMany extends Relation
     /**
      * Set a where clause for a pivot table column.
      *
-     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TPivotModel>): mixed)|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -383,6 +383,18 @@ class BelongsToMany extends Relation
      */
     public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if ($column instanceof Closure) {
+            $pivotQuery = (new ($this->getPivotClass()))
+                ->setTable($this->table)
+                ->newQueryWithoutRelationships();
+
+            $column($pivotQuery);
+
+            $this->query->getQuery()->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+
+            return $this;
+        }
+
         $this->pivotWheres[] = func_get_args();
 
         return $this->where($this->qualifyPivotColumn($column), $operator, $value, $boolean);
@@ -458,7 +470,7 @@ class BelongsToMany extends Relation
     /**
      * Set an "or where" clause for a pivot table column.
      *
-     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TPivotModel>): mixed)|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this

--- a/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Schema\Blueprint;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyWherePivotClosureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema(): void
+    {
+        $this->schema()->create('users', function (Blueprint $t) {
+            $t->id();
+            $t->string('name');
+        });
+
+        $this->schema()->create('projects', function (Blueprint $t) {
+            $t->id();
+            $t->string('title');
+        });
+
+        $this->schema()->create('project_user', function (Blueprint $t) {
+            $t->unsignedBigInteger('project_id');
+            $t->unsignedBigInteger('user_id');
+            $t->string('role')->default('member');
+            $t->boolean('muted')->default(false);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('project_user');
+        $this->schema()->drop('projects');
+        $this->schema()->drop('users');
+    }
+
+    public function testWherePivotWithClosureCallsPivotModelScope(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false, 'role' => 'admin']);
+        $project->subscribers()->attach($muted->id, ['muted' => true, 'role' => 'member']);
+
+        $results = $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($active->id, $results->first()->id);
+    }
+
+    public function testOrWherePivotWithClosureCallsPivotModelScope(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $admin = WherePivotClosureUser::create(['name' => 'Admin']);
+        $active = WherePivotClosureUser::create(['name' => 'Active']);
+        $mutedMember = WherePivotClosureUser::create(['name' => 'Muted Member']);
+
+        $project->subscribers()->attach($admin->id, ['muted' => true, 'role' => 'admin']);
+        $project->subscribers()->attach($active->id, ['muted' => false, 'role' => 'member']);
+        $project->subscribers()->attach($mutedMember->id, ['muted' => true, 'role' => 'member']);
+
+        $results = $project->subscribers()
+            ->wherePivot('role', 'admin')
+            ->orWherePivot(function ($query) {
+                $query->active();
+            })
+            ->get();
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($results->contains('id', $admin->id));
+        $this->assertTrue($results->contains('id', $active->id));
+    }
+
+    public function testWherePivotClosureWithMultipleScopeConditions(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $activeAdmin = WherePivotClosureUser::create(['name' => 'Active Admin']);
+        $activeMember = WherePivotClosureUser::create(['name' => 'Active Member']);
+        $mutedAdmin = WherePivotClosureUser::create(['name' => 'Muted Admin']);
+
+        $project->subscribers()->attach($activeAdmin->id, ['muted' => false, 'role' => 'admin']);
+        $project->subscribers()->attach($activeMember->id, ['muted' => false, 'role' => 'member']);
+        $project->subscribers()->attach($mutedAdmin->id, ['muted' => true, 'role' => 'admin']);
+
+        $results = $project->subscribers()->wherePivot(function ($query) {
+            $query->active()->admins();
+        })->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($activeAdmin->id, $results->first()->id);
+    }
+
+    public function testWherePivotClosureWithInlineWhere(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $user1 = WherePivotClosureUser::create(['name' => 'User 1']);
+        $user2 = WherePivotClosureUser::create(['name' => 'User 2']);
+
+        $project->subscribers()->attach($user1->id, ['muted' => false, 'role' => 'admin']);
+        $project->subscribers()->attach($user2->id, ['muted' => false, 'role' => 'member']);
+
+        $results = $project->subscribers()->wherePivot(function ($query) {
+            $query->where('role', 'admin');
+        })->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($user1->id, $results->first()->id);
+    }
+
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class WherePivotClosureProject extends Eloquent
+{
+    protected $table = 'projects';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function subscribers(): BelongsToMany
+    {
+        return $this->belongsToMany(WherePivotClosureUser::class, 'project_user', 'project_id', 'user_id')
+            ->using(WherePivotClosureSubscription::class)
+            ->withPivot(['role', 'muted']);
+    }
+}
+
+class WherePivotClosureUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+class WherePivotClosureSubscription extends Pivot
+{
+    protected $table = 'project_user';
+
+    public function scopeActive($query)
+    {
+        return $query->where('muted', false);
+    }
+
+    public function scopeAdmins($query)
+    {
+        return $query->where('role', 'admin');
+    }
+}

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1070,6 +1070,47 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 
+    public function testWherePivotWithClosure()
+    {
+        $tag1 = Tag::create(['name' => Str::random()])->fresh();
+        $tag2 = Tag::create(['name' => Str::random()])->fresh();
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+
+        $tags = $post->tagsWithCustomExtraPivot()->wherePivot(function ($query) {
+            $query->active();
+        })->get();
+
+        $this->assertCount(1, $tags);
+        $this->assertEquals($tag1->id, $tags->first()->id);
+    }
+
+    public function testOrWherePivotWithClosure()
+    {
+        $tag1 = Tag::create(['name' => Str::random()])->fresh();
+        $tag2 = Tag::create(['name' => Str::random()])->fresh();
+        $tag3 = Tag::create(['name' => Str::random()])->fresh();
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $tags = $post->tagsWithCustomExtraPivot()->wherePivot('flag', 'bar')->orWherePivot(function ($query) {
+            $query->active();
+        })->get();
+
+        $this->assertCount(2, $tags);
+        $this->assertTrue($tags->contains('id', $tag1->id));
+        $this->assertTrue($tags->contains('id', $tag2->id));
+    }
+
     public function testFirstWhere()
     {
         $tag = Tag::create(['name' => 'foo'])->fresh();
@@ -1649,6 +1690,11 @@ class PostTagPivot extends Pivot
     public function getCreatedAtAttribute($value)
     {
         return Carbon::parse($value)->format('U');
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('flag', 'foo');
     }
 }
 


### PR DESCRIPTION
Hello!

This allows passing a Closure to `wherePivot()` that receives a query builder scoped to the pivot model. This enables calling scopes defined on custom pivot models directly from the relationship query, rather than scattering pivot filtering logic across parent models or using static helpers.

When a Closure is passed, the pivot model (from `->using()` or the base Pivot class) is instantiated with the correct table name, and its query builder is passed to the closure. The resulting where clauses are merged as a nested group into the main relationship query. `orWherePivot` works automatically since it delegates to `wherePivot` with `$boolean = 'or'`.

```php
$project->subscribers()
    ->wherePivot(function ($query) {
        $query->active()->notMuted();
    })
    ->get();
```

Thanks!