### PR TITLE
[13.x] Add Defaults attribute for Eloquent model default attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Defaults.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Defaults.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Defaults
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(
+        public array $attributes,
+    ) {
+        //
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\DateFormat;
+use Illuminate\Database\Eloquent\Attributes\Defaults;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -215,6 +216,11 @@ trait HasAttributes
             ?? null;
 
         $this->mergeAppends(static::resolveClassAttribute(Appends::class, 'columns') ?? []);
+
+        $this->attributes = array_merge(
+            static::resolveClassAttribute(Defaults::class, 'attributes') ?? [],
+            $this->attributes,
+        );
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\DateFormat;
+use Illuminate\Database\Eloquent\Attributes\Defaults;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -198,6 +199,42 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $model = new ModelWithDateFormatAttributeOverride;
 
         $this->assertSame('Y-m-d', $model->getDateFormat());
+    }
+
+    public function test_defaults_attribute(): void
+    {
+        $model = new ModelWithDefaultsAttribute;
+
+        $this->assertSame(['status' => 'pending', 'active' => true], $model->getAttributes());
+        $this->assertSame(['status' => 'pending', 'active' => true], $model->getOriginal());
+        $this->assertFalse($model->isDirty());
+    }
+
+    public function test_defaults_property_takes_precedence(): void
+    {
+        $model = new ModelWithDefaultsAttributeAndProperty;
+
+        $this->assertSame([
+            'status' => 'approved',
+            'active' => true,
+            'name' => 'Taylor',
+        ], $model->getAttributes());
+    }
+
+    public function test_constructor_attributes_override_defaults(): void
+    {
+        $model = new ModelWithDefaultsAttribute(['status' => 'published']);
+
+        $this->assertSame('published', $model->status);
+        $this->assertSame('pending', $model->getOriginal('status'));
+        $this->assertTrue($model->isDirty('status'));
+    }
+
+    public function test_defaults_attribute_is_inherited(): void
+    {
+        $model = new ModelExtendingDefaultsParent;
+
+        $this->assertSame(['status' => 'pending'], $model->getAttributes());
     }
 
     public function test_dedicated_without_timestamps_attribute(): void
@@ -795,6 +832,32 @@ class ModelWithTouchesAttributeVariadic extends Model
 
 #[DateFormat('Y-m-d')]
 class ModelWithDedicatedDateFormatAttribute extends Model
+{
+    //
+}
+
+#[Defaults(['status' => 'pending', 'active' => true])]
+class ModelWithDefaultsAttribute extends Model
+{
+    protected $guarded = [];
+}
+
+#[Defaults(['status' => 'pending', 'active' => true])]
+class ModelWithDefaultsAttributeAndProperty extends Model
+{
+    protected $attributes = [
+        'status' => 'approved',
+        'name' => 'Taylor',
+    ];
+}
+
+#[Defaults(['status' => 'pending'])]
+class ModelWithDefaultsParent extends Model
+{
+    //
+}
+
+class ModelExtendingDefaultsParent extends ModelWithDefaultsParent
 {
     //
 }


### PR DESCRIPTION
This PR adds a `Defaults` PHP attribute for defining Eloquent model
default attribute values.

Previously, default model attributes needed to be defined using the
`$attributes` property:

```php
protected $attributes = [
    'status' => 'draft',
    'views' => 0,
];
```

They may now alternatively be defined using the `Defaults` attribute:
```php
use Illuminate\Database\Eloquent\Attributes\Defaults;

#[Defaults([
    'status' => 'draft',
    'views' => 0,
])]
class Post extends Model
{
    //
}
```

Default values declared using the attribute are initialized before the
model's original state is synchronized and before constructor attributes
are filled, preserving the existing behavior of the $attributes
property.