### PR TITLE
[13.x] Discard queued commands when a phpredis pipeline or transaction fails

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use RedisException;
+use Throwable;
 
 /**
  * @mixin \Redis
@@ -402,7 +403,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
 
         return is_null($callback)
             ? $pipeline
-            : tap($pipeline, $callback)->exec();
+            : $this->executeQueuedCommands($pipeline, $callback);
     }
 
     /**
@@ -417,7 +418,43 @@ class PhpRedisConnection extends Connection implements ConnectionContract
 
         return is_null($callback)
             ? $transaction
-            : tap($transaction, $callback)->exec();
+            : $this->executeQueuedCommands($transaction, $callback);
+    }
+
+    /**
+     * Queue the commands built by the callback and execute them.
+     *
+     * @param  \Redis  $client
+     * @param  callable  $callback
+     * @return array
+     */
+    protected function executeQueuedCommands($client, callable $callback)
+    {
+        try {
+            $callback($client);
+
+            return $client->exec();
+        } catch (Throwable $e) {
+            $this->discardQueuedCommands();
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Discard any commands left queued by an aborted pipeline or transaction.
+     *
+     * @return void
+     */
+    protected function discardQueuedCommands()
+    {
+        try {
+            $this->client()->discard();
+        } catch (Throwable $e) {
+            // The connection is already broken, so there is nothing left to discard and
+            // the exception that got us here is the one worth reporting. Swallowing
+            // this keeps it from replacing the failure the caller cares about...
+        }
     }
 
     /**

--- a/tests/Redis/Connections/PhpRedisConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisConnectionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class PhpRedisConnectionTest extends TestCase
+{
+    public function testTransactionExecutesQueuedCommands()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        $result = $connection->transaction(fn ($transaction) => $transaction->set('foo', 'bar'));
+
+        $this->assertSame(['result'], $result);
+        $this->assertSame(['multi', 'set', 'exec'], $client->calls);
+    }
+
+    public function testPipelineExecutesQueuedCommands()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        $result = $connection->pipeline(fn ($pipeline) => $pipeline->set('foo', 'bar'));
+
+        $this->assertSame(['result'], $result);
+        $this->assertSame(['pipeline', 'set', 'exec'], $client->calls);
+    }
+
+    public function testTransactionDiscardsQueuedCommandsWhenTheCallbackThrows()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        try {
+            $connection->transaction(fn () => throw new RuntimeException('Whoops'));
+
+            $this->fail('The exception thrown by the callback should not be swallowed.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Whoops', $e->getMessage());
+        }
+
+        $this->assertContains('discard', $client->calls);
+        $this->assertNotContains('exec', $client->calls);
+    }
+
+    public function testPipelineDiscardsQueuedCommandsWhenTheCallbackThrows()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        try {
+            $connection->pipeline(fn () => throw new RuntimeException('Whoops'));
+
+            $this->fail('The exception thrown by the callback should not be swallowed.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Whoops', $e->getMessage());
+        }
+
+        $this->assertContains('discard', $client->calls);
+        $this->assertNotContains('exec', $client->calls);
+    }
+
+    public function testTransactionDiscardsQueuedCommandsWhenExecutionFails()
+    {
+        $client = new PhpRedisQueueingClientStub(failOnExec: true);
+
+        $connection = new PhpRedisConnection($client);
+
+        try {
+            $connection->transaction(fn ($transaction) => $transaction->set('foo', 'bar'));
+
+            $this->fail('The exception thrown while executing should not be swallowed.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Connection lost', $e->getMessage());
+        }
+
+        $this->assertContains('discard', $client->calls);
+    }
+
+    public function testTransactionDoesNotDiscardWhenNothingFails()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        $connection->transaction(fn ($transaction) => $transaction->set('foo', 'bar'));
+
+        $this->assertNotContains('discard', $client->calls);
+    }
+
+    public function testFailureToDiscardDoesNotReplaceTheOriginalException()
+    {
+        $client = new PhpRedisQueueingClientStub(failOnDiscard: true);
+
+        $connection = new PhpRedisConnection($client);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Whoops');
+
+        $connection->transaction(fn () => throw new RuntimeException('Whoops'));
+    }
+
+    public function testTransactionWithoutACallbackReturnsTheClient()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        $this->assertSame($client, $connection->transaction());
+        $this->assertSame(['multi'], $client->calls);
+    }
+
+    public function testPipelineWithoutACallbackReturnsTheClient()
+    {
+        $client = new PhpRedisQueueingClientStub;
+
+        $connection = new PhpRedisConnection($client);
+
+        $this->assertSame($client, $connection->pipeline());
+        $this->assertSame(['pipeline'], $client->calls);
+    }
+}
+
+/**
+ * Mimics the way phpredis queues commands: multi() and pipeline() return the client
+ * itself, and so does every command queued against it until exec() is called.
+ */
+class PhpRedisQueueingClientStub
+{
+    public array $calls = [];
+
+    public function __construct(
+        protected bool $failOnExec = false,
+        protected bool $failOnDiscard = false,
+    ) {
+    }
+
+    public function multi()
+    {
+        $this->calls[] = 'multi';
+
+        return $this;
+    }
+
+    public function pipeline()
+    {
+        $this->calls[] = 'pipeline';
+
+        return $this;
+    }
+
+    public function set($key, $value)
+    {
+        $this->calls[] = 'set';
+
+        return $this;
+    }
+
+    public function exec()
+    {
+        $this->calls[] = 'exec';
+
+        if ($this->failOnExec) {
+            throw new RuntimeException('Connection lost');
+        }
+
+        return ['result'];
+    }
+
+    public function discard()
+    {
+        $this->calls[] = 'discard';
+
+        if ($this->failOnDiscard) {
+            throw new RuntimeException('Redis server went away');
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
`PhpRedisConnection::pipeline()` and `transaction()` put the client into a queueing mode and rely on `exec()` to take it back out again:

```php
public function transaction(?callable $callback = null)
{
    $transaction = $this->client()->multi();

    return is_null($callback)
        ? $transaction
        : tap($transaction, $callback)->exec();
}
```

If the callback throws, or `exec()` itself fails, that `exec()` never completes and the client stays in `MULTI` / pipeline mode. phpredis answers every subsequent command on a queueing client by returning the client itself, so the connection is silently poisoned for the rest of the process - and because the return value is an object rather than an error, the damage surfaces somewhere unrelated, long after the exception that caused it.

Against a live server on current `13.x`:

```php
$connection = new PhpRedisConnection($client);   // $client is a connected \Redis

try {
    $connection->transaction(function ($t) {
        throw new RuntimeException('callback blew up');
    });
} catch (RuntimeException) {
}

$connection->get('k');                 // Redis {}  <- not the string that was stored
$connection->zrevrangebyscore(...);    // Redis {}  <- not an array
```

Connections are shared and long-lived, so a queue worker or any long-running process keeps handing that object to unsuspecting callers until it restarts. The report that led to this was a Horizon master supervisor dying with `Argument #1 ($names) must be of type array, RedisCluster given` - `RedisSupervisorRepository::names()` had returned the client, because an unrelated transaction on the same connection had aborted earlier.

`PredisConnection` declares neither method and lets Predis manage its own state, so this is specific to phpredis.

### The fix

Both methods now route through a small helper that discards the queue if anything goes wrong and rethrows the original exception:

```php
protected function executeQueuedCommands($client, callable $callback)
{
    try {
        $callback($client);

        return $client->exec();
    } catch (Throwable $e) {
        $this->discardQueuedCommands();

        throw $e;
    }
}
```

Three details, all verified against phpredis 6.3.0 and a real server:

- `discard()` clears **both** `MULTI` and pipeline mode, so one call covers both entry points.
- `discard()` can itself throw when the socket is already gone (`exec()` failing with `Connection lost and socket is in MULTI/watching mode` is followed by `discard()` raising `Redis server went away`). It is therefore guarded, so cleanup can never replace the caller's exception.
- `discard()` is only reached on the failure path. On a cluster, calling it with no transaction open emits a `Cluster is not in MULTI mode` warning, so it deliberately is not run after a successful `exec()`.

`Redis::reset()` looked like the tidier primitive but is not usable here - it raises `Reset isn't allowed in pipeline mode!`.

### Tests

`tests/Redis/Connections/PhpRedisConnectionTest.php` (new), driven by a stub client that mimics phpredis returning itself for queued commands, so no server is required:

- both methods still queue and execute normally, and still return the client when no callback is given
- an exception from the callback discards the queue and is rethrown unchanged, for both `pipeline()` and `transaction()`
- a failure inside `exec()` also discards
- nothing is discarded when the transaction succeeds
- a `discard()` that throws does not replace the original exception

Six of the nine fail to exercise anything new on the current branch and three fail outright without the fix.