### PR TITLE
[13.x] `AuthManager` session guard mixin

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -14,6 +14,7 @@ use function Illuminate\Support\enum_value;
 /**
  * @mixin \Illuminate\Contracts\Auth\Guard
  * @mixin \Illuminate\Contracts\Auth\StatefulGuard
+ * @mixin \Illuminate\Auth\SessionGuard
  */
 class AuthManager implements FactoryContract
 {

--- a/types/Managers/AuthManager.php
+++ b/types/Managers/AuthManager.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Auth\AuthManager;
+
+use function PHPStan\Testing\assertType;
+
+$authManager = resolve(AuthManager::class);
+
+$authManager->extend('custom', function (): void {
+    assertType('Illuminate\Auth\AuthManager', $this);
+});
+
+// Methods declared on the guard contracts keep their contract signatures...
+assertType('Illuminate\Contracts\Auth\Authenticatable|null', $authManager->user());
+assertType('bool', $authManager->attempt(['email' => 'foo']));
+
+// ... while session specific methods are resolved from the concrete guard.
+assertType('Illuminate\Contracts\Auth\Authenticatable|null', $authManager->logoutOtherDevices('password'));
+assertType('Illuminate\Auth\SessionGuard', $authManager->setRememberDuration(5));


### PR DESCRIPTION
**Requires #61163 to take effect via `auth()`**, alone it improves `Auth` and explicit `AuthManager` type hints.

### Reason
 
I use VSCode with Intelephense and it was unable to resolve some methods from the `auth()` helper:

<details>
<img width="500" alt="Screenshot 2026-08-13 at 09 46 55" src="https://github.com/user-attachments/assets/40dc9c43-0215-4c62-b7e9-5d71c01ac1fe" />
</details>

`AuthManager` forwards undefined calls to the resolved guard via `__call()`, but only the `Guard` and `StatefulGuard` contracts were mixed in, so session specific methods couldn't be resolved.

### Notes

This makes `auth()->logoutOtherDevices()` resolve the same as `Auth::logoutOtherDevices()`. `SessionGuard` has 22 public methods that appear on no auth contract, and all 22 are already documented on the `Auth` facade, which carries `@see \Illuminate\Auth\SessionGuard`. So this doesn't introduce a new position, it resolves an inconsistency between the facade and the helper.

**Ordering** - `SessionGuard` implements `StatefulGuard`, so the third tag subsumes the first two, and listing it last is what keeps contract methods resolving to contract signatures.

On an app with a token or request guard, this mixin will show methods that throw `BadMethodCallException` at runtime but this is exactly what the `Auth` facade already does. aef19cd74d reverted a narrowing. Custom guards implementing only `Guard` started failing analysis on code that was valid. A `@mixin` is additive, so at worst it permits a call that fails at runtime on a non-session guard. Nobody's passing CI turns red on upgrade.

