### PR TITLE
[13.x] Add debounceable queued listeners

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -111,6 +111,11 @@ class CallQueuedListener implements ShouldQueue
     public ?int $uniqueFor = null;
 
     /**
+     * The debounce ID of the listener.
+     */
+    public mixed $debounceId = null;
+
+    /**
      * Create a new job instance.
      *
      * @param  class-string  $class
@@ -187,6 +192,30 @@ class CallQueuedListener implements ShouldQueue
         $this->prepareData();
 
         return $listener->uniqueVia(...array_values($this->data));
+    }
+
+    /**
+     * Get the debounce ID for the listener.
+     */
+    public function debounceId(): mixed
+    {
+        return $this->debounceId;
+    }
+
+    /**
+     * Get the cache store used to manage debounce ownership.
+     */
+    public function debounceVia(): ?Cache
+    {
+        $listener = Container::getInstance()->make($this->class);
+
+        if (! method_exists($listener, 'debounceVia')) {
+            return null;
+        }
+
+        $this->prepareData();
+
+        return $listener->debounceVia(...array_values($this->data));
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -697,6 +697,7 @@ class Dispatcher implements DispatcherContract
             );
 
             $job->debounceOwner = $debounce['owner'];
+
             $delay ??= $debounce['maxWaitExceeded'] ? 0 : $debounceFor;
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -4,6 +4,7 @@ namespace Illuminate\Events;
 
 use Closure;
 use Exception;
+use Illuminate\Bus\DebounceLock;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
@@ -20,6 +21,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\FailOnTimeout;
@@ -35,6 +37,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReadsClassAttributes;
 use Illuminate\Support\Traits\ReflectsClosures;
+use LogicException;
 use ReflectionClass;
 
 use function Illuminate\Support\enum_value;
@@ -650,10 +653,18 @@ class Dispatcher implements DispatcherContract
      * @param  string  $method
      * @param  array  $arguments
      * @return void
+     *
+     * @throws \LogicException
      */
     protected function queueHandler($class, $method, $arguments)
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
+
+        $debounceFor = $this->getAttributeValue($listener, DebounceFor::class, 'debounceFor');
+
+        if (! is_null($debounceFor) && $job->shouldBeUnique) {
+            throw new LogicException('A debounced listener cannot also implement ShouldBeUnique.');
+        }
 
         if ($job->shouldBeUnique &&
             ! (new UniqueLock($this->container->make(Cache::class)))->acquire($job)) {
@@ -678,6 +689,15 @@ class Dispatcher implements DispatcherContract
 
         if (is_null($queue)) {
             $queue = $this->resolveQueueFromQueueRoute($listener) ?? null;
+        }
+
+        if (! is_null($debounceFor)) {
+            $debounce = (new DebounceLock($this->container->make(Cache::class)))->acquire(
+                $job, $debounceFor, $this->getAttributeInstance($listener, DebounceFor::class)?->maxWait
+            );
+
+            $job->debounceOwner = $debounce['owner'];
+            $delay ??= $debounce['maxWaitExceeded'] ? 0 : $debounceFor;
         }
 
         is_null($delay)
@@ -754,6 +774,12 @@ class Dispatcher implements DispatcherContract
                 $job->uniqueFor = method_exists($listener, 'uniqueFor')
                     ? $listener->uniqueFor(...$data)
                     : ($this->getAttributeValue($listener, UniqueFor::class, 'uniqueFor') ?? 0);
+            }
+
+            if (! is_null($this->getAttributeValue($listener, DebounceFor::class, 'debounceFor'))) {
+                $job->debounceId = method_exists($listener, 'debounceId')
+                    ? $listener->debounceId(...$data)
+                    : ($listener->debounceId ?? null);
             }
         });
     }

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Events;
 
+use Illuminate\Bus\DebounceLock;
 use Illuminate\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Contracts\Cache\LockProvider;
@@ -14,6 +17,7 @@ use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\QueueManager;
@@ -21,6 +25,7 @@ use Illuminate\Queue\QueueRoutes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Laravel\SerializableClosure\SerializableClosure;
+use LogicException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -601,6 +606,148 @@ class QueuedEventsTest extends TestCase
 
         $this->assertTrue(TestDispatcherShouldBeUniqueUntilProcessing::$lockReleasedBeforeHandling);
     }
+
+    public function testQueuePropagatesDebounceOptions()
+    {
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $fakeQueue = new QueueFake($container);
+        $cache = new Repository(new ArrayStore);
+
+        $container->instance(Cache::class, $cache);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherDebouncedHandler::class.'@handle');
+        $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+
+        $expectedKey = 'laravel_debounced_job:'.hash('xxh128', TestDispatcherDebouncedHandler::class).':event-123';
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) use ($cache, $expectedKey) {
+            return $job->debounceId() === 'event-123'
+                && is_string($job->debounceOwner)
+                && $job->debounceOwner !== ''
+                && $cache->get($expectedKey) === $job->debounceOwner;
+        });
+
+        $this->assertSame(1, $fakeQueue->delayedSize());
+    }
+
+    public function testExplicitListenerDelayTakesPrecedenceOverDebounceDelay()
+    {
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $queue = Mockery::mock(Queue::class);
+        $cache = new Repository(new ArrayStore);
+
+        $container->instance(Cache::class, $cache);
+
+        $queue->expects('connection')->with(null)->andReturnSelf();
+        $queue->expects('laterOn')->with(null, 20, Mockery::on(function ($job) use ($cache) {
+            $expectedKey = 'laravel_debounced_job:'.hash('xxh128', TestDispatcherDebouncedHandlerWithDelay::class).':event-123';
+
+            return $job instanceof CallQueuedListener
+                && $job->debounceOwner !== ''
+                && $cache->get($expectedKey) === $job->debounceOwner;
+        }));
+
+        $d->setQueueResolver(function () use ($queue) {
+            return $queue;
+        });
+
+        $d->listen('some.event', TestDispatcherDebouncedHandlerWithDelay::class.'@handle');
+        $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+    }
+
+    public function testDebouncedListenerMaxWaitForcesImmediateExecution()
+    {
+        Carbon::setTestNow('2026-01-01 00:00:00');
+
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $queue = Mockery::mock(Queue::class);
+        $cache = new Repository(new ArrayStore);
+
+        $container->instance(Cache::class, $cache);
+
+        $queue->expects('connection')->twice()->with(null)->andReturnSelf();
+        $queue->expects('laterOn')->with(null, 30, Mockery::type(CallQueuedListener::class))->ordered();
+        $queue->expects('laterOn')->with(null, 0, Mockery::type(CallQueuedListener::class))->ordered();
+
+        $d->setQueueResolver(function () use ($queue) {
+            return $queue;
+        });
+
+        $d->listen('some.event', TestDispatcherDebouncedHandlerWithMaxWait::class.'@handle');
+        $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(60));
+
+        $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+    }
+
+    public function testDebounceViaUsesListenerCacheRepository()
+    {
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $fakeQueue = new QueueFake($container);
+        $defaultCache = new Repository(new ArrayStore);
+        $debounceCache = new Repository(new ArrayStore);
+
+        $container->instance(Cache::class, $defaultCache);
+
+        $originalContainer = Container::getInstance();
+        Container::setInstance($container);
+
+        TestDispatcherDebouncedHandlerWithCustomCache::$cache = ['event-123' => $debounceCache];
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        try {
+            $d->listen('some.event', TestDispatcherDebouncedHandlerWithCustomCache::class.'@handle');
+            $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+
+            $job = $fakeQueue->pushed(CallQueuedListener::class)->first();
+
+            $this->assertNull($defaultCache->get(DebounceLock::getKey($job)));
+            $this->assertSame($job->debounceOwner, $debounceCache->get(DebounceLock::getKey($job)));
+        } finally {
+            Container::setInstance($originalContainer);
+        }
+    }
+
+    public function testDebouncedListenerCannotAlsoBeUnique()
+    {
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $fakeQueue = new QueueFake($container);
+        $cache = Mockery::mock(Cache::class);
+
+        $cache->shouldNotReceive('put');
+        $cache->shouldNotReceive('lock');
+
+        $container->instance(Cache::class, $cache);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherDebouncedAndUniqueHandler::class.'@handle');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A debounced listener cannot also implement ShouldBeUnique.');
+
+        $d->dispatch('some.event', [['id' => 'event-123'], 'bar']);
+    }
 }
 
 class TestDispatcherQueuedHandler implements ShouldQueue
@@ -919,5 +1066,84 @@ class TestDispatcherShouldBeUniqueWithCustomCache implements ShouldQueue, Should
     public function uniqueVia(): Cache
     {
         return static::$cache;
+    }
+}
+
+#[DebounceFor(30)]
+class TestDispatcherDebouncedHandler implements ShouldQueue
+{
+    public function debounceId($event)
+    {
+        return $event['id'];
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[DebounceFor(30)]
+class TestDispatcherDebouncedHandlerWithDelay implements ShouldQueue
+{
+    public $debounceId = 'event-123';
+
+    public function withDelay()
+    {
+        return 20;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[DebounceFor(30, maxWait: 60)]
+class TestDispatcherDebouncedHandlerWithMaxWait implements ShouldQueue
+{
+    public function debounceId($event)
+    {
+        return $event['id'];
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[DebounceFor(30)]
+class TestDispatcherDebouncedHandlerWithCustomCache implements ShouldQueue
+{
+    public static $cache = null;
+
+    public function debounceId($event)
+    {
+        return $event['id'];
+    }
+
+    public function debounceVia($event): Cache
+    {
+        return static::$cache[$event['id']];
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[DebounceFor(30)]
+class TestDispatcherDebouncedAndUniqueHandler implements ShouldQueue, ShouldBeUnique
+{
+    public function debounceId($event)
+    {
+        return $event['id'];
+    }
+
+    public function handle()
+    {
+        //
     }
 }

--- a/tests/Integration/Queue/DebouncedListenerTest.php
+++ b/tests/Integration/Queue/DebouncedListenerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('cache')]
+#[WithMigration('queue')]
+class DebouncedListenerTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('cache.default', 'database');
+    }
+
+    public function testSupersededDebouncedListenerIsSkipped()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
+
+        DebouncedTestListener::$handledValues = [];
+
+        Event::listen(DebouncedTestEvent::class, DebouncedTestListener::class);
+
+        Event::dispatch(new DebouncedTestEvent('entity-1', 'first'));
+        Event::dispatch(new DebouncedTestEvent('entity-1', 'second'));
+
+        $this->travelTo(Carbon::now()->addSeconds(31));
+        $this->runQueueWorkerCommand(['--once' => true], 2);
+
+        $this->assertSame(['second'], DebouncedTestListener::$handledValues);
+    }
+}
+
+class DebouncedTestEvent
+{
+    public function __construct(public string $entityId, public string $value)
+    {
+    }
+}
+
+#[DebounceFor(30)]
+class DebouncedTestListener implements ShouldQueue
+{
+    public static $handledValues = [];
+
+    public function debounceId(DebouncedTestEvent $event): string
+    {
+        return $event->entityId;
+    }
+
+    public function handle(DebouncedTestEvent $event)
+    {
+        static::$handledValues[] = $event->value;
+    }
+}


### PR DESCRIPTION
This PR adds support for applying the existing `#[DebounceFor]` attribute to queued event listeners. This is useful when an event may be dispatched repeatedly for the same resource and only its latest state needs to be processed after activity has settled. Example:

```php
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\Attributes\DebounceFor;

#[DebounceFor(30, maxWait: 120)]
class UpdateProductSearchIndex implements ShouldQueue
{
    public function debounceId(ProductUpdated $event): string
    {
        return (string) $event->product->getKey();
    }

    public function handle(ProductUpdated $event): void
    {
        // Update the product's search index...
    }
}
```

When multiple `ProductUpdated` events for the same product are dispatched during the debounce window, superseded listener invocations are skipped and only the most recently dispatched listener is handled. Different products are debounced independently, while `maxWait` prevents a continuous stream of events from deferring the listener indefinitely.

Debouncing is scoped to the queued listener, so the event itself and its other listeners remain unaffected. Like debounced jobs, listeners may also customize the cache repository using `debounceVia`.

Since uniqueness uses first-dispatch-wins semantics while debouncing uses last-dispatch-wins semantics, a debounced listener may not also implement `ShouldBeUnique`.