### PR TITLE
[13.x] Fix infinite scan loop when pruning stale cache tags on a Redis cluster

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -395,7 +395,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
                 foreach ($tagsChunk as $tag) {
                     yield $tag;
                 }
-            } while (((string) $cursor) !== $defaultCursorValue);
+            } while (((string) $cursor) !== ((string) $defaultCursorValue));
         }))->map(fn (string $tagKey) => Str::match('/^'.preg_quote($prefix, '/').'tag:(.*):entries$/', $tagKey));
     }
 

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -78,7 +78,7 @@ class RedisTagSet extends TagSet
                     foreach ($entries as $entry) {
                         yield $entry;
                     }
-                } while (((string) $cursor) !== $defaultCursorValue);
+                } while (((string) $cursor) !== ((string) $defaultCursorValue));
             }
         });
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -4,7 +4,9 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Mockery;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class CacheRedisStoreTest extends TestCase
@@ -164,6 +166,29 @@ class CacheRedisStoreTest extends TestCase
         $this->assertSame('foo', $redis->getPrefix());
         $redis->setPrefix(null);
         $this->assertEmpty($redis->getPrefix());
+    }
+
+    #[RequiresPhpExtension('redis', '>= 6.1.0')]
+    public function testFlushStaleTagsStopsScanningWhenTheCursorReturnsToItsStartingValue()
+    {
+        $calls = 0;
+
+        $connection = Mockery::mock(PhpRedisConnection::class);
+        $connection->allows('_prefix')->with('')->andReturn('');
+        $connection->allows('zremrangebyscore');
+        $connection->allows('scan')->andReturnUsing(function () use (&$calls) {
+            $calls++;
+
+            // A second call means the loop did not recognise the cursor it started with.
+            return $calls > 1 ? false : [null, ['prefix:tag:foo:entries']];
+        });
+
+        $redis = $this->getRedis();
+        $redis->getRedis()->allows('connection')->with('default')->andReturn($connection);
+
+        $redis->flushStaleTags();
+
+        $this->assertSame(1, $calls);
     }
 
     protected function getRedis()


### PR DESCRIPTION
`RedisStore::currentTags()` ends its scan loop with `((string) $cursor) !== $defaultCursorValue`, but `$defaultCursorValue` is `null` on phpredis >= 6.1, so `"" !== null` is always true and the loop can never terminate on the cursor - it only ever stopped because `scan()` returned `false`. 

#61174 changed the cluster connection to hand that sentinel back on the final page instead of `false`, so the loop now calls `scan(null)` again and restarts the whole iteration: `cache:prune-stale-tags` hangs. 
Casting both sides fixes it, and `RedisTagSet::entries()` gets the same correction since it carries the identical expression against `zscan`.