### PR TITLE
[13.x] Scan every master when scanning a phpredis cluster connection

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -14,26 +14,60 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     protected $client;
 
     /**
-     * The default node to use from the cluster.
-     *
-     * @var string|array
-     */
-    protected $defaultNode;
-
-    /**
      * Scan all keys based on the given options.
+     *
+     * SCAN is per-node, so the cursor encodes the master being iterated and its own cursor.
      *
      * @param  mixed  $cursor
      * @param  array  $options
-     * @return mixed
+     * @return array|false
      *
      * @throws \InvalidArgumentException
      */
     #[\Override]
     public function scan($cursor, $options = [])
     {
+        if (isset($options['node'])) {
+            return $this->scanNode($cursor, $options['node'], $options);
+        }
+
+        $masters = $this->masters();
+
+        [$node, $nodeCursor] = $this->parseScanCursor($cursor);
+
+        while ($node < count($masters)) {
+            $keys = $this->client->scan(
+                $nodeCursor,
+                $masters[$node],
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
+
+            if ((int) $nodeCursor === 0) {
+                $node++;
+                $nodeCursor = $this->freshScanCursor();
+            }
+
+            if (! empty($keys)) {
+                return [$node.':'.$nodeCursor, $keys];
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Scan a single node of the cluster.
+     *
+     * @param  mixed  $cursor
+     * @param  string|array  $node
+     * @param  array  $options
+     * @return array|false
+     */
+    protected function scanNode($cursor, $node, array $options)
+    {
         $result = $this->client->scan($cursor,
-            $options['node'] ?? $this->defaultNode(),
+            $node,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -43,6 +77,45 @@ class PhpRedisClusterConnection extends PhpRedisConnection
         }
 
         return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+    }
+
+    /**
+     * Split a scan() cursor into a master index and that master's cursor.
+     *
+     * @param  mixed  $cursor
+     * @return array
+     */
+    protected function parseScanCursor($cursor)
+    {
+        if (is_string($cursor) && str_contains($cursor, ':')) {
+            [$node, $nodeCursor] = explode(':', $cursor, 2);
+
+            return [(int) $node, $nodeCursor === '' ? $this->freshScanCursor() : (int) $nodeCursor];
+        }
+
+        return [0, $this->freshScanCursor()];
+    }
+
+    /**
+     * Get the cursor value that starts a fresh iteration of a node.
+     *
+     * @return string|null
+     */
+    protected function freshScanCursor()
+    {
+        return version_compare(phpversion('redis'), '6.1.0', '>=') ? null : '0';
+    }
+
+    /**
+     * Get the master nodes of the cluster.
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function masters()
+    {
+        return $this->client->_masters() ?: throw new InvalidArgumentException('No master nodes found in the cluster.');
     }
 
     /**
@@ -61,22 +134,6 @@ class PhpRedisClusterConnection extends PhpRedisConnection
                 ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
                 : $this->command('flushdb', [$master]);
         }
-    }
-
-    /**
-     * Return default node to use for cluster.
-     *
-     * @return string|array
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function defaultNode()
-    {
-        if (! isset($this->defaultNode)) {
-            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
-        }
-
-        return $this->defaultNode;
     }
 
     /**

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -11,27 +11,61 @@ use PHPUnit\Framework\TestCase;
 #[RequiresPhpExtension('redis')]
 class PhpRedisClusterConnectionTest extends TestCase
 {
-    public function testItScansUsingDefaultNode()
+    public function testItScansStartingFromTheFirstMaster()
     {
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(0, ['127.0.0.1', '6379'], '*', 10)
+            ->with(null, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(['key']);
 
         $connection = new PhpRedisClusterConnection($client);
-        $this->assertEquals([0, ['key']], $connection->scan(0));
+        $this->assertEquals(['1:', ['key']], $connection->scan(0));
     }
 
-    public function testItOnlyFetchesDefaultNodeOnce()
+    public function testItScansEveryMasterInTurn()
     {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379'], ['127.0.0.3', '6379']];
+
         $client = Mockery::mock(\RedisCluster::class);
-        $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
-        $client->expects('scan')->times(2);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn(['a']);
+        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['b']);
+        $client->expects('scan')->with(null, $masters[2], '*', 10)->andReturn(['c']);
 
         $connection = new PhpRedisClusterConnection($client);
-        $connection->scan(0);
-        $connection->scan(0);
+
+        $this->assertEquals(['1:', ['a']], $connection->scan(0));
+        $this->assertEquals(['2:', ['b']], $connection->scan('1:'));
+        $this->assertEquals(['3:', ['c']], $connection->scan('2:'));
+        $this->assertFalse($connection->scan('3:'));
+    }
+
+    public function testItResumesAMasterFromTheEncodedCursor()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')
+            ->with(42, $masters[1], '*', 10)
+            ->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals(['1:42', ['key']], $connection->scan('1:42'));
+    }
+
+    public function testItKeepsScanningWhenAMasterReturnsNoKeys()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn([]);
+        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals(['2:', ['key']], $connection->scan(0));
     }
 
     public function testItScansUsingOptionNode()
@@ -51,7 +85,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client->expects('_masters')->andReturn([]);
         $client->shouldNotReceive('scan');
 
-        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.'));
+        $this->expectExceptionObject(new InvalidArgumentException('No master nodes found in the cluster.'));
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->scan(0);
@@ -62,7 +96,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(0, ['127.0.0.1', '6379'], '*', 10)
+            ->with(null, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(false);
 
         $connection = new PhpRedisClusterConnection($client);


### PR DESCRIPTION
`PhpRedisClusterConnection::scan()` always targets a single node:

```php
$result = $this->client->scan($cursor,
    $options['node'] ?? $this->defaultNode(),   // _masters()[0], cached forever
    ...
);
```

SCAN is a per-node command, so this only ever sees the keys held by the first master. `RedisStore::currentTags()` scans for `tag:*:entries`, which means `flushStaleTags()` - and therefore the scheduled `cache:prune-stale-tags` command - silently prunes only the fraction of tag sets that happen to live on that one node. Stale tag entries on every other master are never reclaimed and grow without bound.

Measured against a real 3-node cluster, writing 30 tag sets:

```
master[0] 127.0.0.1:7000 holds 13 tag keys
master[1] 127.0.0.1:7001 holds  9 tag keys
master[2] 127.0.0.1:7002 holds  8 tag keys

scan() found: 13 of 30
```

Through the public API, on the same cluster - 60 tag sets written with `Cache::tags([...])->put(...)`, left to go stale, then pruned:

```
tag sets per master: {7000: 25, 7001: 21, 7002: 14}   (60 total)

stock 13.x   stale members before flushStaleTags(): 60 -> after: 35 left behind
with the fix stale members before flushStaleTags(): 60 -> after: 0
```

`RedisTagSet::entries()` uses `zscan` against named keys, which routes correctly, so `Cache::tags(...)->flush()` is unaffected. This is specifically about whole-keyspace scanning.

### Horizon is affected too, more sharply

`Laravel\Horizon\Repositories\RedisMetricsRepository::clear()` is the other consumer of this method, using it to find the `queue:*`, `job:*` and `snapshot:*` metric keys it then deletes.

Horizon hash-tags its prefix, so *all* of its keys occupy a single slot on a single master. Which master that is depends on the configured prefix and the cluster's slot allocation. Where cache tags are partially pruned, Horizon's layout makes this all or nothing: unless the slot happens to fall on the scanned node, `clear()` matches nothing and deletes nothing.

Running Horizon's own unmodified `clear()` against a 3-node cluster, swapping only the framework underneath it:

```
stock 13.x   horizon keys before: 61 -> after: 60 survived
with the fix horizon keys before: 61 -> after: 0
```

The single key stock does remove is `measured_jobs`, deleted by a direct `forget()` that routes by key; every one of the 60 pattern-matched keys survives.

Horizon needs no changes for this. Its loop treats the cursor as opaque - it terminates on `! is_array($scanResult)` and passes the cursor straight back without inspecting it - so it keeps working and simply starts finding the keys it was always looking for. Both callers are written correctly against what `scan()` claims to do; it is the connection that only scans a third of a three-node cluster, so that is where it seemed right to fix it rather than teaching each caller to iterate `_masters()` for itself.

### The fix

`scan()` now walks every master in turn. Because SCAN is per-node, the returned cursor carries both the master being iterated and that master's own cursor (`"<index>:<cursor>"`), so callers page through the entire cluster with the same loop they already write against a single server. Passing an explicit `node` option still scans just that node.

### On the change to the cursor

`scan()` is not declared in any Redis contract, and `RedisStore::currentTags()` is its only caller inside the framework - `PredisConnection` has no `scan()` override, and `zscan`/`hscan`/`sscan` take their own per-key cursors and are untouched. Horizon's `RedisMetricsRepository::clear()` is the only first-party caller outside it, and works unmodified, as above.

The termination signal is unchanged: `scan()` still returns `false` once the iteration is finished, which is what every caller has to branch on today, so loops written against the existing contract keep working. What changes is the shape of the opaque cursor value in between. Both existing callers already treat it as opaque and pass it straight back. Code that instead treats it as an integer - comparing it to `0` rather than checking for `false` - would need updating, and that is the thing worth calling out.

### On correctness when the topology changes

The cursor holds a master *index*, so it is worth being explicit about what happens when the cluster moves underneath an in-flight scan. Verified against a 3-master/3-replica cluster:

- `_masters()` is ordered by slot range, not discovery order, and its ordering was stable across 200 consecutive calls.
- A promoted replica inherits the failed master's slot range, and therefore its index, and holds an identical keyspace - so an existing cursor stays meaningful. Pausing a scan at `1:54779`, killing that master, waiting for promotion and resuming from the same cursor found **6000 of 6000** keys, none missed.
- During the promotion window phpredis raises `RedisClusterException: Couldn't send SCAN to node` rather than quietly returning short results, so the failure is loud.

Adding or removing masters mid-scan reshapes the slot ranges and can shift indices, which may skip or repeat a node. Redis offers no cluster-wide SCAN, and SCAN's own contract already permits keys mutated during an iteration to be missed or repeated, so this seemed the right place to stop rather than encoding a full node set into the cursor.

### On cost

`_masters()` is now read on each call rather than cached once. It is a local lookup with no I/O - 0.096 µs per call against 173 µs for a real GET, roughly 1/1800th of a round trip - so caching it would buy nothing and would risk holding a stale node list across a failover.

Scanning a 100,300-key keyspace across 3 masters for a selective pattern:

```
this implementation : 28.2 ms | 102 SCAN round trips | 300/300 keys
hand-rolled optimum : 28.1 ms | 102 SCAN round trips | 300/300 keys
```

Identical round-trip count; the difference in wall time is noise.

### Note on the starting cursor

Advancing to the next master resets that master's cursor to the same sentinel `RedisStore` and `RedisTagSet` already select by version (`null` on phpredis >= 6.1, `'0'` below). This is load-bearing rather than cosmetic: on phpredis 6.3 a start cursor of `0` ends the iteration after a single pass, where `null` runs all 34.

```
start cursor int 0    ->  1 pass,      1 key seen
start cursor string 0 ->  1 pass,      1 key seen
start cursor null     -> 34 passes, 33418 keys seen
```

### Tests

`tests/Redis/Connections/PhpRedisClusterConnectionTest.php`: covers walking every master in turn, resuming a master from an encoded cursor, continuing past masters that return no keys, and ending the iteration once every master is exhausted. Three existing tests were updated because they pinned the single-node cursor, and `testItOnlyFetchesDefaultNodeOnce` was dropped along with the cached default node it described. Four of the nine fail without the change.

`defaultNode()` was private and is removed; the "no master nodes" guard it carried is kept, with its message shortened now that there is no default node to determine.
