### PR TITLE
[13.x] Add a dedicated exception for idle process timeouts

### DIFF
--- a/src/Illuminate/Process/Exceptions/ProcessIdleTimedOutException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessIdleTimedOutException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Process\Exceptions;
+
+class ProcessIdleTimedOutException extends ProcessTimedOutException
+{
+    //
+}

--- a/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
@@ -16,6 +16,13 @@ class ProcessTimedOutException extends RuntimeException
     public $result;
 
     /**
+     * The original Symfony exception instance.
+     *
+     * @var \Symfony\Component\Process\Exception\ProcessTimedOutException
+     */
+    protected $original;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Symfony\Component\Process\Exception\ProcessTimedOutException  $original
@@ -24,7 +31,38 @@ class ProcessTimedOutException extends RuntimeException
     public function __construct(SymfonyTimeoutException $original, ProcessResult $result)
     {
         $this->result = $result;
+        $this->original = $original;
 
         parent::__construct($original->getMessage(), $original->getCode(), $original);
+    }
+
+    /**
+     * Determine if the process exceeded its total allotted time.
+     *
+     * @return bool
+     */
+    public function isGeneralTimeout()
+    {
+        return $this->original->isGeneralTimeout();
+    }
+
+    /**
+     * Determine if the process went too long without returning any output.
+     *
+     * @return bool
+     */
+    public function isIdleTimeout()
+    {
+        return $this->original->isIdleTimeout();
+    }
+
+    /**
+     * Get the number of seconds the process was allowed to run before timing out.
+     *
+     * @return float|null
+     */
+    public function exceededTimeout()
+    {
+        return $this->original->getExceededTimeout();
     }
 }

--- a/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
@@ -37,23 +37,17 @@ class ProcessTimedOutException extends RuntimeException
     }
 
     /**
-     * Determine if the process exceeded its total allotted time.
+     * Create a new exception instance for the type of timeout that occurred.
      *
-     * @return bool
+     * @param  \Symfony\Component\Process\Exception\ProcessTimedOutException  $original
+     * @param  \Illuminate\Contracts\Process\ProcessResult  $result
+     * @return \Illuminate\Process\Exceptions\ProcessTimedOutException
      */
-    public function isGeneralTimeout()
+    public static function make(SymfonyTimeoutException $original, ProcessResult $result)
     {
-        return $this->original->isGeneralTimeout();
-    }
-
-    /**
-     * Determine if the process went too long without returning any output.
-     *
-     * @return bool
-     */
-    public function isIdleTimeout()
-    {
-        return $this->original->isIdleTimeout();
+        return $original->isIdleTimeout()
+            ? new ProcessIdleTimedOutException($original, $result)
+            : new ProcessTimedOutException($original, $result);
     }
 
     /**

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -136,7 +136,7 @@ class InvokedProcess implements InvokedProcessContract
         try {
             $this->process->checkTimeout();
         } catch (SymfonyTimeoutException $e) {
-            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+            throw ProcessTimedOutException::make($e, new ProcessResult($this->process));
         }
     }
 
@@ -155,7 +155,7 @@ class InvokedProcess implements InvokedProcessContract
 
             return new ProcessResult($this->process);
         } catch (SymfonyTimeoutException $e) {
-            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+            throw ProcessTimedOutException::make($e, new ProcessResult($this->process));
         }
     }
 
@@ -174,7 +174,7 @@ class InvokedProcess implements InvokedProcessContract
 
             return new ProcessResult($this->process);
         } catch (SymfonyTimeoutException $e) {
-            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+            throw ProcessTimedOutException::make($e, new ProcessResult($this->process));
         }
     }
 }

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -259,7 +259,7 @@ class PendingProcess
 
             return new ProcessResult(tap($process)->run($output));
         } catch (SymfonyTimeoutException $e) {
-            throw new ProcessTimedOutException($e, new ProcessResult($process));
+            throw ProcessTimedOutException::make($e, new ProcessResult($process));
         }
     }
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -652,6 +652,52 @@ class ProcessTest extends TestCase
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testGeneralTimeoutsCanBeDistinguishedFromIdleTimeouts()
+    {
+        $factory = new Factory;
+
+        try {
+            $factory->timeout(1)->path(__DIR__)->run('sleep 2;');
+
+            $this->fail('The process did not time out.');
+        } catch (ProcessTimedOutException $e) {
+            $this->assertTrue($e->isGeneralTimeout());
+            $this->assertFalse($e->isIdleTimeout());
+            $this->assertSame(1.0, $e->exceededTimeout());
+        }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testIdleTimeoutsCanBeDistinguishedFromGeneralTimeouts()
+    {
+        $factory = new Factory;
+
+        try {
+            $factory->timeout(10)->idleTimeout(1)->path(__DIR__)->run('sleep 5;');
+
+            $this->fail('The process did not time out.');
+        } catch (ProcessTimedOutException $e) {
+            $this->assertTrue($e->isIdleTimeout());
+            $this->assertFalse($e->isGeneralTimeout());
+            $this->assertSame(1.0, $e->exceededTimeout());
+        }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testTimedOutProcessesStillExposeTheirResult()
+    {
+        $factory = new Factory;
+
+        try {
+            $factory->timeout(1)->path(__DIR__)->run('echo "Hello World"; sleep 2;');
+
+            $this->fail('The process did not time out.');
+        } catch (ProcessTimedOutException $e) {
+            $this->assertStringContainsString('Hello World', $e->result->output());
+        }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowIfTrue()
     {
         $this->expectException(ProcessFailedException::class);

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Process;
 use Carbon\CarbonInterval;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
+use Illuminate\Process\Exceptions\ProcessIdleTimedOutException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
 use OutOfBoundsException;
@@ -652,7 +653,7 @@ class ProcessTest extends TestCase
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
-    public function testGeneralTimeoutsCanBeDistinguishedFromIdleTimeouts()
+    public function testGeneralTimeoutsThrowTheBaseException()
     {
         $factory = new Factory;
 
@@ -661,14 +662,13 @@ class ProcessTest extends TestCase
 
             $this->fail('The process did not time out.');
         } catch (ProcessTimedOutException $e) {
-            $this->assertTrue($e->isGeneralTimeout());
-            $this->assertFalse($e->isIdleTimeout());
+            $this->assertNotInstanceOf(ProcessIdleTimedOutException::class, $e);
             $this->assertSame(1.0, $e->exceededTimeout());
         }
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
-    public function testIdleTimeoutsCanBeDistinguishedFromGeneralTimeouts()
+    public function testIdleTimeoutsThrowTheIdleException()
     {
         $factory = new Factory;
 
@@ -676,11 +676,18 @@ class ProcessTest extends TestCase
             $factory->timeout(10)->idleTimeout(1)->path(__DIR__)->run('sleep 5;');
 
             $this->fail('The process did not time out.');
-        } catch (ProcessTimedOutException $e) {
-            $this->assertTrue($e->isIdleTimeout());
-            $this->assertFalse($e->isGeneralTimeout());
+        } catch (ProcessIdleTimedOutException $e) {
             $this->assertSame(1.0, $e->exceededTimeout());
         }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testIdleTimeoutsAreStillCaughtByTheBaseException()
+    {
+        $this->expectException(ProcessTimedOutException::class);
+
+        $factory = new Factory;
+        $factory->timeout(10)->idleTimeout(1)->path(__DIR__)->run('sleep 5;');
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]


### PR DESCRIPTION
Laravel lets you set two different timeouts on a process:

```php
Process::timeout(600)      // total time limit
    ->idleTimeout(30)      // max time without any output
    ->run('./deploy.sh');
```

Both throw the same `ProcessTimedOutException`, so there's no way to tell
which one fired — even though they mean opposite things. An idle timeout
means the process is hung and should be killed. A general timeout means
it's working fine and just needed more time.

This adds a dedicated exception for the idle case:

```php
try {
    Process::timeout(600)->idleTimeout(30)->run('./deploy.sh');
} catch (ProcessIdleTimedOutException $e) {
    // hung — no output for {$e->exceededTimeout()} seconds
    $this->killAndAlert();
} catch (ProcessTimedOutException $e) {
    // still working, just needed longer
    $this->extendAndRetry();
}
```