### PR TITLE
[13.x] feat: add chaperone support for BelongsToMany pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -290,9 +290,7 @@ class BelongsToMany extends Relation
             if ($key !== null && isset($dictionary[$key])) {
                 $items = $dictionary[$key];
 
-                // During eager loading, hydratePivotRelation sets the declaring
-                // side to $this->parent which is only the first parent model. Here
-                // we correct it to the actual parent for each group of results.
+                // Correct $this->parent to the actual parent for each group of results...
                 if ($this->declaringInverseRelationship) {
                     foreach ($items as $item) {
                         $item->{$this->accessor}?->setRelation(

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsPivotInverseRelations;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
@@ -31,7 +32,7 @@ use SortDirection;
  */
 class BelongsToMany extends Relation
 {
-    use InteractsWithDictionary, InteractsWithPivotTable;
+    use InteractsWithDictionary, InteractsWithPivotTable, SupportsPivotInverseRelations;
 
     /**
      * The intermediate table for the relation.
@@ -287,8 +288,21 @@ class BelongsToMany extends Relation
             $key = $this->getDictionaryKey($model->{$this->parentKey});
 
             if ($key !== null && isset($dictionary[$key])) {
+                $items = $dictionary[$key];
+
+                // During eager loading, hydratePivotRelation sets the declaring
+                // side to $this->parent which is only the first parent model. Here
+                // we correct it to the actual parent for each group of results.
+                if ($this->declaringInverseRelationship) {
+                    foreach ($items as $item) {
+                        $item->{$this->accessor}?->setRelation(
+                            $this->declaringInverseRelationship, $model
+                        );
+                    }
+                }
+
                 $model->setRelation(
-                    $relation, $this->related->newCollection($dictionary[$key])
+                    $relation, $this->related->newCollection($items)
                 );
             }
         }
@@ -1252,9 +1266,11 @@ class BelongsToMany extends Relation
         // and create a new Pivot model, which is basically a dynamic model that we
         // will set the attributes, table, and connections on it so it will work.
         foreach ($models as $model) {
-            $model->setRelation($this->accessor, $this->newExistingPivot(
-                $this->migratePivotAttributes($model)
-            ));
+            $pivot = $this->newExistingPivot($this->migratePivotAttributes($model));
+
+            $this->applyChaperonesToPivot($pivot, $this->parent, $model);
+
+            $model->setRelation($this->accessor, $pivot);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsPivotInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsPivotInverseRelations.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+trait SupportsPivotInverseRelations
+{
+    /**
+     * The name of the declaring model's relationship on the pivot.
+     */
+    protected ?string $declaringInverseRelationship = null;
+
+    /**
+     * The name of the related model's relationship on the pivot.
+     */
+    protected ?string $relatedInverseRelationship = null;
+
+    /**
+     * Instruct Eloquent to link the declaring and related models back to the pivot after the relationship query has run.
+     *
+     * @return $this
+     */
+    public function chaperone(?string $declaring = null, ?string $related = null): static
+    {
+        if (! $this->using) {
+            return $this;
+        }
+
+        $pivotModel = new $this->using;
+
+        $this->declaringInverseRelationship = $this->resolvePivotInverseRelation(
+            $pivotModel, $declaring, $this->foreignPivotKey, $this->parent
+        );
+
+        $this->relatedInverseRelationship = $this->resolvePivotInverseRelation(
+            $pivotModel, $related, $this->relatedPivotKey, $this->related
+        );
+
+        return $this;
+    }
+
+    /**
+     * Remove the chaperone relationships for this query.
+     *
+     * @return $this
+     */
+    public function withoutChaperone(): static
+    {
+        $this->declaringInverseRelationship = null;
+        $this->relatedInverseRelationship = null;
+
+        return $this;
+    }
+
+    /**
+     * Resolve the inverse relation name on the pivot for a given model.
+     *
+     * If an explicit name is provided and invalid, an exception is thrown.
+     * If guessing fails, null is returned.
+     *
+     * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
+     */
+    protected function resolvePivotInverseRelation(Model $pivotModel, ?string $relation, string $foreignKey, Model $model): ?string
+    {
+        if ($relation !== null) {
+            if (! $pivotModel->isRelation($relation)) {
+                throw RelationNotFoundException::make($pivotModel, $relation);
+            }
+
+            return $relation;
+        }
+
+        return $this->guessPivotInverseRelation($pivotModel, $foreignKey, $model);
+    }
+
+    /**
+     * Attempt to guess the inverse relation name on the pivot for a given model.
+     */
+    protected function guessPivotInverseRelation(Model $pivotModel, string $foreignKey, Model $model): ?string
+    {
+        $candidates = array_filter(array_unique([
+            Str::camel(Str::beforeLast($foreignKey, $model->getKeyName())),
+            Str::camel(class_basename($model)),
+        ]));
+
+        return Arr::first(
+            $candidates,
+            fn ($relation) => $pivotModel->isRelation($relation)
+        );
+    }
+
+    /**
+     * Apply chaperone relationships to a pivot model instance.
+     */
+    protected function applyChaperonesToPivot(Model $pivot, Model $declaring, Model $related): void
+    {
+        if ($this->declaringInverseRelationship) {
+            $pivot->setRelation($this->declaringInverseRelationship, $declaring);
+        }
+
+        if ($this->relatedInverseRelationship) {
+            $pivot->setRelation($this->relatedInverseRelationship, $related);
+        }
+    }
+}

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1470,6 +1470,171 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             $instance->toArray(),
         );
     }
+
+    public function testChaperoneSetsDeclaringAndRelatedOnPivot()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tagsWithChaperoneCustomPivot()->attach($tag);
+
+        $post = Post::first();
+        $tags = $post->tagsWithChaperoneCustomPivot;
+
+        $this->assertCount(1, $tags);
+        $pivot = $tags[0]->pivot;
+        $this->assertInstanceOf(ChaperonePostTagPivot::class, $pivot);
+        $this->assertTrue($pivot->relationLoaded('post'));
+        $this->assertTrue($pivot->relationLoaded('tag'));
+        $this->assertTrue($post->is($pivot->post));
+        $this->assertTrue($tag->is($pivot->tag));
+    }
+
+    public function testChaperoneWithExplicitRelationNames()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tagsWithChaperoneExplicit()->attach($tag);
+
+        $post = Post::first();
+        $tags = $post->tagsWithChaperoneExplicit;
+
+        $pivot = $tags[0]->pivot;
+        $this->assertTrue($pivot->relationLoaded('post'));
+        $this->assertTrue($pivot->relationLoaded('tag'));
+        $this->assertTrue($post->is($pivot->post));
+        $this->assertTrue($tag->is($pivot->tag));
+    }
+
+    public function testChaperoneGuessesOnlyExistingRelations()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tagsWithChaperonePartialPivot()->attach($tag);
+
+        $post = Post::first();
+        $tags = $post->tagsWithChaperonePartialPivot;
+
+        $pivot = $tags[0]->pivot;
+        $this->assertInstanceOf(ChaperonePartialPivot::class, $pivot);
+        $this->assertTrue($pivot->relationLoaded('post'));
+        $this->assertFalse($pivot->relationLoaded('tag'));
+        $this->assertTrue($post->is($pivot->post));
+    }
+
+    public function testChaperoneWithEagerLoading()
+    {
+        $post1 = Post::create(['title' => Str::random()]);
+        $post2 = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post1->tagsWithChaperoneCustomPivot()->attach($tag);
+        $post2->tagsWithChaperoneCustomPivot()->attach($tag);
+
+        $posts = Post::with('tagsWithChaperoneCustomPivot')->get();
+
+        foreach ($posts as $post) {
+            $this->assertCount(1, $post->tagsWithChaperoneCustomPivot);
+            $pivot = $post->tagsWithChaperoneCustomPivot[0]->pivot;
+            $this->assertTrue($pivot->relationLoaded('post'));
+            $this->assertTrue($pivot->relationLoaded('tag'));
+            $this->assertTrue($post->is($pivot->post));
+            $this->assertTrue($tag->is($pivot->tag));
+        }
+    }
+
+    public function testChaperoneWithoutCustomPivotIsNoop()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach($tag, ['flag' => 'test']);
+
+        $post = Post::first();
+        $relation = $post->tags()->chaperone();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class, $relation);
+    }
+
+    public function testWithoutChaperoneClearsInverseRelations()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tagsWithChaperoneCustomPivot()->attach($tag);
+
+        $post = Post::first();
+        $tags = $post->tagsWithChaperoneCustomPivot()->withoutChaperone()->get();
+
+        $pivot = $tags[0]->pivot;
+        $this->assertFalse($pivot->relationLoaded('post'));
+        $this->assertFalse($pivot->relationLoaded('tag'));
+    }
+
+    public function testChaperoneThrowsForExplicitInvalidRelation()
+    {
+        $this->expectException(\Illuminate\Database\Eloquent\RelationNotFoundException::class);
+
+        $post = Post::create(['title' => Str::random()]);
+        $post->tagsWithChaperoneCustomPivot()->chaperone('nonexistent');
+    }
+
+    public function testChaperoneFromRelatedSide()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $tag->postsWithChaperone()->attach($post);
+
+        $tag = Tag::first();
+        $posts = $tag->postsWithChaperone;
+
+        $this->assertCount(1, $posts);
+        $pivot = $posts[0]->pivot;
+        $this->assertInstanceOf(ChaperonePostTagPivot::class, $pivot);
+        $this->assertTrue($pivot->relationLoaded('tag'));
+        $this->assertTrue($pivot->relationLoaded('post'));
+        $this->assertTrue($tag->is($pivot->tag));
+        $this->assertTrue($post->is($pivot->post));
+    }
+
+    public function testChaperoneFromRelatedSideWithEagerLoading()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+
+        $tag1->postsWithChaperone()->attach($post);
+        $tag2->postsWithChaperone()->attach($post);
+
+        $tags = Tag::with('postsWithChaperone')->get();
+
+        foreach ($tags as $tag) {
+            $this->assertCount(1, $tag->postsWithChaperone);
+            $pivot = $tag->postsWithChaperone[0]->pivot;
+            $this->assertTrue($pivot->relationLoaded('tag'));
+            $this->assertTrue($pivot->relationLoaded('post'));
+            $this->assertTrue($tag->is($pivot->tag));
+            $this->assertTrue($post->is($pivot->post));
+        }
+    }
+
+    public function testChaperoneWithoutCustomPivotStillReturnsResults()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach($tag, ['flag' => 'test']);
+
+        $post = Post::first();
+        $tags = $post->tags()->chaperone()->get();
+
+        $this->assertCount(1, $tags);
+        $this->assertTrue($tag->is($tags[0]));
+        $this->assertInstanceOf(Pivot::class, $tags[0]->pivot);
+    }
 }
 
 class User extends Model
@@ -1627,6 +1792,27 @@ class Post extends Model
     {
         return $this->belongsToMany(TagWithGlobalScope::class, 'posts_tags', 'post_id', 'tag_id');
     }
+
+    public function tagsWithChaperoneCustomPivot()
+    {
+        return $this->belongsToMany(Tag::class, 'posts_tags', 'post_id', 'tag_id')
+            ->using(ChaperonePostTagPivot::class)
+            ->chaperone();
+    }
+
+    public function tagsWithChaperoneExplicit()
+    {
+        return $this->belongsToMany(Tag::class, 'posts_tags', 'post_id', 'tag_id')
+            ->using(ChaperonePostTagPivot::class)
+            ->chaperone('post', 'tag');
+    }
+
+    public function tagsWithChaperonePartialPivot()
+    {
+        return $this->belongsToMany(Tag::class, 'posts_tags', 'post_id', 'tag_id')
+            ->using(ChaperonePartialPivot::class)
+            ->chaperone();
+    }
 }
 
 class Tag extends Model
@@ -1638,6 +1824,13 @@ class Tag extends Model
     public function posts()
     {
         return $this->belongsToMany(Post::class, 'posts_tags', 'tag_id', 'post_id');
+    }
+
+    public function postsWithChaperone()
+    {
+        return $this->belongsToMany(Post::class, 'posts_tags', 'tag_id', 'post_id')
+            ->using(ChaperonePostTagPivot::class)
+            ->chaperone();
     }
 }
 
@@ -1711,5 +1904,30 @@ class TagWithGlobalScope extends Model
         static::addGlobalScope(function ($query) {
             $query->select('tags.id');
         });
+    }
+}
+
+class ChaperonePostTagPivot extends Pivot
+{
+    protected $table = 'posts_tags';
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function tag()
+    {
+        return $this->belongsTo(Tag::class);
+    }
+}
+
+class ChaperonePartialPivot extends Pivot
+{
+    protected $table = 'posts_tags';
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
     }
 }


### PR DESCRIPTION
Hello!

Many times when using custom pivot models, the BelongsTo relations can be defined on the model---however, trying to use them requires loading the models from the database even though both of the models are available during the BelongsToMany hydration

This PR adds `chaperone` support to the `BelongsToMany` relation, if a custom pivot model is not provided then calling `->chaperone()` is a no-op. Any  relations that don't exist are skipped (some pivot models only define one relation or even no relations); however, if a relation name is explicitly provided and the corresponding relation does not exist then an exception is thrown

```php
class PostTagPivot extends Pivot
{
    public function post(): BelongsTo
    {
        return $this->belongsTo(Post::class);
    }

    public function tag(): BelongsTo
    {
        return $this->belongsTo(Tag::class);
    }
}

class Tag extends Model
{
    public function posts(): BelongsToMany
    {
        return $this->belongsToMany(Post::class)
            ->using(PostTagPivot::class)
            // automatically guesses relationship names
            ->chaperone();
            // but can override if needed or non-standard
            ->chaperone(declaring: 'tag', related: 'post');
    }
}

class Post extends Model
{
    public function tags(): BelongsToMany
    {
        return $this->belongsToMany(Tag::class)
            ->using(PostTagPivot::class)
            ->chaperone(declaring: 'post', related: 'tag');
    }
}
```

Thanks!