### PR TITLE
[13.x] Pass a connector to PhpRedisClusterConnection so it can rebuild its client

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -51,9 +51,11 @@ class PhpRedisConnector implements Connector
     {
         $options = array_merge($options, $clusterOptions, Arr::pull($config, 'options', []));
 
-        return new PhpRedisClusterConnection($this->createRedisClusterInstance(
+        $connector = fn () => $this->createRedisClusterInstance(
             array_map($this->buildClusterConnectionString(...), $config), $options
-        ));
+        );
+
+        return new PhpRedisClusterConnection($connector(), $connector, $config);
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Tests\Redis;
 
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use RedisException;
+use ReflectionProperty;
 
 class PhpRedisConnectorTest extends TestCase
 {
@@ -288,6 +291,54 @@ class PhpRedisConnectorTest extends TestCase
             'host' => null,
             'scheme' => 'tls',
         ]);
+    }
+
+    public function testConnectToClusterPassesAConnectorToTheConnection()
+    {
+        $connector = new ClusterStubPhpRedisConnector;
+
+        $connection = $connector->connectToCluster([['host' => '127.0.0.1', 'port' => 6379]], [], []);
+
+        $property = new ReflectionProperty(PhpRedisConnection::class, 'connector');
+
+        $this->assertIsCallable($property->getValue($connection));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectToClusterAllowsTheConnectionToRebuildItsClient()
+    {
+        $connector = new ClusterStubPhpRedisConnector;
+
+        $connection = $connector->connectToCluster([['host' => '127.0.0.1', 'port' => 6379]], [], []);
+
+        $original = $connection->client();
+
+        try {
+            $connection->command('get', ['foo']);
+        } catch (RedisException) {
+            //
+        }
+
+        $this->assertSame(2, $connector->created);
+        $this->assertNotSame($original, $connection->client());
+    }
+}
+
+class ClusterStubPhpRedisConnector extends PhpRedisConnector
+{
+    public int $created = 0;
+
+    protected function createRedisClusterInstance(array $servers, array $options)
+    {
+        $this->created++;
+
+        return new class
+        {
+            public function get($key)
+            {
+                throw new RedisException('Connection lost');
+            }
+        };
     }
 }
 


### PR DESCRIPTION

`PhpRedisConnection::command()` rebuilds the underlying client when a command fails with a dropped-connection error:

```php
} catch (RedisException $e) {
    if (Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost'])) {
        $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
    }

    throw $e;
}
```

`connect()` passes a connector closure, so this works for single-instance connections. `connectToCluster()` never has:

```php
return new PhpRedisClusterConnection($this->createRedisClusterInstance(
    array_map($this->buildClusterConnectionString(...), $config), $options
));
```

Only the client is passed, so `$this->connector` is always `null` on a cluster connection and the reconnect above is a permanent no-op. The connection keeps using the dead client for the rest of the process - a queue worker or long-running process that loses a node never recovers until it is restarted, even though the framework is trying to reconnect it on every command.

This PR builds the client through a closure and hands it to the connection, so `connectToCluster()` matches the shape `connect()` already uses:

```php
$connector = fn () => $this->createRedisClusterInstance(
    array_map($this->buildClusterConnectionString(...), $config), $options
);

return new PhpRedisClusterConnection($connector(), $connector, $config);
```

`$config` is passed for parity with `connect()`. It is only stored on the connection and never read today.

The reconnect semantics for cluster connections are now identical to single-instance ones - including the fact that a reconnect attempt raising its own exception will surface instead of the original error. That behaviour is unchanged from `connect()`, so it felt out of scope to address here, but happy to follow up if you would rather it were handled centrally.

### Tests

Two tests added to `tests/Redis/PhpRedisConnectorTest.php`, using a connector subclass that stubs `createRedisClusterInstance()` so no live cluster is needed:

- `testConnectToClusterPassesAConnectorToTheConnection` - the connection actually receives a callable.
- `testConnectToClusterAllowsTheConnectionToRebuildItsClient` - a command failing with `Connection lost` swaps in a freshly built client.

Both fail on the current `13.x` (`Failed asserting that null is of type callable`, and `Failed asserting that 1 is identical to 2`) and pass with the change. `tests/Redis` is green and Pint reports no style changes.

### How this came up

A Horizon master supervisor against a Redis Cluster hit `read error on connection to <node>:7003`. The framework ran its reconnect branch, silently did nothing because the connector was `null`, and the process carried on against the dead client.
