### PR TITLE
[13.x] Add Redis Sentinel support for PhpRedis with transient failure retries

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -5,8 +5,11 @@ namespace Illuminate\Redis\Connections;
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Redis;
 use RedisException;
+use Throwable;
 
 /**
  * @mixin \Redis
@@ -40,6 +43,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         'hlen',
         'hmget',
         'hmset',
+        'hscan',
         'hstrlen',
         'hvals',
         'keys',
@@ -52,6 +56,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         'ping',
         'pttl',
         'randomkey',
+        'scan',
         'scard',
         'sdiff',
         'sinter',
@@ -59,6 +64,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         'smembers',
         'smismember',
         'srandmember',
+        'sscan',
         'strlen',
         'sunion',
         'time',
@@ -76,7 +82,31 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         'zrange',
         'zrank',
         'zrevrank',
+        'zscan',
         'zscore',
+    ];
+
+    /**
+     * The error messages that indicate a transient connection failure.
+     *
+     * @var list<string>
+     */
+    protected const TRANSIENT_ERROR_MESSAGES = [
+        "can't write against a read only replica",
+        'connection closed',
+        'connection lost',
+        'connection refused',
+        'connection timed out',
+        'error while reading',
+        'failed while reconnecting',
+        'getaddrinfo',
+        'loading',
+        'name or service not known',
+        'php_network_getaddresses',
+        'read error on connection',
+        'readonly',
+        'socket',
+        'went away',
     ];
 
     /**
@@ -376,16 +406,18 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function scan($cursor, $options = [])
     {
-        $result = $this->client->scan($cursor,
-            $options['match'] ?? '*',
-            $options['count'] ?? 10
-        );
+        return $this->retryOnTransientErrors($this->commandRetries('scan'), function () use ($cursor, $options) {
+            $result = $this->client->scan($cursor,
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
 
-        if ($result === false) {
-            $result = [];
-        }
+            if ($result === false) {
+                $result = [];
+            }
 
-        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+            return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+        });
     }
 
     /**
@@ -398,16 +430,18 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zscan($key, $cursor, $options = [])
     {
-        $result = $this->client->zscan($key, $cursor,
-            $options['match'] ?? '*',
-            $options['count'] ?? 10
-        );
+        return $this->retryOnTransientErrors($this->commandRetries('zscan'), function () use ($key, $cursor, $options) {
+            $result = $this->client->zscan($key, $cursor,
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
 
-        if ($result === false) {
-            $result = [];
-        }
+            if ($result === false) {
+                $result = [];
+            }
 
-        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+            return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+        });
     }
 
     /**
@@ -420,16 +454,18 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function hscan($key, $cursor, $options = [])
     {
-        $result = $this->client->hscan($key, $cursor,
-            $options['match'] ?? '*',
-            $options['count'] ?? 10
-        );
+        return $this->retryOnTransientErrors($this->commandRetries('hscan'), function () use ($key, $cursor, $options) {
+            $result = $this->client->hscan($key, $cursor,
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
 
-        if ($result === false) {
-            $result = [];
-        }
+            if ($result === false) {
+                $result = [];
+            }
 
-        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+            return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+        });
     }
 
     /**
@@ -442,16 +478,18 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function sscan($key, $cursor, $options = [])
     {
-        $result = $this->client->sscan($key, $cursor,
-            $options['match'] ?? '*',
-            $options['count'] ?? 10
-        );
+        return $this->retryOnTransientErrors($this->commandRetries('sscan'), function () use ($key, $cursor, $options) {
+            $result = $this->client->sscan($key, $cursor,
+                $options['match'] ?? '*',
+                $options['count'] ?? 10
+            );
 
-        if ($result === false) {
-            $result = [];
-        }
+            if ($result === false) {
+                $result = [];
+            }
 
-        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+            return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+        });
     }
 
     /**
@@ -462,11 +500,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function pipeline(?callable $callback = null)
     {
-        $pipeline = $this->client()->pipeline();
+        return $this->retryOnTransientErrors((int) ($this->config['command_retries'] ?? 0), function () use ($callback) {
+            $pipeline = $this->client()->pipeline();
 
-        return is_null($callback)
-            ? $pipeline
-            : tap($pipeline, $callback)->exec();
+            return is_null($callback)
+                ? $pipeline
+                : tap($pipeline, $callback)->exec();
+        });
     }
 
     /**
@@ -477,11 +517,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function transaction(?callable $callback = null)
     {
-        $transaction = $this->client()->multi();
+        return $this->retryOnTransientErrors((int) ($this->config['command_retries'] ?? 0), function () use ($callback) {
+            $transaction = $this->client()->multi();
 
-        return is_null($callback)
-            ? $transaction
-            : tap($transaction, $callback)->exec();
+            return is_null($callback)
+                ? $transaction
+                : tap($transaction, $callback)->exec();
+        });
     }
 
     /**
@@ -521,8 +563,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function subscribe($channels, Closure $callback)
     {
-        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
-            $callback($message, $channel);
+        $this->retryOnTransientErrors((int) ($this->config['command_retries'] ?? 0), function () use ($channels, $callback) {
+            $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
+                $callback($message, $channel);
+            });
         });
     }
 
@@ -535,8 +579,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function psubscribe($channels, Closure $callback)
     {
-        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
-            $callback($message, $channel);
+        $this->retryOnTransientErrors((int) ($this->config['command_retries'] ?? 0), function () use ($channels, $callback) {
+            $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
+                $callback($message, $channel);
+            });
         });
     }
 
@@ -591,26 +637,58 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function command($method, array $parameters = [])
     {
-        $retries = max(
-            $this->isRetryable($method, $parameters) ? 1 : 0,
-            (int) ($this->config['command_retries'] ?? 0),
+        return $this->retryOnTransientErrors(
+            $this->commandRetries($method, $parameters),
+            fn () => parent::command($method, $parameters)
         );
+    }
+
+    /**
+     * Run the given callback, retrying when a transient connection failure occurs.
+     *
+     * @param  int  $retries
+     * @param  callable  $callback
+     * @return mixed
+     *
+     * @throws \RedisException
+     */
+    protected function retryOnTransientErrors($retries, callable $callback)
+    {
+        $attempts = 0;
+        $delay = 0;
 
         while (true) {
             try {
-                return parent::command($method, $parameters);
+                return $callback();
             } catch (RedisException $e) {
-                if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost'])) {
+                if (! $this->causedByTransientError($e)) {
                     throw $e;
                 }
 
-                $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+                $this->reconnect();
 
-                if ($retries-- === 0) {
+                if ($attempts >= $retries) {
                     throw $e;
                 }
+
+                $delay = $this->backoff($attempts++, $delay);
             }
         }
+    }
+
+    /**
+     * Determine the number of times the given command may be retried.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return int
+     */
+    protected function commandRetries($method, array $parameters = [])
+    {
+        return max(
+            $this->isRetryable($method, $parameters) ? 1 : 0,
+            (int) ($this->config['command_retries'] ?? 0),
+        );
     }
 
     /**
@@ -629,6 +707,119 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         }
 
         return in_array($method, static::RETRYABLE_COMMANDS, true);
+    }
+
+    /**
+     * Determine if the given exception was caused by a transient connection failure.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    protected function causedByTransientError(Throwable $e)
+    {
+        return Str::contains($e->getMessage(), static::TRANSIENT_ERROR_MESSAGES, true);
+    }
+
+    /**
+     * Reconnect to the Redis server, replacing the underlying client.
+     *
+     * @return void
+     */
+    protected function reconnect()
+    {
+        if (! $this->connector) {
+            return;
+        }
+
+        try {
+            $this->disconnect();
+        } catch (Throwable) {
+            //
+        }
+
+        try {
+            $this->client = call_user_func($this->connector);
+        } catch (RedisException) {
+            //
+        } catch (Throwable $e) {
+            if (! $this->causedByTransientError($e)) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Pause execution before the next retry attempt.
+     *
+     * @param  int  $attempt
+     * @param  int  $previousDelay
+     * @return int
+     */
+    protected function backoff($attempt, $previousDelay)
+    {
+        $delay = $this->backoffDelay($attempt, $previousDelay);
+
+        if ($delay > 0) {
+            Sleep::usleep($delay * 1000);
+        }
+
+        return $delay;
+    }
+
+    /**
+     * Calculate the backoff delay in milliseconds for the given retry attempt.
+     *
+     * Mirrors the backoff algorithms provided by PhpRedis using the same
+     * "backoff_algorithm", "backoff_base", and "backoff_cap" options.
+     *
+     * @param  int  $attempt
+     * @param  int  $previousDelay
+     * @return int
+     */
+    protected function backoffDelay($attempt, $previousDelay)
+    {
+        $base = (int) ($this->config['backoff_base'] ?? 0);
+        $cap = (int) ($this->config['backoff_cap'] ?? 1000);
+
+        if ($base <= 0) {
+            return 0;
+        }
+
+        $exponential = min($cap, $base * (1 << min($attempt, 10)));
+
+        return match ($this->backoffAlgorithm()) {
+            Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER => min($cap, random_int(min($base, $previousDelay * 3), max($base, $previousDelay * 3))),
+            Redis::BACKOFF_ALGORITHM_FULL_JITTER => random_int(0, $exponential),
+            Redis::BACKOFF_ALGORITHM_EQUAL_JITTER => intdiv($exponential, 2) + intdiv(random_int(0, $exponential), 2),
+            Redis::BACKOFF_ALGORITHM_EXPONENTIAL => $exponential,
+            Redis::BACKOFF_ALGORITHM_UNIFORM => min($cap, random_int(0, $base)),
+            Redis::BACKOFF_ALGORITHM_CONSTANT => min($cap, $base),
+            default => $attempt > 0 ? min($cap, $base) : min($cap, random_int(0, $base)),
+        };
+    }
+
+    /**
+     * Get the backoff algorithm used when retrying commands.
+     *
+     * @return int
+     */
+    protected function backoffAlgorithm()
+    {
+        $algorithm = $this->config['backoff_algorithm'] ?? Redis::BACKOFF_ALGORITHM_DEFAULT;
+
+        if (is_int($algorithm)) {
+            return $algorithm;
+        }
+
+        return match ($algorithm) {
+            'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
+            'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
+            'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
+            'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
+            'uniform' => Redis::BACKOFF_ALGORITHM_UNIFORM,
+            'constant' => Redis::BACKOFF_ALGORITHM_CONSTANT,
+            default => Redis::BACKOFF_ALGORITHM_DEFAULT,
+        };
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -368,6 +368,7 @@ class PhpRedisConnector implements Connector
         return match ($algorithm) {
             'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
             'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
+            'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
             'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
             'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
             'uniform' => Redis::BACKOFF_ALGORITHM_UNIFORM,

--- a/src/Illuminate/Redis/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisSentinelConnector.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Illuminate\Redis\Connectors;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use InvalidArgumentException;
+use RedisException;
+use RedisSentinel;
+
+class PhpRedisSentinelConnector extends PhpRedisConnector
+{
+    /**
+     * The default retry configuration for Sentinel managed connections.
+     *
+     * @var array
+     */
+    protected const SENTINEL_DEFAULTS = [
+        'command_retries' => 20,
+        'backoff_base' => 1000,
+        'backoff_cap' => 1000,
+    ];
+
+    /**
+     * Create a new connection.
+     *
+     * @param  array  $config
+     * @param  array  $options
+     * @return PhpRedisConnection
+     */
+    public function connect(array $config, array $options)
+    {
+        return parent::connect($config + static::SENTINEL_DEFAULTS, $options);
+    }
+
+    /**
+     * Create the Redis client instance, connected to the master resolved by Sentinel.
+     *
+     * @param  array  $config
+     * @return \Redis
+     *
+     * @throws \RedisException
+     */
+    protected function createClient(array $config)
+    {
+        $master = $this->resolveMaster($config);
+
+        return parent::createClient(array_merge($config, [
+            'host' => $master['ip'],
+            'port' => (int) $master['port'],
+        ]));
+    }
+
+    /**
+     * Resolve the current master for the configured service from Sentinel.
+     *
+     * @param  array  $config
+     * @return array
+     *
+     * @throws \RedisException
+     */
+    protected function resolveMaster(array $config)
+    {
+        $service = $config['sentinel_service'] ?? 'mymaster';
+
+        $lastException = null;
+
+        foreach ($this->sentinelConfigurations($config) as $sentinelConfig) {
+            try {
+                $master = $this->connectToSentinel($sentinelConfig)->master($service);
+            } catch (RedisException $e) {
+                $lastException = $e;
+
+                continue;
+            }
+
+            if (is_array($master) && isset($master['ip'], $master['port'])) {
+                return $master;
+            }
+
+            throw new RedisException("No master found for service [{$service}].");
+        }
+
+        throw $lastException ?? new RedisException("No master found for service [{$service}].");
+    }
+
+    /**
+     * Get the Sentinel connection configurations in the order they should be tried.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function sentinelConfigurations(array $config)
+    {
+        if (empty($config['sentinel_hosts'])) {
+            return [$config];
+        }
+
+        return array_map(fn ($host) => array_merge($config, [
+            'sentinel_host' => $host['host'] ?? null,
+            'sentinel_port' => (int) ($host['port'] ?? 26379),
+        ]), $config['sentinel_hosts']);
+    }
+
+    /**
+     * Connect to the configured Redis Sentinel instance.
+     *
+     * @param  array  $config
+     * @return \RedisSentinel
+     *
+     * @throws InvalidArgumentException
+     * @throws \RedisException
+     */
+    protected function connectToSentinel(array $config)
+    {
+        return new RedisSentinel(...$this->sentinelParameters($config));
+    }
+
+    /**
+     * Build the RedisSentinel constructor parameters for the installed PhpRedis version.
+     *
+     * @param  array  $config
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function sentinelParameters(array $config)
+    {
+        $host = $config['sentinel_host'] ?? null;
+
+        if (! is_string($host) || trim($host) === '') {
+            throw new InvalidArgumentException('Redis Sentinel host must be a non-empty string.');
+        }
+
+        $port = (int) ($config['sentinel_port'] ?? 26379);
+        $timeout = $config['sentinel_timeout'] ?? 0.2;
+        $persistent = $config['sentinel_persistent'] ?? null;
+        $retryInterval = $config['sentinel_retry_interval'] ?? 0;
+        $readTimeout = $config['sentinel_read_timeout'] ?? 0;
+
+        $auth = null;
+
+        if (! empty($config['sentinel_password'])) {
+            $auth = isset($config['sentinel_username']) && $config['sentinel_username'] !== '' && is_string($config['sentinel_password'])
+                ? [$config['sentinel_username'], $config['sentinel_password']]
+                : $config['sentinel_password'];
+        }
+
+        if (version_compare($version = $this->phpRedisVersion(), '6.0', '>=')) {
+            $options = [
+                'host' => $host,
+                'port' => $port,
+                'connectTimeout' => $timeout,
+                'persistent' => $persistent,
+                'retryInterval' => $retryInterval,
+                'readTimeout' => $readTimeout,
+            ];
+
+            if (! is_null($auth)) {
+                $options['auth'] = $auth;
+            }
+
+            if (version_compare($version, '6.1', '>=') && isset($config['sentinel_ssl'])) {
+                $options['ssl'] = $config['sentinel_ssl'];
+            }
+
+            return [$options];
+        }
+
+        $parameters = [$host, $port, $timeout, $persistent, $retryInterval, $readTimeout];
+
+        if (! is_null($auth)) {
+            $parameters[] = $auth;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Get the version of the PhpRedis extension.
+     *
+     * @return string
+     */
+    protected function phpRedisVersion()
+    {
+        return phpversion('redis');
+    }
+}

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Redis\Factory;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
+use Illuminate\Redis\Connectors\PhpRedisSentinelConnector;
 use Illuminate\Redis\Connectors\PredisConnector;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
@@ -173,6 +174,7 @@ class RedisManager implements Factory
         return match ($this->driver) {
             'predis' => new PredisConnector,
             'phpredis' => new PhpRedisConnector,
+            'phpredis-sentinel' => new PhpRedisSentinelConnector,
             default => null,
         };
     }

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
+use Illuminate\Support\Sleep;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
@@ -12,6 +13,13 @@ use ReflectionProperty;
 
 class PhpRedisConnectorTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Sleep::fake(false);
+
+        parent::tearDown();
+    }
+
     public function testNormalizeContextWrapsFlatArrayInStream()
     {
         $connector = new TestablePhpRedisConnector;
@@ -213,6 +221,7 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_DEFAULT, $connector->testParseBackoffAlgorithm('default'));
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER, $connector->testParseBackoffAlgorithm('decorrelated_jitter'));
+        $this->assertSame(\Redis::BACKOFF_ALGORITHM_FULL_JITTER, $connector->testParseBackoffAlgorithm('full_jitter'));
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_EQUAL_JITTER, $connector->testParseBackoffAlgorithm('equal_jitter'));
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_EXPONENTIAL, $connector->testParseBackoffAlgorithm('exponential'));
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_UNIFORM, $connector->testParseBackoffAlgorithm('uniform'));
@@ -411,6 +420,234 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(3, $reconnects);
     }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionRetriesWithBackoffDelaysAcrossFailover()
+    {
+        Sleep::fake();
+
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->exactly(2))->method('get')->with('foo')->willThrowException(new RedisException('Connection lost'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+
+        $reconnects = 0;
+        $connection = new PhpRedisConnection($failedClient, function () use (&$reconnects, $healthyClient) {
+            if (++$reconnects === 1) {
+                throw new RedisException('Connection refused');
+            }
+
+            return $healthyClient;
+        }, ['command_retries' => 2, 'backoff_algorithm' => 'constant', 'backoff_base' => 100, 'backoff_cap' => 1000]);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+        $this->assertSame(2, $reconnects);
+        $this->assertSame($healthyClient, $connection->client());
+
+        Sleep::assertSleptTimes(2);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionRetriesNameResolutionErrors()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('get')->with('foo')->willThrowException(
+            new RedisException('php_network_getaddresses: getaddrinfo for redis-master failed: Name or service not known')
+        );
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionThrowsOriginalExceptionWhenReconnectionKeepsFailing()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->exactly(2))->method('get')->with('foo')->willThrowException(new RedisException('Connection lost'));
+
+        $connection = new PhpRedisConnection($failedClient, function () {
+            throw new RedisException('Connection refused');
+        }, ['command_retries' => 1]);
+
+        try {
+            $connection->command('get', ['foo']);
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertSame('Connection lost', $e->getMessage());
+        }
+
+        $this->assertSame($failedClient, $connection->client());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionDoesNotRetryNonIdempotentCommandOnNewlyMatchedErrors()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('incr')->with('foo')->willThrowException(new RedisException('Connection refused'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->never())->method('incr');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->expectExceptionObject(new RedisException('Connection refused'));
+
+        $connection->command('incr', ['foo']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testScanIsRetriedAfterTransientError()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('scan')->willThrowException(new RedisException('read error on connection'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('scan')->willReturn(['foo']);
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->assertSame([0, ['foo']], $connection->scan(0));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testPipelineIsRetriedWhenCommandRetriesAreConfigured()
+    {
+        $pipeline = $this->createMock(\Redis::class);
+        $pipeline->expects($this->once())->method('exec')->willReturn(['ok']);
+
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('pipeline')->willThrowException(new RedisException('went away'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('pipeline')->willReturn($pipeline);
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient, ['command_retries' => 1]);
+
+        $this->assertSame(['ok'], $connection->pipeline(function ($pipe) {
+            //
+        }));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testPipelineIsNotRetriedByDefault()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('pipeline')->willThrowException(new RedisException('went away'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->never())->method('pipeline');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        try {
+            $connection->pipeline(function ($pipe) {
+                //
+            });
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertSame('went away', $e->getMessage());
+        }
+
+        $this->assertSame($healthyClient, $connection->client());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testSubscribeResubscribesAfterTransientError()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('subscribe')->willThrowException(new RedisException('Connection lost'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('subscribe')->with(['channel'], $this->isInstanceOf(\Closure::class));
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient, ['command_retries' => 1]);
+
+        $connection->subscribe('channel', function () {
+            //
+        });
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayIsZeroWithoutConfiguredBase()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_algorithm' => 'constant',
+        ]);
+
+        $this->assertSame(0, $connection->testBackoffDelay(0, 0));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayForConstantAlgorithm()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_algorithm' => 'constant', 'backoff_base' => 100, 'backoff_cap' => 1000,
+        ]);
+
+        $this->assertSame(100, $connection->testBackoffDelay(0, 0));
+        $this->assertSame(100, $connection->testBackoffDelay(5, 100));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayForExponentialAlgorithmIsCapped()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_algorithm' => 'exponential', 'backoff_base' => 100, 'backoff_cap' => 1000,
+        ]);
+
+        $this->assertSame(100, $connection->testBackoffDelay(0, 0));
+        $this->assertSame(200, $connection->testBackoffDelay(1, 0));
+        $this->assertSame(800, $connection->testBackoffDelay(3, 0));
+        $this->assertSame(1000, $connection->testBackoffDelay(4, 0));
+        $this->assertSame(1000, $connection->testBackoffDelay(20, 0));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayForDefaultAlgorithmUsesBaseAfterFirstRetry()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_base' => 100, 'backoff_cap' => 1000,
+        ]);
+
+        $first = $connection->testBackoffDelay(0, 0);
+
+        $this->assertGreaterThanOrEqual(0, $first);
+        $this->assertLessThanOrEqual(100, $first);
+        $this->assertSame(100, $connection->testBackoffDelay(1, $first));
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayForDecorrelatedJitterAlgorithmStaysWithinBounds()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_algorithm' => 'decorrelated_jitter', 'backoff_base' => 100, 'backoff_cap' => 1000,
+        ]);
+
+        $delay = $connection->testBackoffDelay(0, 0);
+
+        $this->assertGreaterThanOrEqual(0, $delay);
+        $this->assertLessThanOrEqual(100, $delay);
+
+        $next = $connection->testBackoffDelay(1, 400);
+
+        $this->assertGreaterThanOrEqual(100, $next);
+        $this->assertLessThanOrEqual(1000, $next);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testBackoffDelayAcceptsPhpRedisAlgorithmConstants()
+    {
+        $connection = new TestablePhpRedisConnection($this->createStub(\Redis::class), null, [
+            'backoff_algorithm' => \Redis::BACKOFF_ALGORITHM_CONSTANT, 'backoff_base' => 100, 'backoff_cap' => 1000,
+        ]);
+
+        $this->assertSame(100, $connection->testBackoffDelay(3, 0));
+    }
 }
 
 class ClusterStubPhpRedisConnector extends PhpRedisConnector
@@ -428,6 +665,14 @@ class ClusterStubPhpRedisConnector extends PhpRedisConnector
                 throw new RedisException('Connection lost');
             }
         };
+    }
+}
+
+class TestablePhpRedisConnection extends PhpRedisConnection
+{
+    public function testBackoffDelay(int $attempt, int $previousDelay): int
+    {
+        return $this->backoffDelay($attempt, $previousDelay);
     }
 }
 

--- a/tests/Redis/PhpRedisSentinelConnectorTest.php
+++ b/tests/Redis/PhpRedisSentinelConnectorTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Redis\Connectors\PhpRedisSentinelConnector;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use RedisException;
+use ReflectionProperty;
+
+class PhpRedisSentinelConnectorTest extends TestCase
+{
+    #[RequiresPhpExtension('redis')]
+    public function testConnectsToMasterResolvedBySentinel()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => ['ip' => '10.0.0.9', 'port' => '6381'],
+        ]);
+
+        $connection = $connector->connect([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_service' => 'mymaster',
+        ], []);
+
+        $this->assertInstanceOf(PhpRedisConnection::class, $connection);
+        $this->assertSame('10.0.0.9', $connector->established['host']);
+        $this->assertSame(6381, $connector->established['port']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testDiscoveryFailsOverToNextSentinelHost()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => new RedisException('Connection refused'),
+            'sentinel-b' => ['ip' => '10.0.0.7', 'port' => '6379'],
+        ]);
+
+        $connection = $connector->connect([
+            'sentinel_hosts' => [
+                ['host' => 'sentinel-a', 'port' => 26379],
+                ['host' => 'sentinel-b', 'port' => 26380],
+            ],
+            'sentinel_service' => 'mymaster',
+        ], []);
+
+        $this->assertInstanceOf(PhpRedisConnection::class, $connection);
+        $this->assertSame(['sentinel-a', 'sentinel-b'], $connector->attempted);
+        $this->assertSame('10.0.0.7', $connector->established['host']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testThrowsWhenSentinelKnowsNoMasterForService()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => false,
+        ]);
+
+        $this->expectExceptionObject(new RedisException('No master found for service [mymaster].'));
+
+        $connector->connect(['sentinel_host' => 'sentinel-a'], []);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testThrowsLastExceptionWhenAllSentinelsAreUnreachable()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => new RedisException('Connection refused by a'),
+            'sentinel-b' => new RedisException('Connection refused by b'),
+        ]);
+
+        $this->expectExceptionObject(new RedisException('Connection refused by b'));
+
+        $connector->connect([
+            'sentinel_hosts' => [
+                ['host' => 'sentinel-a', 'port' => 26379],
+                ['host' => 'sentinel-b', 'port' => 26379],
+            ],
+        ], []);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testSentinelRetryDefaultsAreApplied()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => ['ip' => '10.0.0.9', 'port' => '6381'],
+        ]);
+
+        $connection = $connector->connect(['sentinel_host' => 'sentinel-a'], []);
+
+        $property = new ReflectionProperty(PhpRedisConnection::class, 'config');
+        $config = $property->getValue($connection);
+
+        $this->assertSame(20, $config['command_retries']);
+        $this->assertSame(1000, $config['backoff_base']);
+        $this->assertSame(1000, $config['backoff_cap']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testSentinelRetryDefaultsMayBeOverridden()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-a' => ['ip' => '10.0.0.9', 'port' => '6381'],
+        ]);
+
+        $connection = $connector->connect([
+            'sentinel_host' => 'sentinel-a',
+            'command_retries' => 3,
+            'backoff_base' => 250,
+        ], []);
+
+        $property = new ReflectionProperty(PhpRedisConnection::class, 'config');
+        $config = $property->getValue($connection);
+
+        $this->assertSame(3, $config['command_retries']);
+        $this->assertSame(250, $config['backoff_base']);
+    }
+
+    public function testSentinelParametersForPhpRedis61IncludeSsl()
+    {
+        $connector = new TestableVersionSentinelConnector('6.1.0');
+
+        [$options] = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_port' => 26380,
+            'sentinel_timeout' => 0.5,
+            'sentinel_read_timeout' => 1.0,
+            'sentinel_ssl' => ['verify_peer' => false],
+        ]);
+
+        $this->assertSame('sentinel-a', $options['host']);
+        $this->assertSame(26380, $options['port']);
+        $this->assertSame(0.5, $options['connectTimeout']);
+        $this->assertSame(1.0, $options['readTimeout']);
+        $this->assertSame(['verify_peer' => false], $options['ssl']);
+    }
+
+    public function testSentinelParametersForPhpRedis60OmitSsl()
+    {
+        $connector = new TestableVersionSentinelConnector('6.0.2');
+
+        [$options] = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_ssl' => ['verify_peer' => false],
+        ]);
+
+        $this->assertSame('sentinel-a', $options['host']);
+        $this->assertArrayNotHasKey('ssl', $options);
+    }
+
+    public function testSentinelParametersIncludeAuthWhenCredentialsAreConfigured()
+    {
+        $connector = new TestableVersionSentinelConnector('6.0.2');
+
+        [$options] = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_username' => 'sentinel-user',
+            'sentinel_password' => 'secret',
+        ]);
+
+        $this->assertSame(['sentinel-user', 'secret'], $options['auth']);
+
+        [$options] = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_password' => 'secret',
+        ]);
+
+        $this->assertSame('secret', $options['auth']);
+    }
+
+    public function testSentinelParametersForLegacyPhpRedisArePositional()
+    {
+        $connector = new TestableVersionSentinelConnector('5.3.7');
+
+        $parameters = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_port' => 26380,
+        ]);
+
+        $this->assertSame(['sentinel-a', 26380, 0.2, null, 0, 0], $parameters);
+    }
+
+    public function testSentinelParametersForLegacyPhpRedisAppendAuth()
+    {
+        $connector = new TestableVersionSentinelConnector('5.3.7');
+
+        $parameters = $connector->testSentinelParameters([
+            'sentinel_host' => 'sentinel-a',
+            'sentinel_password' => 'secret',
+        ]);
+
+        $this->assertCount(7, $parameters);
+        $this->assertSame('secret', $parameters[6]);
+    }
+
+    public function testSentinelParametersRequireAHost()
+    {
+        $connector = new TestableVersionSentinelConnector('6.1.0');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Redis Sentinel host must be a non-empty string.'));
+
+        $connector->testSentinelParameters([]);
+    }
+}
+
+class SentinelStubPhpRedisConnector extends PhpRedisSentinelConnector
+{
+    public $attempted = [];
+
+    public $established;
+
+    public function __construct(protected array $sentinels = [])
+    {
+    }
+
+    protected function connectToSentinel(array $config)
+    {
+        $host = $config['sentinel_host'];
+
+        $this->attempted[] = $host;
+
+        $outcome = $this->sentinels[$host] ?? new RedisException('Connection refused');
+
+        if ($outcome instanceof RedisException) {
+            throw $outcome;
+        }
+
+        return new class($outcome)
+        {
+            public function __construct(private $master)
+            {
+            }
+
+            public function master($service)
+            {
+                return $this->master;
+            }
+        };
+    }
+
+    protected function establishConnection($client, array $config)
+    {
+        $this->established = $config;
+    }
+}
+
+class TestableVersionSentinelConnector extends PhpRedisSentinelConnector
+{
+    public function __construct(protected string $version)
+    {
+    }
+
+    protected function phpRedisVersion()
+    {
+        return $this->version;
+    }
+
+    public function testSentinelParameters(array $config)
+    {
+        return $this->sentinelParameters($config);
+    }
+}


### PR DESCRIPTION
We use sentinel in production with k8s. When a pod failure occurs, we want Laravel to gracefully retry the master list, find out who the new pod to talk to is, and handle the request.

The implementation is derived from [`namoshek/laravel-redis-sentinel`](https://github.com/Namoshek/laravel-redis-sentinel), which we've used now for some time successfully. All credit to namoshek.

A new `phpredis-sentinel` client selects the connector. The connection keys are identical to the community package, so existing users can drop the dependency without touching their configuration:

```php
'redis' => [
    'client' => env('REDIS_CLIENT', 'phpredis-sentinel'),

    'default' => [
        'sentinel_host' => env('REDIS_SENTINEL_HOST', '127.0.0.1'),
        'sentinel_port' => env('REDIS_SENTINEL_PORT', 26379),
        'sentinel_service' => env('REDIS_SENTINEL_SERVICE', 'mymaster'),
        // or, instead of sentinel_host / sentinel_port:
        // 'sentinel_hosts' => [
        //     ['host' => '10.0.0.1', 'port' => 26379],
        //     ['host' => '10.0.0.2', 'port' => 26379],
        // ],
        'password' => env('REDIS_PASSWORD'),
        'database' => 0,
    ],
],
```

Also supported: `sentinel_timeout`, `sentinel_persistent`, `sentinel_retry_interval`, `sentinel_read_timeout`, `sentinel_username`, `sentinel_password`, and `sentinel_ssl` (PhpRedis >= 6.1). `host`/`port` are ignored for Sentinel connections — the master is resolved at connect time, and re-resolved on every reconnect, which is what makes failover work.

Used a distinct client, since this changes how connections are established, rather than changing any behavior once connected.

Should be backwards compatible, with some improvements on retries.

Wanted to stick this out here and see if there is any interest.
