### PR TITLE
[13.x] feat: add orWhereKey and orWhereKeyNot to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -271,10 +271,9 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the primary key to the query.
      *
-     * @param  mixed  $id
      * @return $this
      */
-    public function whereKey($id)
+    public function whereKey(mixed $id, string $boolean = 'and', bool $not = false): static
     {
         if ($id instanceof Model) {
             $id = $id->getKey();
@@ -282,9 +281,9 @@ class Builder implements BuilderContract
 
         if (is_array($id) || $id instanceof Arrayable) {
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
-                $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id);
+                $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id, $boolean, $not);
             } else {
-                $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+                $this->query->whereIn($this->model->getQualifiedKeyName(), $id, $boolean, $not);
             }
 
             return $this;
@@ -294,36 +293,37 @@ class Builder implements BuilderContract
             $id = (string) $id;
         }
 
-        return $this->where($this->model->getQualifiedKeyName(), '=', $id);
+        return $this->where($this->model->getQualifiedKeyName(), $not ? '!=' : '=', $id, $boolean);
     }
 
     /**
      * Add a where clause on the primary key to the query.
      *
-     * @param  mixed  $id
      * @return $this
      */
-    public function whereKeyNot($id)
+    public function whereKeyNot(mixed $id, string $boolean = 'and'): static
     {
-        if ($id instanceof Model) {
-            $id = $id->getKey();
-        }
+        return $this->whereKey($id, $boolean, true);
+    }
 
-        if (is_array($id) || $id instanceof Arrayable) {
-            if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
-                $this->query->whereIntegerNotInRaw($this->model->getQualifiedKeyName(), $id);
-            } else {
-                $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
-            }
+    /**
+     * Add an "or where" clause on the primary key to the query.
+     *
+     * @return $this
+     */
+    public function orWhereKey(mixed $id): static
+    {
+        return $this->whereKey($id, 'or');
+    }
 
-            return $this;
-        }
-
-        if ($id !== null && $this->model->getKeyType() === 'string') {
-            $id = (string) $id;
-        }
-
-        return $this->where($this->model->getQualifiedKeyName(), '!=', $id);
+    /**
+     * Add an "or where not" clause on the primary key to the query.
+     *
+     * @return $this
+     */
+    public function orWhereKeyNot(mixed $id): static
+    {
+        return $this->whereKeyNot($id, 'or');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -33,7 +33,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('first')->with(['column'])->andReturn('baz');
 
         $result = $builder->find('bar', ['column']);
@@ -46,7 +46,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('sole')->with(['column'])->andReturn('baz');
 
         $result = $builder->findSole('bar', ['column']);
@@ -60,7 +60,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', ['one', 'two']);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', ['one', 'two'], 'and', false);
         $builder->expects('get')->with(['column'])->andReturn(['baz']);
 
         $result = $builder->findMany(['one', 'two'], ['column']);
@@ -98,7 +98,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('first')->with(['column'])->andReturn('baz');
 
         $expected = $model->findOrNew('bar', ['column']);
@@ -114,7 +114,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('first')->with(['column'])->andReturn(null);
 
         $result = $model->findOrNew('bar', ['column']);
@@ -131,7 +131,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('first')->with(['column'])->andReturn(null);
         $builder->findOrFail('bar', ['column']);
     }
@@ -164,7 +164,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail([1, 2], ['column']);
     }
@@ -179,7 +179,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail(new Collection([1, 2]), ['column']);
     }
@@ -190,8 +190,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->times(3)->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 1)->times(2);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 2);
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 1, 'and')->times(2);
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 2, 'and');
         $builder->expects('first')->andReturn($model);
         $builder->expects('first')->with(['column'])->andReturn($model);
         $builder->expects('first')->andReturn(null);
@@ -209,8 +209,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1->expects('getKeyType')->times(3)->andReturn('int');
         $model2->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model1);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->times(2);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false)->times(2);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3], 'and', false);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->andReturn(null);
@@ -237,8 +237,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1->expects('getKeyType')->times(3)->andReturn('int');
         $model2->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model1);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->times(2);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false)->times(2);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3], 'and', false);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->andReturn(null);
@@ -272,7 +272,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
         $builder->setModel($model);
         $builder->expects('get')->with(['column'])->andReturn('baz');
 
@@ -286,7 +286,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
         $builder->setModel($model);
         $builder->expects('get')->with(['column'])->andReturn('baz');
 
@@ -384,7 +384,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
         $builder->expects('first')->with(['column'])->andReturn(null);
         $builder->whereKey('bar')->valueOrFail('column');
     }
@@ -2293,7 +2293,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $int = 1;
 
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '=', $int);
+        $builder->getQuery()->expects('where')->with($keyName, '=', $int, 'and');
 
         $builder->whereKey($int);
     }
@@ -2306,7 +2306,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->expects('where')->with($keyName, '=', (string) $int);
+        $builder->getQuery()->expects('where')->with($keyName, '=', (string) $int, 'and');
 
         $builder->whereKey($int);
     }
@@ -2319,7 +2319,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '=', Mockery::on(function ($argument) {
             return $argument === null;
-        }));
+        }), 'and');
 
         $builder->whereKey(null);
     }
@@ -2333,7 +2333,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $array = [1, 2, 3];
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'and', false);
 
         $builder->whereKey($array);
     }
@@ -2347,7 +2347,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $collection = new Collection([1, 2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'and', false);
 
         $builder->whereKey($collection);
     }
@@ -2360,7 +2360,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }));
+        }), 'and');
 
         $builder->whereKey(new class extends Model
         {
@@ -2376,7 +2376,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->expects('where')->with($keyName, '!=', (string) $int);
+        $builder->getQuery()->expects('where')->with($keyName, '!=', (string) $int, 'and');
 
         $builder->whereKeyNot($int);
     }
@@ -2389,7 +2389,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === null;
-        }));
+        }), 'and');
 
         $builder->whereKeyNot(null);
     }
@@ -2403,7 +2403,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $int = 1;
 
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '!=', $int);
+        $builder->getQuery()->expects('where')->with($keyName, '!=', $int, 'and');
 
         $builder->whereKeyNot($int);
     }
@@ -2417,7 +2417,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $array = [1, 2, 3];
 
-        $builder->getQuery()->expects('whereIntegerNotInRaw')->with($keyName, $array);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'and', true);
 
         $builder->whereKeyNot($array);
     }
@@ -2431,7 +2431,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $collection = new Collection([1, 2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerNotInRaw')->with($keyName, $collection);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'and', true);
 
         $builder->whereKeyNot($collection);
     }
@@ -2444,12 +2444,96 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }));
+        }), 'and');
 
         $builder->whereKeyNot(new class extends Model
         {
             protected $attributes = ['id' => 1];
         });
+    }
+
+    public function testOrWhereKeyMethodWithInt()
+    {
+        $model = $this->getMockModel();
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $int = 1;
+
+        $model->expects('getKeyType')->andReturn('int');
+        $builder->getQuery()->expects('where')->with($keyName, '=', $int, 'or');
+
+        $builder->orWhereKey($int);
+    }
+
+    public function testOrWhereKeyMethodWithArray()
+    {
+        $model = $this->getMockModel();
+        $model->expects('getKeyType')->andReturn('int');
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $array = [1, 2, 3];
+
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'or', false);
+
+        $builder->orWhereKey($array);
+    }
+
+    public function testOrWhereKeyMethodWithCollection()
+    {
+        $model = $this->getMockModel();
+        $model->expects('getKeyType')->andReturn('int');
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $collection = new Collection([1, 2, 3]);
+
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'or', false);
+
+        $builder->orWhereKey($collection);
+    }
+
+    public function testOrWhereKeyNotMethodWithInt()
+    {
+        $model = $this->getMockModel();
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $int = 1;
+
+        $model->expects('getKeyType')->andReturn('int');
+        $builder->getQuery()->expects('where')->with($keyName, '!=', $int, 'or');
+
+        $builder->orWhereKeyNot($int);
+    }
+
+    public function testOrWhereKeyNotMethodWithArray()
+    {
+        $model = $this->getMockModel();
+        $model->expects('getKeyType')->andReturn('int');
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $array = [1, 2, 3];
+
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'or', true);
+
+        $builder->orWhereKeyNot($array);
+    }
+
+    public function testOrWhereKeyNotMethodWithCollection()
+    {
+        $model = $this->getMockModel();
+        $model->expects('getKeyType')->andReturn('int');
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $collection = new Collection([1, 2, 3]);
+
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'or', true);
+
+        $builder->orWhereKeyNot($collection);
     }
 
     public function testExceptMethodWithModel()
@@ -2460,7 +2544,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }));
+        }), 'and');
 
         $builder->except(new class extends Model
         {
@@ -2474,9 +2558,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
+        $builder->getQuery()->expects('whereIn')->with($keyName, Mockery::on(function ($argument) {
             return $argument === [1, 2];
-        }));
+        }), 'and', true);
 
         $models = new Collection([
             new class extends Model
@@ -2498,9 +2582,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
+        $builder->getQuery()->expects('whereIn')->with($keyName, Mockery::on(function ($argument) {
             return $argument === [1, 2];
-        }));
+        }), 'and', true);
 
         $models = [
             new class extends Model


### PR DESCRIPTION
Hello!

There's been many, many times where I've wanted to reach for a `orWhereKey()` method, but it doesn't exist so I've had to completely restructure my query or fallback to the `->orWhereIn('id', ...)` that the `whereKey()` method was generally supposed to replace.

This PR adds both the `orWhereKey()` and `orWhereKeyNot()` methods for completeness. The existing `whereKey()`/`whereKeyNot()` methods were basically duplicates of each other with a lot of repetitive code, so that's been cleaned up as well.

> [!NOTE]
> This is not a BC from the *caller's* perspective, however, this does change the method signatures so I guess this technically would be a BC if someone extended the Builder class and overrode the `whereKey`/`whereKeyNot` methods (but not sure why anyone would do that).
> 
> In any case, let me know if it's acceptable to put into 13.x, or if I need to target 14.x

Thanks!