### PR TITLE
[13.x] Scan every master node in phpredis cluster connections

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -45,6 +45,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
             throw new InvalidArgumentException('No master nodes found in the cluster.');
         }
 
+        // Restore the active node and its untouched phpredis cursor between calls...
         if (is_string($cursor) && str_starts_with($cursor, 'laravel:')) {
             [$scanned, $node, $cursor, $initialCursor] = json_decode(
                 base64_decode(substr($cursor, 8), true), true, flags: JSON_THROW_ON_ERROR
@@ -55,12 +56,14 @@ class PhpRedisClusterConnection extends PhpRedisConnection
             $initialCursor = $cursor;
         }
 
+        // Continue with an unscanned master if the active node disappeared during a failover...
         if ($node !== null && ! in_array($node, $masters, true)) {
             $node = null;
             $cursor = $initialCursor;
         }
 
         while (true) {
+            // Advance to the next unscanned master and start its node-local cursor...
             if ($node === null) {
                 $node = current(array_filter($masters, fn ($master) => ! in_array($master, $scanned, true)));
 
@@ -85,6 +88,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
             if (! empty($result)) {
                 $remainingMasters = array_filter($masters, fn ($master) => ! in_array($master, $scanned, true));
 
+                // Preserve the caller's null or zero sentinel so existing scan loops terminate...
                 if ($node === null && empty($remainingMasters)) {
                     return [$initialCursor, $result];
                 }

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -14,13 +14,6 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     protected $client;
 
     /**
-     * The default node to use from the cluster.
-     *
-     * @var string|array
-     */
-    protected $defaultNode;
-
-    /**
      * Scan all keys based on the given options.
      *
      * @param  mixed  $cursor
@@ -32,17 +25,51 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     #[\Override]
     public function scan($cursor, $options = [])
     {
-        $result = $this->client->scan($cursor,
-            $options['node'] ?? $this->defaultNode(),
-            $options['match'] ?? '*',
-            $options['count'] ?? 10
-        );
+        if (isset($options['node'])) {
+            $result = $this->client->scan($cursor,
+                $options['node'],
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
 
-        if ($result === false) {
-            $result = [];
+            if ($result === false) {
+                $result = [];
+            }
+
+            return $cursor === 0 && empty($result) ? false : [$cursor, $result];
         }
 
-        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+        $masters = $this->client->_masters();
+
+        if (empty($masters)) {
+            throw new InvalidArgumentException('No master nodes found in the cluster.');
+        }
+
+        [$master, $cursor] = is_string($cursor) && str_contains($cursor, ':')
+            ? explode(':', $cursor, 2)
+            : [0, ''];
+
+        $master = (int) $master;
+        $cursor = $cursor === '' ? null : (int) $cursor;
+
+        while ($master < count($masters)) {
+            $result = $this->client->scan($cursor,
+                $masters[$master],
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
+
+            if ((int) $cursor === 0) {
+                $master++;
+                $cursor = null;
+            }
+
+            if (! empty($result)) {
+                return [$master.':'.$cursor, $result];
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -61,22 +88,6 @@ class PhpRedisClusterConnection extends PhpRedisConnection
                 ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
                 : $this->command('flushdb', [$master]);
         }
-    }
-
-    /**
-     * Return default node to use for cluster.
-     *
-     * @return string|array
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function defaultNode()
-    {
-        if (! isset($this->defaultNode)) {
-            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
-        }
-
-        return $this->defaultNode;
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -45,31 +45,61 @@ class PhpRedisClusterConnection extends PhpRedisConnection
             throw new InvalidArgumentException('No master nodes found in the cluster.');
         }
 
-        [$master, $cursor] = is_string($cursor) && str_contains($cursor, ':')
-            ? explode(':', $cursor, 2)
-            : [0, ''];
+        if (is_string($cursor) && str_starts_with($cursor, 'laravel:')) {
+            [$scanned, $node, $cursor, $initialCursor] = json_decode(
+                base64_decode(substr($cursor, 8), true), true, flags: JSON_THROW_ON_ERROR
+            );
+        } else {
+            $scanned = [];
+            $node = null;
+            $initialCursor = $cursor;
+        }
 
-        $master = (int) $master;
-        $cursor = $cursor === '' ? null : (int) $cursor;
+        if ($node !== null && ! in_array($node, $masters, true)) {
+            $node = null;
+            $cursor = $initialCursor;
+        }
 
-        while ($master < count($masters)) {
+        while (true) {
+            if ($node === null) {
+                $node = current(array_filter($masters, fn ($master) => ! in_array($master, $scanned, true)));
+
+                if ($node === false) {
+                    return false;
+                }
+
+                $cursor = $initialCursor;
+            }
+
             $result = $this->client->scan($cursor,
-                $masters[$master],
+                $node,
                 $options['match'] ?? '*',
                 $options['count'] ?? 10
             );
 
-            if ((int) $cursor === 0) {
-                $master++;
-                $cursor = null;
+            if ((string) $cursor === '0') {
+                $scanned[] = $node;
+                $node = null;
             }
 
             if (! empty($result)) {
-                return [$master.':'.$cursor, $result];
+                $remainingMasters = array_filter($masters, fn ($master) => ! in_array($master, $scanned, true));
+
+                if ($node === null && empty($remainingMasters)) {
+                    return [$initialCursor, $result];
+                }
+
+                return ['laravel:'.base64_encode(json_encode([
+                    $scanned, $node, $cursor, $initialCursor,
+                ], JSON_THROW_ON_ERROR)), $result];
+            }
+
+            if ($node !== null) {
+                return ['laravel:'.base64_encode(json_encode([
+                    $scanned, $node, $cursor, $initialCursor,
+                ], JSON_THROW_ON_ERROR)), []];
             }
         }
-
-        return false;
     }
 
     /**

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -11,27 +11,16 @@ use PHPUnit\Framework\TestCase;
 #[RequiresPhpExtension('redis')]
 class PhpRedisClusterConnectionTest extends TestCase
 {
-    public function testItScansUsingDefaultNode()
+    public function testItScansStartingFromTheFirstMaster()
     {
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(0, ['127.0.0.1', '6379'], '*', 10)
+            ->with(null, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(['key']);
 
         $connection = new PhpRedisClusterConnection($client);
-        $this->assertEquals([0, ['key']], $connection->scan(0));
-    }
-
-    public function testItOnlyFetchesDefaultNodeOnce()
-    {
-        $client = Mockery::mock(\RedisCluster::class);
-        $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
-        $client->expects('scan')->times(2);
-
-        $connection = new PhpRedisClusterConnection($client);
-        $connection->scan(0);
-        $connection->scan(0);
+        $this->assertEquals(['1:', ['key']], $connection->scan(0));
     }
 
     public function testItScansUsingOptionNode()
@@ -51,7 +40,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client->expects('_masters')->andReturn([]);
         $client->shouldNotReceive('scan');
 
-        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.'));
+        $this->expectExceptionObject(new InvalidArgumentException('No master nodes found in the cluster.'));
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->scan(0);
@@ -62,7 +51,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(0, ['127.0.0.1', '6379'], '*', 10)
+            ->with(null, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(false);
 
         $connection = new PhpRedisClusterConnection($client);
@@ -95,5 +84,50 @@ class PhpRedisClusterConnectionTest extends TestCase
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->flushdb('ASYNC');
+    }
+
+    public function testItScansEveryMasterInTurn()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379'], ['127.0.0.3', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn(['a']);
+        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['b']);
+        $client->expects('scan')->with(null, $masters[2], '*', 10)->andReturn(['c']);
+
+        $connection = new PhpRedisClusterConnection($client);
+
+        $this->assertEquals(['1:', ['a']], $connection->scan(0));
+        $this->assertEquals(['2:', ['b']], $connection->scan('1:'));
+        $this->assertEquals(['3:', ['c']], $connection->scan('2:'));
+        $this->assertFalse($connection->scan('3:'));
+    }
+
+    public function testItResumesAMasterFromTheEncodedCursor()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')
+            ->with(42, $masters[1], '*', 10)
+            ->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals(['1:42', ['key']], $connection->scan('1:42'));
+    }
+
+    public function testItKeepsScanningWhenAMasterReturnsNoKeys()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn($masters);
+        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn([]);
+        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals(['2:', ['key']], $connection->scan(0));
     }
 }

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -16,11 +16,11 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(null, ['127.0.0.1', '6379'], '*', 10)
+            ->with(0, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(['key']);
 
         $connection = new PhpRedisClusterConnection($client);
-        $this->assertEquals(['1:', ['key']], $connection->scan(0));
+        $this->assertEquals([0, ['key']], $connection->scan(0));
     }
 
     public function testItScansUsingOptionNode()
@@ -51,7 +51,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client = Mockery::mock(\RedisCluster::class);
         $client->expects('_masters')->andReturn([['127.0.0.1', '6379']]);
         $client->expects('scan')
-            ->with(null, ['127.0.0.1', '6379'], '*', 10)
+            ->with(0, ['127.0.0.1', '6379'], '*', 10)
             ->andReturn(false);
 
         $connection = new PhpRedisClusterConnection($client);
@@ -92,30 +92,49 @@ class PhpRedisClusterConnectionTest extends TestCase
 
         $client = Mockery::mock(\RedisCluster::class);
         $client->allows('_masters')->andReturn($masters);
-        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn(['a']);
-        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['b']);
-        $client->expects('scan')->with(null, $masters[2], '*', 10)->andReturn(['c']);
+        $client->expects('scan')->with(0, $masters[0], '*', 10)->andReturn(['a']);
+        $client->expects('scan')->with(0, $masters[1], '*', 10)->andReturn(['b']);
+        $client->expects('scan')->with(0, $masters[2], '*', 10)->andReturn(['c']);
 
         $connection = new PhpRedisClusterConnection($client);
 
-        $this->assertEquals(['1:', ['a']], $connection->scan(0));
-        $this->assertEquals(['2:', ['b']], $connection->scan('1:'));
-        $this->assertEquals(['3:', ['c']], $connection->scan('2:'));
-        $this->assertFalse($connection->scan('3:'));
+        [$cursor, $keys] = $connection->scan(0);
+        $this->assertSame(['a'], $keys);
+
+        [$cursor, $keys] = $connection->scan($cursor);
+        $this->assertSame(['b'], $keys);
+
+        $this->assertSame([0, ['c']], $connection->scan($cursor));
     }
 
     public function testItResumesAMasterFromTheEncodedCursor()
     {
-        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+        $masters = [['127.0.0.1', '6379']];
 
         $client = Mockery::mock(\RedisCluster::class);
         $client->allows('_masters')->andReturn($masters);
         $client->expects('scan')
-            ->with(42, $masters[1], '*', 10)
-            ->andReturn(['key']);
+            ->with(0, $masters[0], '*', 10)
+            ->andReturnUsing(function (&$cursor) {
+                $cursor = 42;
+
+                return ['first'];
+            });
+        $client->expects('scan')
+            ->with(42, $masters[0], '*', 10)
+            ->andReturnUsing(function (&$cursor) {
+                $cursor = 0;
+
+                return ['last'];
+            });
 
         $connection = new PhpRedisClusterConnection($client);
-        $this->assertEquals(['1:42', ['key']], $connection->scan('1:42'));
+
+        [$cursor, $keys] = $connection->scan(0);
+
+        $this->assertStringStartsWith('laravel:', $cursor);
+        $this->assertSame(['first'], $keys);
+        $this->assertSame([0, ['last']], $connection->scan($cursor));
     }
 
     public function testItKeepsScanningWhenAMasterReturnsNoKeys()
@@ -124,10 +143,77 @@ class PhpRedisClusterConnectionTest extends TestCase
 
         $client = Mockery::mock(\RedisCluster::class);
         $client->allows('_masters')->andReturn($masters);
-        $client->expects('scan')->with(null, $masters[0], '*', 10)->andReturn([]);
-        $client->expects('scan')->with(null, $masters[1], '*', 10)->andReturn(['key']);
+        $client->expects('scan')->with(0, $masters[0], '*', 10)->andReturn([]);
+        $client->expects('scan')->with(0, $masters[1], '*', 10)->andReturn(['key']);
 
         $connection = new PhpRedisClusterConnection($client);
-        $this->assertEquals(['2:', ['key']], $connection->scan(0));
+        $this->assertEquals([0, ['key']], $connection->scan(0));
+    }
+
+    public function testItPreservesLargeStringCursors()
+    {
+        $master = ['127.0.0.1', '6379'];
+        $largeCursor = '18446744073709551615';
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->allows('_masters')->andReturn([$master]);
+        $client->expects('scan')
+            ->with(null, $master, '*', 10)
+            ->andReturnUsing(function (&$cursor) use ($largeCursor) {
+                $cursor = $largeCursor;
+
+                return ['first'];
+            });
+        $client->expects('scan')
+            ->with($largeCursor, $master, '*', 10)
+            ->andReturnUsing(function (&$cursor) {
+                $cursor = '0';
+
+                return ['last'];
+            });
+
+        $connection = new PhpRedisClusterConnection($client);
+
+        [$cursor] = $connection->scan(null);
+
+        $this->assertSame([null, ['last']], $connection->scan($cursor));
+    }
+
+    public function testItKeepsNodeAffinityWhenMastersAreReordered()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->expects('_masters')->twice()->andReturn($masters, array_reverse($masters));
+        $client->expects('scan')->with(0, $masters[0], '*', 10)->andReturn(['a']);
+        $client->expects('scan')->with(0, $masters[1], '*', 10)->andReturn(['b']);
+
+        $connection = new PhpRedisClusterConnection($client);
+
+        [$cursor] = $connection->scan(0);
+
+        $this->assertSame([0, ['b']], $connection->scan($cursor));
+    }
+
+    public function testItContinuesWithAnotherMasterWhenTheCurrentMasterDisappears()
+    {
+        $masters = [['127.0.0.1', '6379'], ['127.0.0.2', '6379']];
+
+        $client = Mockery::mock(\RedisCluster::class);
+        $client->expects('_masters')->twice()->andReturn($masters, [$masters[1]]);
+        $client->expects('scan')
+            ->with(0, $masters[0], '*', 10)
+            ->andReturnUsing(function (&$cursor) {
+                $cursor = 42;
+
+                return ['a'];
+            });
+        $client->expects('scan')->with(0, $masters[1], '*', 10)->andReturn(['b']);
+
+        $connection = new PhpRedisClusterConnection($client);
+
+        [$cursor] = $connection->scan(0);
+
+        $this->assertSame([0, ['b']], $connection->scan($cursor));
     }
 }


### PR DESCRIPTION
On a phpredis cluster, scan() only ever queries the first master, so cache:prune-stale-tags and Horizon's metric cleanup silently miss every key that lives on the other nodes. 
This changes scan() to walk each master in turn, carrying the master's index inside the opaque cursor - iteration still ends with false so existing callers work unchanged, and an explicit node option still scans just that node. 
Two tests that pinned the single-node cursor were updated, one covering the removed default-node cache was dropped, and three new ones cover the multi-master iteration.