### PR TITLE
[13.x] Only register pail dev command when installed

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Support\NodePackageManager;
+use Laravel\Pail\PailServiceProvider;
 use ReflectionClass;
 
 /**
@@ -96,7 +97,7 @@ class DevCommands
         self::artisan('serve', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
 
-        if (function_exists('pcntl_fork')) {
+        if (function_exists('pcntl_fork') && class_exists(PailServiceProvider::class)) {
             self::artisan('pail --timeout=0', 'logs');
         }
 

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -97,7 +97,7 @@ class DevCommands
         self::artisan('serve', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
 
-        if (function_exists('pcntl_fork') && class_exists(PailServiceProvider::class)) {
+        if (function_exists('pcntl_fork') && app()->providerIsLoaded(PailServiceProvider::class)) {
             self::artisan('pail --timeout=0', 'logs');
         }
 

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -304,7 +304,6 @@ class FoundationDevCommandsTest extends TestCase
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRegisterDefaultsRegistersExpectedCommands()
     {
-        // Pretend the "laravel/pail" package is installed to prove it registers...
         $provider = Mockery::mock('alias:Laravel\Pail\PailServiceProvider');
         $provider->shouldReceive('register');
 

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -8,8 +8,10 @@ use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommandMode;
 use Illuminate\Foundation\DevCommands;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use stdClass;
 
 class FoundationDevCommandsTest extends TestCase
 {
@@ -301,8 +303,13 @@ class FoundationDevCommandsTest extends TestCase
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RunInSeparateProcess]
     public function testRegisterDefaultsRegistersExpectedCommands()
     {
+        if (! class_exists('Laravel\Pail\PailServiceProvider')) {
+            class_alias(stdClass::class, 'Laravel\Pail\PailServiceProvider');
+        }
+
         DevCommands::registerDefaults();
 
         $commands = DevCommands::commands();

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -7,11 +7,10 @@ use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommandMode;
 use Illuminate\Foundation\DevCommands;
+use Mockery;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use stdClass;
 
 class FoundationDevCommandsTest extends TestCase
 {
@@ -303,12 +302,13 @@ class FoundationDevCommandsTest extends TestCase
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
-    #[RunInSeparateProcess]
     public function testRegisterDefaultsRegistersExpectedCommands()
     {
-        if (! class_exists('Laravel\Pail\PailServiceProvider')) {
-            class_alias(stdClass::class, 'Laravel\Pail\PailServiceProvider');
-        }
+        // Pretend the "laravel/pail" package is installed to prove it registers...
+        $provider = Mockery::mock('alias:Laravel\Pail\PailServiceProvider');
+        $provider->shouldReceive('register');
+
+        Application::getInstance()->register($provider);
 
         DevCommands::registerDefaults();
 


### PR DESCRIPTION
We have an older application that was built by people twice my age, us young boys keep it on the latest versions

But, we don't use pail, it was removed many moons ago

Thus, when we run `php artisan dev` 

We get: 
<details> 

<img width="1193" height="403" alt="Screenshot 2026-08-13 at 00 21 34" src="https://github.com/user-attachments/assets/5a6ddddf-fe2c-4b02-900d-a708333986bb" />

</details>

We could remove it in via `DevCommands::except`, but it felt nicer to have this handled automatically as if teams decide to remove this it should just automatically be gone imo.

I went with a provider loaded check as per feedback below, but open to just doing class_exists if you prefer.

The tests is adjusted to work the same as they do now..

Thank you sir