### PR TITLE
[13.x] Add test to ensure pail is ignored if not installed

### DIFF
--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -323,6 +323,22 @@ class FoundationDevCommandsTest extends TestCase
         $this->assertContains('vite', $names);
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testRegisterDefaultsExcludesPailWhenNotInstalled()
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(3, $commands);
+
+        $names = array_column($commands, 'name');
+        $this->assertContains('server', $names);
+        $this->assertContains('queue', $names);
+        $this->assertContains('vite', $names);
+        $this->assertNotContains('logs', $names);
+    }
+
     #[RequiresOperatingSystem('Windows')]
     public function testRegisterDefaultsExcludesPailOnWindows()
     {


### PR DESCRIPTION
I missed this test when I did https://github.com/laravel/framework/pull/61157 

This just completes the loop to prove it's ignored when its not installed and unix.. vs the positive test 

Thank you brother 