### PR TITLE
[13.x] Remove the pinned `@laravel/multiplex` version

### DIFF
--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -20,13 +20,6 @@ class DevCommand extends Command
     use Prohibitable;
 
     /**
-     * The version of `@laravel/multiplex` to use.
-     *
-     * @var string
-     */
-    protected const MULTIPLEX_VERSION = '0.4.2';
-
-    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -133,7 +126,7 @@ class DevCommand extends Command
 
         $title = 'artisan dev · '.(config('app.name') === 'Laravel' ? basename(base_path()) : config('app.name'));
 
-        $command = '@laravel/multiplex@'.self::MULTIPLEX_VERSION.' --title '.escapeshellarg($title);
+        $command = '@laravel/multiplex --title '.escapeshellarg($title);
 
         if (! $flags->isEmpty()) {
             $command .= ' '.$flags->implode(' ');

--- a/tests/Foundation/Console/DevCommandTest.php
+++ b/tests/Foundation/Console/DevCommandTest.php
@@ -42,7 +42,7 @@ class DevCommandTest extends TestCase
     public function testMultiplexCommandDefaultsToTabs()
     {
         $this->assertSame(
-            "@laravel/multiplex@0.4.2 --title 'artisan dev · my-app' "
+            "@laravel/multiplex --title 'artisan dev · my-app' "
                 ."'server@#93c5fd,php artisan serve' 'vite@#fcd34d,npm run dev'",
             $this->command()->buildMultiplexCommandForTesting($this->devCommands())
         );

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -342,6 +342,8 @@ class FoundationDevCommandsTest extends TestCase
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRegisterDefaultsExcludesPailWhenNotInstalled()
     {
+        File::shouldReceive('exists')->with(base_path('package.json'))->andReturnTrue();
+
         DevCommands::registerDefaults();
 
         $commands = DevCommands::commands();


### PR DESCRIPTION
`artisan dev` shelled out to `npx @laravel/multiplex@0.4.2`. An exact pin means an app can only use its own copy of multiplex if that copy is exactly 0.4.2, and every time we bump the constant, everyone gets a fresh install prompt.

Without the version, npx runs the app's locally installed copy whenever it has one and falls back to the latest release otherwise. Apps that want to control the version can add `@laravel/multiplex` to their `devDependencies` and it will be used.

This is not a return to the old `@0.4` constraint that caused the constant "Ok to proceed?" prompts. A range makes npx re-resolve and re-install on every single run, while a bare package name is cached the same way an exact version is and only prompts again once a new version is published.

Also fixes testRegisterDefaultsExcludesPailWhenNotInstalled, which is failing on 13.x. It was added in #61168 without the File::exists(base_path('package.json')) mock its sibling tests use, so the vite command never registers and the count comes up short.
