### PR TITLE
Do not call is_callable() on string factory attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -601,7 +601,7 @@ abstract class Factory
                 return $attribute;
             })
             ->map(function ($attribute, $key) use (&$definition, $evaluateRelations) {
-                if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
+                if (! is_string($attribute) && ! is_array($attribute) && is_callable($attribute)) {
                     $attribute = $attribute($definition);
                 }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -108,6 +108,25 @@ class DatabaseEloquentFactoryTest extends TestCase
         Container::setInstance(null);
     }
 
+    public function test_string_attributes_are_not_passed_to_is_callable()
+    {
+        $autoloaded = [];
+        $spy = function ($class) use (&$autoloaded) {
+            $autoloaded[] = $class;
+        };
+
+        spl_autoload_register($spy);
+
+        try {
+            $user = FactoryTestUserFactory::new()->makeOne(['name' => '\::someMethod']);
+        } finally {
+            spl_autoload_unregister($spy);
+        }
+
+        $this->assertSame('\::someMethod', $user->name);
+        $this->assertNotContains('', $autoloaded);
+    }
+
     public function test_basic_model_can_be_created()
     {
         $user = FactoryTestUserFactory::new()->create();


### PR DESCRIPTION
`Factory::expandAttributes()` currently evaluates

```php
is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)
```

so `is_callable()` runs on *every* attribute, including strings that are then immediately discarded by the following two checks.

That is not free. `is_callable()` on a string containing `::` triggers class resolution, and PHP asks the autoloader for the class part. For a string starting with `\::`, PHP strips the leading `\` and asks the autoloader for the **empty class name**, which makes Composer's `ClassLoader` emit `Warning: Uninitialized string offset 0` — and with `HandleExceptions` in place, that warning becomes an `ErrorException`.

We hit this in CI: `UserFactory` used Faker's `password()`, whose alphabet includes `\` and `:`, so roughly 1 in a million generated passwords starts with `\::`. Random unrelated tests then errored with:

```
ErrorException: Uninitialized string offset 0
  Factory.php:506
```

Autoload spy on PHP 8.3.31:

```
-- is_callable('::a')
-- is_callable('\::a')
autoload requested: ''
-- is_callable('\Foo::a')
autoload requested: 'Foo'
-- is_callable('Foo::a')
autoload requested: 'Foo'
```

I have also reported this to [composer/composer](https://github.com/composer/composer/pull/13031) and to php-src, but the framework can avoid it entirely.

## The change

Reorder the conditions so the cheap type checks come first:

```php
! is_string($attribute) && ! is_array($attribute) && is_callable($attribute)
```

Behaviour is identical — the conjunction is the same set — and it is marginally faster, because strings and arrays now short-circuit before the callable resolution.

The added test registers an autoloader spy and asserts a `'\::someMethod'` attribute never causes a lookup for the empty class name. It fails on `13.x` without the reorder and passes with it.