### PR TITLE
[13.x] Make process pools iterable

### DIFF
--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -71,16 +71,6 @@ class InvokedProcessPool implements Countable, IteratorAggregate
     }
 
     /**
-     * Get an iterator for the invoked processes.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator(): Traversable
-    {
-        return new ArrayIterator($this->invokedProcesses);
-    }
-
-    /**
      * Get the total number of processes.
      *
      * @return int
@@ -88,5 +78,15 @@ class InvokedProcessPool implements Countable, IteratorAggregate
     public function count(): int
     {
         return count($this->invokedProcesses);
+    }
+
+    /**
+     * Get an iterator for the invoked processes.
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->invokedProcesses);
     }
 }

--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Process;
 
+use ArrayIterator;
 use Countable;
 use Illuminate\Support\Collection;
+use IteratorAggregate;
+use Traversable;
 
-class InvokedProcessPool implements Countable
+class InvokedProcessPool implements Countable, IteratorAggregate
 {
     /**
      * The array of invoked processes.
@@ -65,6 +68,16 @@ class InvokedProcessPool implements Countable
     public function wait()
     {
         return new ProcessPoolResults((new Collection($this->invokedProcesses))->map->wait()->all());
+    }
+
+    /**
+     * Get an iterator for the invoked processes.
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->invokedProcesses);
     }
 
     /**

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Process;
 
 use ArrayAccess;
+use ArrayIterator;
 use Illuminate\Support\Collection;
+use IteratorAggregate;
+use Traversable;
 
-class ProcessPoolResults implements ArrayAccess
+class ProcessPoolResults implements ArrayAccess, IteratorAggregate
 {
     /**
      * The results of the processes.
@@ -52,6 +55,16 @@ class ProcessPoolResults implements ArrayAccess
     public function collect()
     {
         return new Collection($this->results);
+    }
+
+    /**
+     * Get an iterator for the results.
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->results);
     }
 
     /**

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -58,16 +58,6 @@ class ProcessPoolResults implements ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Get an iterator for the results.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator(): Traversable
-    {
-        return new ArrayIterator($this->results);
-    }
-
-    /**
      * Determine if the given array offset exists.
      *
      * @param  int  $offset
@@ -110,5 +100,15 @@ class ProcessPoolResults implements ArrayAccess, IteratorAggregate
     public function offsetUnset($offset): void
     {
         unset($this->results[$offset]);
+    }
+
+    /**
+     * Get an iterator for the results.
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->results);
     }
 }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -114,6 +114,48 @@ class ProcessTest extends TestCase
         $this->assertStringContainsString('ProcessTest.php', $poolResults[1]->output());
     }
 
+    public function testInvokedProcessPoolCanBeIterated()
+    {
+        $factory = new Factory;
+
+        $pool = $factory->pool(function ($pool) {
+            return [
+                $pool->as('first')->path(__DIR__)->command($this->ls()),
+                $pool->as('second')->path(__DIR__)->command($this->ls()),
+            ];
+        })->start();
+
+        $keys = [];
+
+        foreach ($pool as $key => $process) {
+            $keys[] = $key;
+        }
+
+        $pool->wait();
+
+        $this->assertSame(['first', 'second'], $keys);
+    }
+
+    public function testProcessPoolResultsCanBeIterated()
+    {
+        $factory = new Factory;
+
+        $results = $factory->pool(function ($pool) {
+            return [
+                $pool->as('first')->path(__DIR__)->command($this->ls()),
+                $pool->as('second')->path(__DIR__)->command($this->ls()),
+            ];
+        })->wait();
+
+        $iterated = [];
+
+        foreach ($results as $key => $result) {
+            $iterated[$key] = $result->successful();
+        }
+
+        $this->assertSame(['first' => true, 'second' => true], $iterated);
+    }
+
     public function testProcessPoolResultsCanBeEvaluatedByName()
     {
         $factory = new Factory;


### PR DESCRIPTION
While looping over the results of a process pool to check exit codes, I noticed that the loop could silently skip all results without throwing an error.

`foreach` over an object iterates its public properties, while both `InvokedProcessPool` and `ProcessPoolResults` store their state in protected properties. As a result, the loop body is never executed.

Although this can be worked around by calling `->collect()`, the silent behavior is the real issue: a loop intended to check pool results for failures can pass without checking anything at all.

This adds `IteratorAggregate` to both classes so their results can be iterated over directly and reliably