### PR TITLE
[13.x] Keep the Redis connection usable when a pipeline or transaction fails

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use RedisException;
+use Throwable;
 
 /**
  * @mixin \Redis
@@ -464,9 +465,17 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $pipeline = $this->client()->pipeline();
 
-        return is_null($callback)
-            ? $pipeline
-            : tap($pipeline, $callback)->exec();
+        if (is_null($callback)) {
+            return $pipeline;
+        }
+
+        try {
+            return tap($pipeline, $callback)->exec();
+        } catch (Throwable $e) {
+            rescue(fn () => $this->client()->discard(), null, false);
+
+            throw $e;
+        }
     }
 
     /**
@@ -479,9 +488,17 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $transaction = $this->client()->multi();
 
-        return is_null($callback)
-            ? $transaction
-            : tap($transaction, $callback)->exec();
+        if (is_null($callback)) {
+            return $transaction;
+        }
+
+        try {
+            return tap($transaction, $callback)->exec();
+        } catch (Throwable $e) {
+            rescue(fn () => $this->client()->discard(), null, false);
+
+            throw $e;
+        }
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Redis;
 
+use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
@@ -789,6 +790,48 @@ class RedisConnectionTest extends TestCase
                 'foo',
                 $redis->foo()
             );
+        }
+    }
+
+    public function testItKeepsTheConnectionUsableWhenATransactionFails()
+    {
+        foreach ($this->connections() as $redis) {
+            $redis->set('name', 'taylor');
+
+            try {
+                $redis->transaction(function ($transaction) {
+                    $transaction->set('name', 'mohamed');
+
+                    throw new Exception('Something went wrong.');
+                });
+            } catch (Exception) {
+                //
+            }
+
+            $this->assertSame('taylor', $redis->get('name'));
+
+            $redis->flushall();
+        }
+    }
+
+    public function testItKeepsTheConnectionUsableWhenAPipelineFails()
+    {
+        foreach ($this->connections() as $redis) {
+            $redis->set('name', 'taylor');
+
+            try {
+                $redis->pipeline(function ($pipeline) {
+                    $pipeline->set('name', 'mohamed');
+
+                    throw new Exception('Something went wrong.');
+                });
+            } catch (Exception) {
+                //
+            }
+
+            $this->assertSame('taylor', $redis->get('name'));
+
+            $redis->flushall();
         }
     }
 


### PR DESCRIPTION
`pipeline()` and `transaction()` put the phpredis client into a queueing mode and rely on `exec()` to take it back out, so a callback that throws leaves the client in `MULTI`/pipeline mode for the rest of the process, silently answering every later command with the client itself rather than a value - `$redis->get('name')` returns `Redis Object #669` instead of the string that was stored. Nothing throws while it is in that state, so it is invisible to the resilience added in #61175: no `RedisException` to match on, no reconnect, no retry, and pipelines and transactions bypass `command()` entirely since the callback is handed the raw client. The fix discards the queued commands and rethrows the original exception, wrapped in `rescue()` because `discard()` can itself throw once the socket is gone and cleanup must never replace the caller's exception.