### PR TITLE
Fix Redis pipeline facade annotation

### DIFF
--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -187,7 +187,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Redis|int|false pfcount(array|string $key_or_keys)
  * @method static \Redis|bool pfmerge(string $dst, array $srckeys)
  * @method static \Redis|string|bool ping(string|null $message = null)
- * @method static \Redis|bool pipeline()
+ * @method static mixed pipeline(?callable $callback = null)
  * @method static \Redis|bool psetex(string $key, int $expire, mixed $value)
  * @method static \Redis|int|false pttl(string $key)
  * @method static \Redis|int|false publish(string $channel, string $message)


### PR DESCRIPTION
## Context

The `Redis` facade currently declares:

```php
@method static \Redis|bool pipeline()
```

However, Laravel's `pipeline` method accepts an optional callback, as documented and implemented by the Redis connection:

```php
Redis::pipeline(function ($pipe) {
    // ...
});
```

The current annotation causes IDEs and static analysis tools to report valid callback usage as an invalid method call.

## Changes

- Update the `Redis` facade `pipeline` annotation to match the actual method signature.

No runtime behavior is changed. This only improves IDE support and aligns the facade annotation with Laravel's documented API.