### PR TITLE
[13.x] Report seeder progress in db:seed command - when a specific class is specified

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -68,9 +68,35 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
+        $seeder = $this->getSeeder();
+
+        $requestedClass = $this->input->getArgument('class') ?? $this->input->getOption('class');
+
+        $shouldReportProgress = ! in_array($requestedClass, [
+            'Database\\Seeders\\DatabaseSeeder', 'DatabaseSeeder',
+        ]);
+
+        if ($shouldReportProgress) {
+            $this->components->twoColumnDetail(
+                get_class($seeder), '<fg=yellow;options=bold>RUNNING</>'
+            );
+        }
+
+        $startTime = microtime(true);
+
+        Model::unguarded(function () use ($seeder) {
+            $seeder->__invoke();
         });
+
+        if ($shouldReportProgress) {
+            $runTime = number_format((microtime(true) - $startTime) * 1000);
+
+            $this->components->twoColumnDetail(
+                get_class($seeder), "<fg=gray>$runTime ms</> <fg=green;options=bold>DONE</>"
+            );
+
+            $this->newLine();
+        }
 
         if ($previousConnection) {
             $this->resolver->setDefaultConnection($previousConnection);

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -15,8 +15,10 @@ use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Testing\Assert;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
 class SeedCommandTest extends TestCase
@@ -105,6 +107,93 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
+    public function testHandleReportsProgressWhenSeederClassIsRequestedExplicitely()
+    {
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => UserSeeder::class,
+        ]);
+        $output = new BufferedOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = Mockery::mock(ConnectionResolverInterface::class);
+        $resolver->expects('getDefaultConnection');
+        $resolver->expects('setDefaultConnection')->with('sqlite');
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->expects('environment')->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->expects('make')->with(UserSeeder::class)->andReturn(new UserSeeder);
+        $container->expects('make')->with(OutputStyle::class, Mockery::any())->andReturn(
+            $outputStyle
+        );
+        $container->expects('make')->with(Factory::class, Mockery::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+
+        $result = $output->fetch();
+
+        Assert::assertStringContainsString(UserSeeder::class, $result);
+        Assert::assertStringContainsString('RUNNING', $result);
+        Assert::assertStringContainsString('DONE', $result);
+    }
+
+    public static function defaultSeederDataProvider()
+    {
+        return [
+            'no default class given' => [[]],
+            'default class given' => [['--class' => 'Database\\Seeders\\DatabaseSeeder']],
+        ];
+    }
+
+    #[DataProvider('defaultSeederDataProvider')]
+    public function testHandleDoesNotReportProgressForTheDefaultSeederClass($parameters)
+    {
+        $input = new ArrayInput($parameters + ['--force' => true, '--database' => 'sqlite']);
+        $output = new BufferedOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = Mockery::mock(Seeder::class);
+        $seeder->expects('setContainer')->andReturnSelf();
+        $seeder->expects('setCommand')->andReturnSelf();
+        $seeder->expects('__invoke');
+
+        $resolver = Mockery::mock(ConnectionResolverInterface::class);
+        $resolver->expects('getDefaultConnection');
+        $resolver->expects('setDefaultConnection')->with('sqlite');
+
+        $container = Mockery::mock(Container::class);
+        $container->expects('call');
+        $container->expects('environment')->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->expects('make')->with('DatabaseSeeder')->andReturn($seeder);
+        $container->expects('make')->with(OutputStyle::class, Mockery::any())->andReturn(
+            $outputStyle
+        );
+        $container->expects('make')->with(Factory::class, Mockery::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+
+        $result = $output->fetch();
+
+        Assert::assertStringNotContainsString('RUNNING', $result);
+        Assert::assertStringNotContainsString('DONE', $result);
+    }
+
     public function testProhibitable()
     {
         $input = new ArrayInput([]);
@@ -139,6 +228,14 @@ class SeedCommandTest extends TestCase
         SeedCommand::prohibit(false);
 
         Model::unsetEventDispatcher();
+    }
+}
+
+class UserSeeder extends Seeder
+{
+    public function run()
+    {
+        //
     }
 }
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -15,10 +15,8 @@ use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Testing\Assert;
 use Mockery;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
 class SeedCommandTest extends TestCase
@@ -107,93 +105,6 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
-    public function testHandleReportsProgressWhenSeederClassIsRequestedExplicitely()
-    {
-        $input = new ArrayInput([
-            '--force' => true,
-            '--database' => 'sqlite',
-            '--class' => UserSeeder::class,
-        ]);
-        $output = new BufferedOutput;
-        $outputStyle = new OutputStyle($input, $output);
-
-        $resolver = Mockery::mock(ConnectionResolverInterface::class);
-        $resolver->expects('getDefaultConnection');
-        $resolver->expects('setDefaultConnection')->with('sqlite');
-
-        $container = Mockery::mock(Container::class);
-        $container->shouldReceive('call');
-        $container->expects('environment')->andReturn('testing');
-        $container->shouldReceive('runningUnitTests')->andReturn('true');
-        $container->expects('make')->with(UserSeeder::class)->andReturn(new UserSeeder);
-        $container->expects('make')->with(OutputStyle::class, Mockery::any())->andReturn(
-            $outputStyle
-        );
-        $container->expects('make')->with(Factory::class, Mockery::any())->andReturn(
-            new Factory($outputStyle)
-        );
-
-        $command = new SeedCommand($resolver);
-        $command->setLaravel($container);
-
-        $command->run($input, $output);
-        $command->handle();
-
-        $result = $output->fetch();
-
-        Assert::assertStringContainsString(UserSeeder::class, $result);
-        Assert::assertStringContainsString('RUNNING', $result);
-        Assert::assertStringContainsString('DONE', $result);
-    }
-
-    public static function defaultSeederDataProvider()
-    {
-        return [
-            'no default class given' => [[]],
-            'default class given' => [['--class' => 'Database\\Seeders\\DatabaseSeeder']],
-        ];
-    }
-
-    #[DataProvider('defaultSeederDataProvider')]
-    public function testHandleDoesNotReportProgressForTheDefaultSeederClass($parameters)
-    {
-        $input = new ArrayInput($parameters + ['--force' => true, '--database' => 'sqlite']);
-        $output = new BufferedOutput;
-        $outputStyle = new OutputStyle($input, $output);
-
-        $seeder = Mockery::mock(Seeder::class);
-        $seeder->expects('setContainer')->andReturnSelf();
-        $seeder->expects('setCommand')->andReturnSelf();
-        $seeder->expects('__invoke');
-
-        $resolver = Mockery::mock(ConnectionResolverInterface::class);
-        $resolver->expects('getDefaultConnection');
-        $resolver->expects('setDefaultConnection')->with('sqlite');
-
-        $container = Mockery::mock(Container::class);
-        $container->expects('call');
-        $container->expects('environment')->andReturn('testing');
-        $container->shouldReceive('runningUnitTests')->andReturn('true');
-        $container->expects('make')->with('DatabaseSeeder')->andReturn($seeder);
-        $container->expects('make')->with(OutputStyle::class, Mockery::any())->andReturn(
-            $outputStyle
-        );
-        $container->expects('make')->with(Factory::class, Mockery::any())->andReturn(
-            new Factory($outputStyle)
-        );
-
-        $command = new SeedCommand($resolver);
-        $command->setLaravel($container);
-
-        $command->run($input, $output);
-        $command->handle();
-
-        $result = $output->fetch();
-
-        Assert::assertStringNotContainsString('RUNNING', $result);
-        Assert::assertStringNotContainsString('DONE', $result);
-    }
-
     public function testProhibitable()
     {
         $input = new ArrayInput([]);
@@ -228,14 +139,6 @@ class SeedCommandTest extends TestCase
         SeedCommand::prohibit(false);
 
         Model::unsetEventDispatcher();
-    }
-}
-
-class UserSeeder extends Seeder
-{
-    public function run()
-    {
-        //
     }
 }
 


### PR DESCRIPTION
### Problem
Kindly check discussion #61185 for details. In short, `php artisan db:seed --class=SpecificSeeder` prints only "INFO Seeding database". with no indication/tracking for whether the seeder is running or has finished - unlike a bare `db:seed` command, which shows progress status (RUNNING/DONE, with time taken) for every seeder the `DatabaseSeeder` delegates to via `Seeder::call()`. The inconsistency comes from `SeedCommand::handle()` invoking an explicitly-named seeder *directly*, bypassing the `Seeder::call()` and the progress output it renders.

### Changes I made
`SeedCommand::handle()` now **wraps the root seeder's invocation** with the same `TwoColumnDetail` RUNNING/DONE output that `Seeder::call()` already produces for each nested seeder. 
I've eensured that it produces this progress output only *when the resolved root class is something other than the default* `Database\Seeders\DatabaseSeeder`. That condition is what keeps **existing output for default DatabaseSeeder untouched** (`migrate --seed` and `migrate:fresh --seed` always pass `--class=Database\Seeders\DatabaseSeeder` internally, and a bare `db:seed` resolves to the same default, so neither path changes at all). 

So, the change will only reflect for the explicit "run a specific seeder" case (which was previously silent)..making it gain the same feedback which the framework already provides for every other seeder invocation.

### Testing
Added a test asserting progress status is printed when a seeder class is explicitly requested, and a data-provider-backed test **asserting it is not printed for the default seeder**, covering both the bare `db:seed` case and the `--class=DatabaseSeeder` case.

### Why PR-ing this to 13.x
This PR **just adds a console output**, safely with **no risk of breaking changes**. it **changes no method signature, return value, or seeder execution order/timing**. The only visible **difference is new RUNNING/DONE lines for the SpecificSeeder invocation path**, which previously produced no per-seeder feedback at all. So bare `db:seed`, `migrate --seed`, `migrate:fresh --seed` - all prints exactly what these used to do before. 
So that's why I think it'd be safe to be merged with `13.x`, just as a small addition in order to fill an output consistency gap.

Pls lemme know if any modification or clarification needed from my end.