### PR TITLE
[13.x] allow read through filesystems to optionally not copy

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -298,6 +298,7 @@ class FilesystemManager implements FactoryContract
             $primary->getDriver(),
             $fallback->getDriver(),
             $config['throw_on_promotion_failure'] ?? false,
+            $config['copy'] ?? true,
         );
 
         return new ReadThroughFilesystem(

--- a/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
@@ -18,6 +18,7 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
         protected FilesystemOperator $primary,
         protected FilesystemOperator $fallback,
         protected bool $throwOnPromotionFailure = false,
+        protected bool $copy = true,
     ) {
     }
 
@@ -64,6 +65,10 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
 
         $contents = $this->fallback->read($path);
 
+        if (! $this->copy) {
+            return $contents;
+        }
+
         if ($this->primary->fileExists($path)) {
             return $this->primary->read($path);
         }
@@ -84,6 +89,10 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
     {
         if ($this->primary->fileExists($path)) {
             return $this->primary->readStream($path);
+        }
+
+        if (! $this->copy) {
+            return $this->fallback->readStream($path);
         }
 
         $source = $this->fallback->readStream($path);

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -275,6 +275,30 @@ class FilesystemManagerTest extends TestCase
         fclose($stream);
     }
 
+    public function testReadThroughDisksDoNotCopyWhenDisabled()
+    {
+        $filesystem = $this->readThroughFilesystemManager([
+            'copy' => false,
+        ]);
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('fallback.txt', 'fallback contents');
+
+        $this->assertSame('fallback contents', $readThrough->get('fallback.txt'));
+        $this->assertTrue($primary->missing('fallback.txt'));
+
+        $fallback->put('stream.txt', 'stream contents');
+
+        $stream = $readThrough->readStream('stream.txt');
+
+        $this->assertSame('stream contents', stream_get_contents($stream));
+        $this->assertTrue($primary->missing('stream.txt'));
+
+        fclose($stream);
+    }
+
     public function testReadThroughDiskPromotionFailuresAreBestEffortByDefault()
     {
         $filesystem = $this->readThroughFilesystemManager([


### PR DESCRIPTION
The original intent of read-through file systems appears to have been migrating between production storage services gradually. Another common use case would be loading a production data snapshot in local dev that has pointers in the data to files stored on production file storage. This copy flag would extend the functionality for me to serve read-through production assets in a dev environment without cluttering my local disk with files.