### PR TITLE
[11.x] Retry timed-out cloud agent long-polls

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -255,6 +255,7 @@ class Queue implements QueueContract, ClearableQueue
         try {
             $response = $this->agentRequest()
                 ->timeout(65)
+                ->retry([0, 500], throw: false)
                 ->get('/next');
         } catch (ConnectionException $e) {
             throw $this->agentUnreachable(

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use InvalidArgumentException;
@@ -799,6 +800,7 @@ class QueueTest extends TestCase
 
     public function testPopThrowsWhenTheAgentSocketIsUnreachable()
     {
+        Sleep::fake();
         $this->fakeEvents();
         [$queue] = $this->fakeQueue();
 
@@ -808,6 +810,53 @@ class QueueTest extends TestCase
         $this->expectException(AgentUnreachableException::class);
 
         $queue->pop();
+    }
+
+    public function testPopRetriesATimedOutLongPollImmediately()
+    {
+        Sleep::fake();
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // A worker that scaled to zero mid long-poll wakes with its request
+        // deadline lapsed, so the poll times out even though the agent is
+        // healthy. The poll is retried transparently - and without any backoff,
+        // since the agent typically answers the fresh attempt at once.
+        $agent->nextExceptions = [$this->pollTimeoutException()];
+        $agent->pushJob(['messageId' => 'message-id', 'body' => 'job-body']);
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+        $this->assertSame(2, $agent->nextRequests);
+        Sleep::assertNeverSlept();
+    }
+
+    public function testPopThrowsWhenEveryLongPollAttemptTimesOut()
+    {
+        Sleep::fake();
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // Timeouts across the original attempt and both retries mean the agent is
+        // live but wedged - the socket accepts, yet nothing answers - so it
+        // escalates to restart the pod. The second retry backs off to give an
+        // agent that is itself still waking a moment to recover.
+        $agent->nextExceptions = [
+            $this->pollTimeoutException(),
+            $this->pollTimeoutException(),
+            $this->pollTimeoutException(),
+        ];
+
+        try {
+            $queue->pop();
+
+            $this->fail('AgentUnreachableException was not thrown.');
+        } catch (AgentUnreachableException) {
+            $this->assertSame(3, $agent->nextRequests);
+            Sleep::assertSequence([Sleep::usleep(500_000)]);
+        }
     }
 
     public function testPopFlagsTheWorkerToStopWhenTheAgentIsUnreachable()
@@ -1603,6 +1652,16 @@ class QueueTest extends TestCase
 
             public $nextResponse = null;
 
+            /**
+             * Exceptions GET /next throws, one per request, before serving jobs.
+             */
+            public array $nextExceptions = [];
+
+            /**
+             * The number of GET /next requests the agent has received.
+             */
+            public int $nextRequests = 0;
+
             public function pushJob(array $job = []): array
             {
                 $job = array_merge([
@@ -1623,6 +1682,12 @@ class QueueTest extends TestCase
 
         Http::fake(function ($request) use ($agent) {
             if (str_ends_with($request->url(), '/next')) {
+                $agent->nextRequests++;
+
+                if ($exception = array_shift($agent->nextExceptions)) {
+                    throw $exception;
+                }
+
                 if ($agent->nextResponse !== null) {
                     return $agent->nextResponse;
                 }
@@ -1646,6 +1711,18 @@ class QueueTest extends TestCase
         });
 
         return $agent;
+    }
+
+    /**
+     * Build the exception a timed-out GET /next long-poll surfaces as. The
+     * message mirrors the curl handler's format, which the client preserves
+     * when wrapping Guzzle's ConnectException.
+     */
+    private function pollTimeoutException(): ConnectionException
+    {
+        return new ConnectionException(
+            'cURL error 28: Operation timed out after 76900 milliseconds with 0 bytes received (see https://curl.se/libcurl/c/libcurl-errors.html) for http://localhost/next'
+        );
     }
 
     private function fakeFailer()


### PR DESCRIPTION
On compute that can [scale to zero](https://cloud.laravel.com/docs/compute#scale-to-zero), a queue worker can wake to find its in-flight `GET /next` long-poll already past its deadline. The request surfaces as a timeout even though the agent is healthy, and the worker exits with a spurious `AgentUnreachableException` ("The Laravel Cloud agent runtime socket is unreachable.").

This PR retries a failed long-poll — immediately, then once more after a 500ms backoff — before treating the agent as unreachable:

- A genuinely unreachable agent still throws `AgentUnreachableException` once all three attempts fail.
- `throw: false` keeps non-2xx responses flowing to the existing status handling, which is unchanged.
- `POST /result` reporting is untouched.

Backport of laravel/framework#61177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)