### PR TITLE
[13.x] Align `auth()` helper return type

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -14,6 +14,7 @@ use function Illuminate\Support\enum_value;
 /**
  * @mixin \Illuminate\Contracts\Auth\Guard
  * @mixin \Illuminate\Contracts\Auth\StatefulGuard
+ * @mixin \Illuminate\Auth\SessionGuard
  */
 class AuthManager implements FactoryContract
 {

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -14,7 +14,6 @@ use function Illuminate\Support\enum_value;
 /**
  * @mixin \Illuminate\Contracts\Auth\Guard
  * @mixin \Illuminate\Contracts\Auth\StatefulGuard
- * @mixin \Illuminate\Auth\SessionGuard
  */
 class AuthManager implements FactoryContract
 {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -169,7 +169,7 @@ if (! function_exists('auth')) {
      * Get the available auth instance.
      *
      * @param  string|null  $guard
-     * @return ($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\Guard)
+     * @return ($guard is null ? \Illuminate\Auth\AuthManager : \Illuminate\Contracts\Auth\Guard)
      */
     function auth($guard = null): AuthFactory|Guard
     {

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -8,7 +8,7 @@ assertType('Illuminate\Foundation\Application', app());
 assertType('mixed', app('foo'));
 assertType('Illuminate\Config\Repository', app(Repository::class));
 
-assertType('Illuminate\Contracts\Auth\Factory', auth());
+assertType('Illuminate\Auth\AuthManager', auth());
 assertType('Illuminate\Contracts\Auth\Guard', auth('foo'));
 
 assertType('Illuminate\Cache\CacheManager', cache());


### PR DESCRIPTION
### Reason
 
I use VSCode with Intelephense and it was unable to resolve some methods from the `auth()` helper:

<details>
<img width="500" alt="Screenshot 2026-08-13 at 09 55 48" src="https://github.com/user-attachments/assets/8f2b6fb8-9bd8-4cb4-ad6d-df2c3467ba63" />
<img width="500" alt="Screenshot 2026-08-13 at 09 55 28" src="https://github.com/user-attachments/assets/b7cb974e-c160-4582-898b-9df473f34540" />
</details>

Looking into it, `auth()` was the last manager-backed helper to return a Contract rather than a concrete class, and by aligning this doc block with the other helpers we could resolve the examples shown above.

There is a continuation of this on #61164 to add a session mixin to `AuthManager` which would need to be merged after this.

### Notes

`Contracts\Auth\Factory` only declares `guard()` and `shouldUse()`, so the return type promised an object on which `auth()->user()` isn't valid. `user()` is declared on `Contracts\Auth\Guard`, the first `@mixin` on `AuthManager`, so returning the concrete class resolves it. Tooling that trusts the docblock (Intelephense, bare PHPStan) flags the old call as undefined, with this change that is fixed.

5d006a562c introduced the whole set of conditional helper return types, including the `Factory` half this PR is now amending, but that change narrowed the `$guard` argument branch to `StatefulGuard` which needed reverting in aef19cd74d. This widens the no argument branch from an interface to the concrete class it already returns, so no previously-valid call becomes invalid.

No new failures for apps resolving the framework's `AuthManager` but apps binding a custom `Factory` may see new errors.