### PR TITLE
[13.x] Fix FoundationDevCommandsTest

### DIFF
--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -342,6 +342,8 @@ class FoundationDevCommandsTest extends TestCase
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRegisterDefaultsExcludesPailWhenNotInstalled()
     {
+        File::shouldReceive('exists')->with(base_path('package.json'))->andReturnTrue();
+
         DevCommands::registerDefaults();
 
         $commands = DevCommands::commands();


### PR DESCRIPTION
This snuck in via https://github.com/laravel/framework/pull/61167 

But, this test was missing it... just cos merge order I guess  https://github.com/laravel/framework/actions/runs/31715280478/job/94498336900#step:5:290 

This fixes it

(sorry you have to see my face 50x today)