### PR TITLE
[13.x] Introduce `Queue::forward()`

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -327,7 +327,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        return enum_value($queue) ?: $this->default;
+        return $this->resolveQueue(enum_value($queue) ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -625,7 +625,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function getQueue($queue)
     {
-        return enum_value($queue) ?: $this->default;
+        return $this->resolveQueue(enum_value($queue) ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -495,7 +495,7 @@ abstract class Queue
      */
     protected function resolveQueue($queue)
     {
-        return $this->queueRoutes()->resolveQueue($queue, $this->connectionName);
+        return $this->queueRoutes()->forwardedQueue($queue, $this->connectionName);
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -488,7 +488,7 @@ abstract class Queue
     }
 
     /**
-     * Get the aliased name for the given queue.
+     * Get the routed queue name for the given queue.
      *
      * @param  string  $queue
      * @return string

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -24,13 +24,14 @@ use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Throwable;
 
 abstract class Queue
 {
-    use InteractsWithTime, ReadsQueueAttributes;
+    use InteractsWithTime, ReadsQueueAttributes, ResolvesQueueRoutes;
 
     /**
      * The IoC container instance.
@@ -484,6 +485,17 @@ abstract class Queue
 
             $this->container['events']->dispatch(new JobQueued($this->connectionName, $queue, $jobId, $job, $payload, $delay));
         }
+    }
+
+    /**
+     * Get the aliased name for the given queue.
+     *
+     * @param  string  $queue
+     * @return string
+     */
+    protected function resolveQueue($queue)
+    {
+        return $this->queueRoutes()->resolveQueue($queue, $this->connectionName);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -149,7 +149,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function forward(array|string|UnitEnum $queue, $to = null, $connection = null)
     {
-        $this->queueRoutes()->setQueue($queue, $to, $connection);
+        $this->queueRoutes()->forward($queue, $to, $connection);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\Factory as FactoryContract;
 use Illuminate\Contracts\Queue\Monitor as MonitorContract;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use InvalidArgumentException;
+use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
@@ -136,6 +137,19 @@ class QueueManager implements FactoryContract, MonitorContract
     public function route(array|string $class, $queue = null, $connection = null)
     {
         $this->queueRoutes()->set($class, $queue, $connection);
+    }
+
+    /**
+     * Register the route for the given queue name.
+     *
+     * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
+     * @param  \UnitEnum|string|null  $to
+     * @param  \UnitEnum|string|null  $connection
+     * @return void
+     */
+    public function routeQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
+    {
+        $this->queueRoutes()->setQueue($queue, $to, $connection);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -140,14 +140,14 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Register the route for the given queue name.
+     * Forward the given queue to another queue and/or connection.
      *
      * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
      * @param  \UnitEnum|string|null  $to
      * @param  \UnitEnum|string|null  $connection
      * @return void
      */
-    public function routeQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
+    public function forward(array|string|UnitEnum $queue, $to = null, $connection = null)
     {
         $this->queueRoutes()->setQueue($queue, $to, $connection);
     }

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -84,6 +84,26 @@ class QueueRoutes
     }
 
     /**
+     * Get the queue the given queue has been forwarded to.
+     *
+     * @param  string  $queue
+     * @param  string|null  $connection
+     * @return string
+     */
+    public function forwardedQueue($queue, $connection = null)
+    {
+        if (! isset($this->forwards[$queue])) {
+            return $queue;
+        }
+
+        [$forwardConnection, $forwardQueue] = $this->forwards[$queue];
+
+        return is_null($forwardConnection) || $forwardConnection === $connection
+            ? $forwardQueue ?? $queue
+            : $queue;
+    }
+
+    /**
      * Get the route for a given queueable instance.
      *
      * @param  object  $queueable
@@ -131,24 +151,14 @@ class QueueRoutes
     }
 
     /**
-     * Get all registered queue routes.
-     *
-     * @return array<class-string, array|string>
-     */
-    public function all()
-    {
-        return $this->routes;
-    }
-
-    /**
      * Register a forward for the given queue.
      *
-     * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
+     * @param  \UnitEnum|array<string, \UnitEnum|string>|string  $queue
      * @param  \UnitEnum|string|null  $to
      * @param  \UnitEnum|string|null  $connection
      * @return void
      */
-    public function forward(array|string|UnitEnum $queue, $to = null, $connection = null)
+    public function forward(UnitEnum|array|string $queue, $to = null, $connection = null)
     {
         $forwards = is_array($queue) ? $queue : [enum_value($queue) => $to];
 
@@ -158,22 +168,12 @@ class QueueRoutes
     }
 
     /**
-     * Get the queue the given queue has been forwarded to.
+     * Get all registered queue routes.
      *
-     * @param  string  $queue
-     * @param  string|null  $connection
-     * @return string
+     * @return array<class-string, array|string>
      */
-    public function forwardedQueue($queue, $connection = null)
+    public function all()
     {
-        if (! isset($this->forwards[$queue])) {
-            return $queue;
-        }
-
-        [$forwardConnection, $forwardQueue] = $this->forwards[$queue];
-
-        return is_null($forwardConnection) || $forwardConnection === $connection
-            ? $forwardQueue ?? $queue
-            : $queue;
+        return $this->routes;
     }
 }

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -22,7 +22,7 @@ class QueueRoutes
     /**
      * The mapping of queue names to their routes.
      *
-     * @var array<string, array{0: string|null, 1: string|null}>
+     * @var array<string, array>
      */
     protected $queueRoutes = [];
 

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -20,11 +20,11 @@ class QueueRoutes
     protected $routes = [];
 
     /**
-     * The mapping of queue names to their routes.
+     * The queues that have been forwarded to another queue and/or connection.
      *
      * @var array<string, array>
      */
-    protected $queueRoutes = [];
+    protected $forwards = [];
 
     /**
      * Get the queue connection that a given queueable instance should be routed to.
@@ -40,28 +40,28 @@ class QueueRoutes
             return is_string($route) ? null : $route[0];
         }
 
-        if (empty($this->queueRoutes)) {
+        if (empty($this->forwards)) {
             return null;
         }
 
-        return $this->connectionForQueue(
+        return $this->forwardedConnection(
             $this->getAttributeValue($queueable, QueueAttribute::class, 'queue')
         );
     }
 
     /**
-     * Get the connection that the given queue name has been forwarded to.
+     * Get the connection the given queue has been forwarded to.
      *
      * @param  \UnitEnum|string|null  $queue
      * @return string|null
      */
-    protected function connectionForQueue($queue)
+    protected function forwardedConnection($queue)
     {
         if (is_null($queue)) {
             return null;
         }
 
-        return $this->queueRoutes[enum_value($queue)][0] ?? null;
+        return $this->forwards[enum_value($queue)][0] ?? null;
     }
 
     /**
@@ -141,39 +141,39 @@ class QueueRoutes
     }
 
     /**
-     * Register the queue route for the given queue name.
+     * Register a forward for the given queue.
      *
      * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
      * @param  \UnitEnum|string|null  $to
      * @param  \UnitEnum|string|null  $connection
      * @return void
      */
-    public function setQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
+    public function forward(array|string|UnitEnum $queue, $to = null, $connection = null)
     {
-        $routes = is_array($queue) ? $queue : [enum_value($queue) => $to];
+        $forwards = is_array($queue) ? $queue : [enum_value($queue) => $to];
 
-        foreach ($routes as $from => $destination) {
-            $this->queueRoutes[enum_value($from)] = [enum_value($connection), enum_value($destination)];
+        foreach ($forwards as $from => $destination) {
+            $this->forwards[enum_value($from)] = [enum_value($connection), enum_value($destination)];
         }
     }
 
     /**
-     * Get the routed name for the given queue and connection.
+     * Get the queue the given queue has been forwarded to.
      *
      * @param  string  $queue
      * @param  string|null  $connection
      * @return string
      */
-    public function resolveQueue($queue, $connection = null)
+    public function forwardedQueue($queue, $connection = null)
     {
-        if (! isset($this->queueRoutes[$queue])) {
+        if (! isset($this->forwards[$queue])) {
             return $queue;
         }
 
-        [$routeConnection, $routeQueue] = $this->queueRoutes[$queue];
+        [$forwardConnection, $forwardQueue] = $this->forwards[$queue];
 
-        return is_null($routeConnection) || $routeConnection === $connection
-            ? $routeQueue ?? $queue
+        return is_null($forwardConnection) || $forwardConnection === $connection
+            ? $forwardQueue ?? $queue
             : $queue;
     }
 }

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -44,9 +44,24 @@ class QueueRoutes
             return null;
         }
 
-        $queue = $this->getAttributeValue($queueable, QueueAttribute::class, 'queue');
+        return $this->connectionForQueue(
+            $this->getAttributeValue($queueable, QueueAttribute::class, 'queue')
+        );
+    }
 
-        return is_null($queue) ? null : ($this->queueRoutes[enum_value($queue)][0] ?? null);
+    /**
+     * Get the connection that the given queue name has been forwarded to.
+     *
+     * @param  \UnitEnum|string|null  $queue
+     * @return string|null
+     */
+    protected function connectionForQueue($queue)
+    {
+        if (is_null($queue)) {
+            return null;
+        }
+
+        return $this->queueRoutes[enum_value($queue)][0] ?? null;
     }
 
     /**

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue;
 
+use UnitEnum;
+
 use function Illuminate\Support\enum_value;
 
 class QueueRoutes
@@ -14,6 +16,13 @@ class QueueRoutes
     protected $routes = [];
 
     /**
+     * The mapping of queue names to their routes.
+     *
+     * @var array<string, array{0: string|null, 1: string|null}>
+     */
+    protected $queueRoutes = [];
+
+    /**
      * Get the queue connection that a given queueable instance should be routed to.
      *
      * @param  object  $queueable
@@ -23,13 +32,13 @@ class QueueRoutes
     {
         $route = $this->getRoute($queueable);
 
-        if (is_null($route)) {
-            return;
+        if (! is_null($route)) {
+            return is_string($route) ? null : $route[0];
         }
 
-        return is_string($route)
-            ? null
-            : $route[0];
+        $queue = isset($queueable->queue) ? enum_value($queueable->queue) : null;
+
+        return $this->queueRoutes[$queue][0] ?? null;
     }
 
     /**
@@ -106,5 +115,42 @@ class QueueRoutes
     public function all()
     {
         return $this->routes;
+    }
+
+    /**
+     * Register the route for the given queue name.
+     *
+     * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
+     * @param  \UnitEnum|string|null  $to
+     * @param  \UnitEnum|string|null  $connection
+     * @return void
+     */
+    public function routeQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
+    {
+        $routes = is_array($queue) ? $queue : [enum_value($queue) => $to];
+
+        foreach ($routes as $from => $destination) {
+            $this->queueRoutes[enum_value($from)] = [enum_value($connection), enum_value($destination)];
+        }
+    }
+
+    /**
+     * Get the routed name for the given queue and connection.
+     *
+     * @param  string  $queue
+     * @param  string|null  $connection
+     * @return string
+     */
+    public function resolveQueue($queue, $connection = null)
+    {
+        if (! isset($this->queueRoutes[$queue])) {
+            return $queue;
+        }
+
+        [$routeConnection, $routeQueue] = $this->queueRoutes[$queue];
+
+        return is_null($routeConnection) || $routeConnection === $connection
+            ? $routeQueue ?? $queue
+            : $queue;
     }
 }

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -2,12 +2,16 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Queue\Attributes\Queue as QueueAttribute;
+use Illuminate\Support\Traits\ReadsClassAttributes;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
 class QueueRoutes
 {
+    use ReadsClassAttributes;
+
     /**
      * The mapping of class names to their default routes.
      *
@@ -36,9 +40,13 @@ class QueueRoutes
             return is_string($route) ? null : $route[0];
         }
 
-        $queue = isset($queueable->queue) ? enum_value($queueable->queue) : null;
+        if (empty($this->queueRoutes)) {
+            return null;
+        }
 
-        return $this->queueRoutes[$queue][0] ?? null;
+        $queue = $this->getAttributeValue($queueable, QueueAttribute::class, 'queue');
+
+        return is_null($queue) ? null : ($this->queueRoutes[enum_value($queue)][0] ?? null);
     }
 
     /**
@@ -118,14 +126,14 @@ class QueueRoutes
     }
 
     /**
-     * Register the route for the given queue name.
+     * Register the queue route for the given queue name.
      *
      * @param  array<string, \UnitEnum|string>|\UnitEnum|string  $queue
      * @param  \UnitEnum|string|null  $to
      * @param  \UnitEnum|string|null  $connection
      * @return void
      */
-    public function routeQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
+    public function setQueue(array|string|UnitEnum $queue, $to = null, $connection = null)
     {
         $routes = is_array($queue) ? $queue : [enum_value($queue) => $to];
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -542,7 +542,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function getQueue($queue)
     {
-        return 'queues:'.(enum_value($queue) ?: $this->default);
+        return 'queues:'.$this->resolveQueue(enum_value($queue) ?: $this->default);
     }
 
     /**
@@ -553,11 +553,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function getQueueRedisKey($queue = null)
     {
-        $queue = enum_value($queue) ?: $this->default;
+        $queue = $this->resolveQueue(enum_value($queue) ?: $this->default);
 
         return $this->isClusterConnection() && ! Connection::hasHashTag($queue)
-            ? $this->getQueue('{'.$queue.'}')
-            : $this->getQueue($queue);
+            ? 'queues:{'.$queue.'}'
+            : 'queues:'.$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -539,7 +539,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function getQueueableOptions($job, $queue, $payload, $delay = null): array
     {
         // Make sure we have a queue name to properly determine if it's a FIFO queue...
-        $queue = enum_value($queue) ?? $this->default;
+        $queue = $this->resolveQueue(enum_value($queue) ?? $this->default);
 
         $isObject = is_object($job);
         $isFifo = str_ends_with((string) $queue, '.fifo');
@@ -644,7 +644,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function getQueue($queue)
     {
-        $queue = enum_value($queue) ?: $this->default;
+        $queue = $this->resolveQueue(enum_value($queue) ?: $this->default);
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
             ? $this->suffixQueue($queue, $this->suffix)

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -94,7 +94,7 @@ class BusDispatcherTest extends TestCase
         Container::setInstance(null);
     }
 
-    public function testCommandsAreRoutedToConnectionByQueueName()
+    public function testCommandsAreForwardedToConnectionByQueueName()
     {
         Container::setInstance($container = new Container);
         $queueRoutes = new QueueRoutes;
@@ -119,7 +119,7 @@ class BusDispatcherTest extends TestCase
         Container::setInstance(null);
     }
 
-    public function testExplicitConnectionWinsOverQueueRoute()
+    public function testExplicitConnectionWinsOverForwardedQueue()
     {
         Container::setInstance($container = new Container);
         $queueRoutes = new QueueRoutes;

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -9,6 +9,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\QueueRoutes;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -89,6 +90,56 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherQueueable);
+
+        Container::setInstance(null);
+    }
+
+    public function testCommandsAreRoutedToConnectionByQueueName()
+    {
+        Container::setInstance($container = new Container);
+        $queueRoutes = new QueueRoutes;
+        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $container->instance('queue.routes', $queueRoutes);
+
+        $mock = Mockery::mock(Queue::class);
+        $mock->expects('push')->with(Mockery::type(BusDispatcherQueueable::class), '', 'reports');
+
+        $usedConnection = false;
+
+        $dispatcher = new Dispatcher($container, function ($connection) use ($mock, &$usedConnection) {
+            $usedConnection = $connection;
+
+            return $mock;
+        });
+
+        $dispatcher->dispatch((new BusDispatcherQueueable)->onQueue('reports'));
+
+        $this->assertSame('cloud', $usedConnection);
+
+        Container::setInstance(null);
+    }
+
+    public function testExplicitConnectionWinsOverQueueRoute()
+    {
+        Container::setInstance($container = new Container);
+        $queueRoutes = new QueueRoutes;
+        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $container->instance('queue.routes', $queueRoutes);
+
+        $mock = Mockery::mock(Queue::class);
+        $mock->expects('push')->with(Mockery::type(BusDispatcherQueueable::class), '', 'reports');
+
+        $usedConnection = false;
+
+        $dispatcher = new Dispatcher($container, function ($connection) use ($mock, &$usedConnection) {
+            $usedConnection = $connection;
+
+            return $mock;
+        });
+
+        $dispatcher->dispatch((new BusDispatcherQueueable)->onConnection('redis')->onQueue('reports'));
+
+        $this->assertSame('redis', $usedConnection);
 
         Container::setInstance(null);
     }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -98,7 +98,7 @@ class BusDispatcherTest extends TestCase
     {
         Container::setInstance($container = new Container);
         $queueRoutes = new QueueRoutes;
-        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $queueRoutes->forward('reports', 'processing', 'cloud');
         $container->instance('queue.routes', $queueRoutes);
 
         $mock = Mockery::mock(Queue::class);
@@ -123,7 +123,7 @@ class BusDispatcherTest extends TestCase
     {
         Container::setInstance($container = new Container);
         $queueRoutes = new QueueRoutes;
-        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $queueRoutes->forward('reports', 'processing', 'cloud');
         $container->instance('queue.routes', $queueRoutes);
 
         $mock = Mockery::mock(Queue::class);

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -181,7 +181,7 @@ class QueuedEventsTest extends TestCase
         Container::setInstance(null);
     }
 
-    public function testConnectionIsSetUsingRoutedQueueName()
+    public function testConnectionIsSetUsingForwardedQueue()
     {
         $container = new Container;
         $d = new Dispatcher($container);
@@ -198,7 +198,7 @@ class QueuedEventsTest extends TestCase
             return $fakeQueue;
         });
 
-        $d->listen('some.event', TestDispatcherRoutedQueue::class.'@handle');
+        $d->listen('some.event', TestDispatcherForwardedQueue::class.'@handle');
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->connection('cloud')->assertPushedOn('reports', CallQueuedListener::class);
@@ -1024,7 +1024,7 @@ class TestDispatcherQueueRoutes implements ShouldQueue
     }
 }
 
-class TestDispatcherRoutedQueue implements ShouldQueue
+class TestDispatcherForwardedQueue implements ShouldQueue
 {
     public $queue = 'reports';
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -187,7 +187,7 @@ class QueuedEventsTest extends TestCase
         $d = new Dispatcher($container);
 
         $queueRoutes = new QueueRoutes;
-        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $queueRoutes->forward('reports', 'processing', 'cloud');
         $container->instance('queue.routes', $queueRoutes);
 
         $fakeQueue = new QueueFake($container);

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -181,6 +181,31 @@ class QueuedEventsTest extends TestCase
         Container::setInstance(null);
     }
 
+    public function testConnectionIsSetUsingRoutedQueueName()
+    {
+        $container = new Container;
+        $d = new Dispatcher($container);
+
+        $queueRoutes = new QueueRoutes;
+        $queueRoutes->setQueue('reports', 'processing', 'cloud');
+        $container->instance('queue.routes', $queueRoutes);
+
+        $fakeQueue = new QueueFake($container);
+
+        Container::setInstance($container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherRoutedQueue::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->connection('cloud')->assertPushedOn('reports', CallQueuedListener::class);
+
+        Container::setInstance(null);
+    }
+
     public function testDelayIsSetByWithDelayDynamically()
     {
         $d = new Dispatcher;
@@ -993,6 +1018,16 @@ class TestDispatcherViaQueueSupportsEnum implements ShouldQueue
 
 class TestDispatcherQueueRoutes implements ShouldQueue
 {
+    public function handle()
+    {
+        //
+    }
+}
+
+class TestDispatcherRoutedQueue implements ShouldQueue
+{
+    public $queue = 'reports';
+
     public function handle()
     {
         //

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -57,14 +57,14 @@ class BroadcastManagerTest extends TestCase
         Queue::connection('broadcast-connection')->assertPushedOn('broadcast-queue', BroadcastEvent::class);
     }
 
-    public function testEventsCanBeBroadcastRoutingByQueueName()
+    public function testEventsCanBeBroadcastWhenForwardingQueue()
     {
         Bus::fake();
         Queue::fake();
 
-        Queue::routeQueue('broadcast-queue', 'events', 'broadcast-connection');
+        Queue::forward('broadcast-queue', 'events', 'broadcast-connection');
 
-        Broadcast::queue(new TestRoutedEvent);
+        Broadcast::queue(new TestForwardedEvent);
         Bus::assertNotDispatched(BroadcastEvent::class);
         Queue::connection('broadcast-connection')->assertPushedOn('broadcast-queue', BroadcastEvent::class);
     }
@@ -333,7 +333,7 @@ class TestEvent implements ShouldBroadcast
     }
 }
 
-class TestRoutedEvent implements ShouldBroadcast
+class TestForwardedEvent implements ShouldBroadcast
 {
     public $queue = 'broadcast-queue';
 

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -57,6 +57,18 @@ class BroadcastManagerTest extends TestCase
         Queue::connection('broadcast-connection')->assertPushedOn('broadcast-queue', BroadcastEvent::class);
     }
 
+    public function testEventsCanBeBroadcastRoutingByQueueName()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Queue::routeQueue('broadcast-queue', 'events', 'broadcast-connection');
+
+        Broadcast::queue(new TestRoutedEvent);
+        Bus::assertNotDispatched(BroadcastEvent::class);
+        Queue::connection('broadcast-connection')->assertPushedOn('broadcast-queue', BroadcastEvent::class);
+    }
+
     public function testEventsCanBeRescued()
     {
         Bus::fake();
@@ -310,6 +322,21 @@ enum BroadcastConnectionName: string
 
 class TestEvent implements ShouldBroadcast
 {
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     */
+    public function broadcastOn()
+    {
+        //
+    }
+}
+
+class TestRoutedEvent implements ShouldBroadcast
+{
+    public $queue = 'broadcast-queue';
+
     /**
      * Get the channels the event should broadcast on.
      *

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -41,6 +41,17 @@ class SendingQueuedMailTest extends TestCase
         Queue::connection('mail-connection')->assertPushedOn('mail-queue', SendQueuedMailable::class);
     }
 
+    public function testMailIsSentWhenRoutingByQueueName()
+    {
+        Queue::fake();
+
+        Queue::routeQueue('mail-queue', 'main', 'mail-connection');
+
+        Mail::to('test@mail.com')->queue(new SendingQueuedRoutedMailTestMail);
+
+        Queue::connection('mail-connection')->assertPushedOn('mail-queue', SendQueuedMailable::class);
+    }
+
     public function testMailIsSentWithDelay()
     {
         Queue::fake();
@@ -70,5 +81,20 @@ class SendingQueuedMailTestMail extends Mailable
     public function middleware()
     {
         return [new RateLimited('limiter')];
+    }
+}
+
+class SendingQueuedRoutedMailTestMail extends Mailable
+{
+    public $queue = 'mail-queue';
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('view');
     }
 }

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -41,13 +41,13 @@ class SendingQueuedMailTest extends TestCase
         Queue::connection('mail-connection')->assertPushedOn('mail-queue', SendQueuedMailable::class);
     }
 
-    public function testMailIsSentWhenRoutingByQueueName()
+    public function testMailIsSentWhenForwardingQueue()
     {
         Queue::fake();
 
-        Queue::routeQueue('mail-queue', 'main', 'mail-connection');
+        Queue::forward('mail-queue', 'main', 'mail-connection');
 
-        Mail::to('test@mail.com')->queue(new SendingQueuedRoutedMailTestMail);
+        Mail::to('test@mail.com')->queue(new SendingQueuedForwardedMailTestMail);
 
         Queue::connection('mail-connection')->assertPushedOn('mail-queue', SendQueuedMailable::class);
     }
@@ -84,7 +84,7 @@ class SendingQueuedMailTestMail extends Mailable
     }
 }
 
-class SendingQueuedRoutedMailTestMail extends Mailable
+class SendingQueuedForwardedMailTestMail extends Mailable
 {
     public $queue = 'mail-queue';
 

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Queue\QueueRoutes;
 use PHPUnit\Framework\TestCase;
 
@@ -79,6 +80,67 @@ class QueueRoutesTest extends TestCase
         $this->assertNull($defaults->getConnection(new FinanceNotification));
     }
 
+    public function testRouteQueueRewritesName()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue('reports', 'audit');
+
+        $this->assertSame('audit', $defaults->resolveQueue('reports'));
+        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
+        $this->assertSame('other', $defaults->resolveQueue('other'));
+    }
+
+    public function testRouteQueueIsScopedToConnection()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue('reports', 'audit', 'cloud');
+
+        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
+        $this->assertSame('reports', $defaults->resolveQueue('reports', 'redis'));
+        $this->assertSame('reports', $defaults->resolveQueue('reports'));
+    }
+
+    public function testRouteQueueWithoutDestinationKeepsName()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue('reports', connection: 'cloud');
+
+        $this->assertSame('reports', $defaults->resolveQueue('reports', 'cloud'));
+    }
+
+    public function testRouteQueueRoutesConnectionByQueueName()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue('reports', 'audit', 'cloud');
+
+        $this->assertSame('cloud', $defaults->getConnection((new SomeJob)->onQueue('reports')));
+        $this->assertNull($defaults->getConnection((new SomeJob)->onQueue('other')));
+        $this->assertNull($defaults->getConnection(new SomeJob));
+    }
+
+    public function testRouteQueueMatchesQueueAttribute()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue('reports', 'audit', 'cloud');
+
+        $this->assertSame('cloud', $defaults->getConnection(new AttributeRoutedJob));
+    }
+
+    public function testRouteQueueResolvesEnums()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue(QueueName::payments, 'settlements', ConnectionName::redis);
+
+        $this->assertSame('settlements', $defaults->resolveQueue('payments', 'redis'));
+        $this->assertSame('payments', $defaults->resolveQueue('payments', 'sqs'));
+    }
+
     public function testEnumsAreResolved()
     {
         $defaults = new QueueRoutes();
@@ -112,6 +174,12 @@ trait CustomTrait
 class SomeJob
 {
     use Queueable, CustomTrait;
+}
+
+#[QueueAttribute('reports')]
+class AttributeRoutedJob
+{
+    use Queueable;
 }
 
 class BaseNotification

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -84,38 +84,38 @@ class QueueRoutesTest extends TestCase
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue('reports', 'audit');
+        $defaults->forward('reports', 'audit');
 
-        $this->assertSame('audit', $defaults->resolveQueue('reports'));
-        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
-        $this->assertSame('other', $defaults->resolveQueue('other'));
+        $this->assertSame('audit', $defaults->forwardedQueue('reports'));
+        $this->assertSame('audit', $defaults->forwardedQueue('reports', 'cloud'));
+        $this->assertSame('other', $defaults->forwardedQueue('other'));
     }
 
     public function testForwardIsScopedToConnection()
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue('reports', 'audit', 'cloud');
+        $defaults->forward('reports', 'audit', 'cloud');
 
-        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
-        $this->assertSame('reports', $defaults->resolveQueue('reports', 'redis'));
-        $this->assertSame('reports', $defaults->resolveQueue('reports'));
+        $this->assertSame('audit', $defaults->forwardedQueue('reports', 'cloud'));
+        $this->assertSame('reports', $defaults->forwardedQueue('reports', 'redis'));
+        $this->assertSame('reports', $defaults->forwardedQueue('reports'));
     }
 
     public function testForwardWithJustConnectionKeepsName()
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue('reports', connection: 'cloud');
+        $defaults->forward('reports', connection: 'cloud');
 
-        $this->assertSame('reports', $defaults->resolveQueue('reports', 'cloud'));
+        $this->assertSame('reports', $defaults->forwardedQueue('reports', 'cloud'));
     }
 
     public function testForwardSetsConnectionByQueueName()
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue('reports', 'audit', 'cloud');
+        $defaults->forward('reports', 'audit', 'cloud');
 
         $this->assertSame('cloud', $defaults->getConnection((new SomeJob)->onQueue('reports')));
         $this->assertNull($defaults->getConnection((new SomeJob)->onQueue('other')));
@@ -126,7 +126,7 @@ class QueueRoutesTest extends TestCase
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue('reports', 'audit', 'cloud');
+        $defaults->forward('reports', 'audit', 'cloud');
 
         $this->assertSame('cloud', $defaults->getConnection(new AttributeForwardedJob));
     }
@@ -135,24 +135,24 @@ class QueueRoutesTest extends TestCase
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue([
+        $defaults->forward([
             'reports' => 'audit',
             'emails' => 'mail',
         ], connection: 'cloud');
 
-        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
-        $this->assertSame('mail', $defaults->resolveQueue('emails', 'cloud'));
-        $this->assertSame('reports', $defaults->resolveQueue('reports', 'redis'));
+        $this->assertSame('audit', $defaults->forwardedQueue('reports', 'cloud'));
+        $this->assertSame('mail', $defaults->forwardedQueue('emails', 'cloud'));
+        $this->assertSame('reports', $defaults->forwardedQueue('reports', 'redis'));
     }
 
     public function testForwardResolvesEnums()
     {
         $defaults = new QueueRoutes();
 
-        $defaults->setQueue(QueueName::payments, 'settlements', ConnectionName::redis);
+        $defaults->forward(QueueName::payments, 'settlements', ConnectionName::redis);
 
-        $this->assertSame('settlements', $defaults->resolveQueue('payments', 'redis'));
-        $this->assertSame('payments', $defaults->resolveQueue('payments', 'sqs'));
+        $this->assertSame('settlements', $defaults->forwardedQueue('payments', 'redis'));
+        $this->assertSame('payments', $defaults->forwardedQueue('payments', 'sqs'));
     }
 
     public function testEnumsAreResolved()

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -102,7 +102,7 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('reports', $defaults->resolveQueue('reports'));
     }
 
-    public function testForwardWithoutDestinationKeepsName()
+    public function testForwardWithJustConnectionKeepsName()
     {
         $defaults = new QueueRoutes();
 

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -80,7 +80,7 @@ class QueueRoutesTest extends TestCase
         $this->assertNull($defaults->getConnection(new FinanceNotification));
     }
 
-    public function testRouteQueueRewritesName()
+    public function testForwardRewritesName()
     {
         $defaults = new QueueRoutes();
 
@@ -91,7 +91,7 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('other', $defaults->resolveQueue('other'));
     }
 
-    public function testRouteQueueIsScopedToConnection()
+    public function testForwardIsScopedToConnection()
     {
         $defaults = new QueueRoutes();
 
@@ -102,7 +102,7 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('reports', $defaults->resolveQueue('reports'));
     }
 
-    public function testRouteQueueWithoutDestinationKeepsName()
+    public function testForwardWithoutDestinationKeepsName()
     {
         $defaults = new QueueRoutes();
 
@@ -111,7 +111,7 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('reports', $defaults->resolveQueue('reports', 'cloud'));
     }
 
-    public function testRouteQueueRoutesConnectionByQueueName()
+    public function testForwardSetsConnectionByQueueName()
     {
         $defaults = new QueueRoutes();
 
@@ -122,16 +122,30 @@ class QueueRoutesTest extends TestCase
         $this->assertNull($defaults->getConnection(new SomeJob));
     }
 
-    public function testRouteQueueMatchesQueueAttribute()
+    public function testForwardMatchesQueueAttribute()
     {
         $defaults = new QueueRoutes();
 
         $defaults->setQueue('reports', 'audit', 'cloud');
 
-        $this->assertSame('cloud', $defaults->getConnection(new AttributeRoutedJob));
+        $this->assertSame('cloud', $defaults->getConnection(new AttributeForwardedJob));
     }
 
-    public function testRouteQueueResolvesEnums()
+    public function testForwardAcceptsArray()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->setQueue([
+            'reports' => 'audit',
+            'emails' => 'mail',
+        ], connection: 'cloud');
+
+        $this->assertSame('audit', $defaults->resolveQueue('reports', 'cloud'));
+        $this->assertSame('mail', $defaults->resolveQueue('emails', 'cloud'));
+        $this->assertSame('reports', $defaults->resolveQueue('reports', 'redis'));
+    }
+
+    public function testForwardResolvesEnums()
     {
         $defaults = new QueueRoutes();
 
@@ -177,7 +191,7 @@ class SomeJob
 }
 
 #[QueueAttribute('reports')]
-class AttributeRoutedJob
+class AttributeForwardedJob
 {
     use Queueable;
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -339,11 +339,11 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
     }
 
-    public function testRoutedQueueNameIsUsedWhenPushing()
+    public function testForwardedQueueNameIsUsedWhenPushing()
     {
         Container::setInstance($container = new Container);
         $routes = new QueueRoutes;
-        $routes->setQueue('jobs', 'processing', 'sqs');
+        $routes->forward('jobs', 'processing', 'sqs');
         $container->instance('queue.routes', $routes);
 
         $queue = new SqsQueue($this->sqs, 'default', $this->prefix);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -339,6 +339,26 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
     }
 
+    public function testRoutedQueueNameIsUsedWhenPushing()
+    {
+        Container::setInstance($container = new Container);
+        $routes = new QueueRoutes;
+        $routes->setQueue('jobs', 'processing', 'sqs');
+        $container->instance('queue.routes', $routes);
+
+        $queue = new SqsQueue($this->sqs, 'default', $this->prefix);
+        $queue->setConnectionName('sqs');
+
+        $this->sqs->expects('sendMessage')->with([
+            'QueueUrl' => $this->prefix.'processing',
+            'MessageBody' => 'payload',
+        ])->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw('payload', 'jobs');
+
+        Container::setInstance(null);
+    }
+
     public function testGetQueueEnsuresTheQueueIsOnlySuffixedOnce()
     {
         $queue = new SqsQueue($this->sqs, "{$this->queueName}-staging", $this->prefix, $suffix = '-staging');


### PR DESCRIPTION
One thing I'd like is the ability to forward one queue to another, HEAR ME OUT.

Imagine today, a lot of our code specifies different queues, we could have hundreds of jobs, all going to different queues and connections, Queue::route does help with this.

BUT, we may have different queues and connections and general infra per site, with different names like fifo, etc. This means locally and Staging 1 they're called via Redis, production SQS and Staging 2 managed queues 

Because the code is spread across different envs, ie Staging1,2,3 and production today that means we need to maintain environment checks in the code, that could be in the job construct, the dispatch point (onQueue) etc.. to ensure they're going to the right queues and connections based on the features, env and infrastructure. This is because our staging site man have a fifo queue for one set of jobs, where as production doesnt.

This PR adds `Queue::forward` call it in the AppServiceProvider ... with 0 code changes needed in the actual jobs or dispatch points and all the gates and logic can be done in one place, that way its easier to gate, easier to track and easier to get approved.

For example..

<details>

```php
// AppServiceProvider - these are just examples
if(laravel_cloud() && app()->environment('hagrid')) {
    Queue::forward('reports', 'reports.fifo', 'cloud'); // rename + move connection
    Queue::forward('payments', connection: 'cloud');  // move connection, keep name
    Queue::forward('updates', 'notifications');   // rename only
    Queue::forward([ // It also works with arrays
        'reports' => 'reports.fifo',
        'emails'  => 'emails.fifo',
    ], connection: 'cloud');
}
```

</details>

A few scenarios I had in mind:

<details>

1. This is super useful for Laravel Cloud, cos I can just do this `Queue::forward('reports', 'reports.fifo', 'cloud');` and use managed queues, I dont need to change it in multiple places. 

The reason for this is we still want to use Redis queues mainly, and we're moving / testing our big queues to managed. It would be nice if Cloud had a provider that could do this for us automatically at some point, but idk yet i'm not the chef so this method felt like the most easiest way without breaking peoples apps.

2. Ability to offload to new queues without rewriting everything ie perhaps we've shipped a new feature, and its blowing up the Redis queue, we make a new bigger instance and can just do `Queue::forward('encoding', connection: 'redis-heavy');` I guess the same for when Redis or etc goes down, perhaps we need to quickly roll everything to a diff connection...

3. General connection testing.. you may wanna test a new connection for a specific env.. just do `Queue::forward('notifications', connection: 'sqs-test');` (You can do a feature lottery to so like 50% of jobs go to the new implementation etc)

</details>

I went with `Queue::forward()` rather than `routeQueue()`, but open to renaming etc ofc. This is not the same as `Queue::route`, as this does it via queue name not class. since an explicit queue always wins over a route

There's no contract changes as the connection resolves through the same `getConnection()` hook `Queue::route()` uses, and the rename of the queue just uses each Queue driver's `getQueue`.

I've added tests that are basically a carbon copy of the `Queue::route` ones, feel free to adjust etc as you see fit.

Granted my implementation may not be golden so please adjust or close if it sucks.. hopefully you see my use case tho, so open to something else if I'm over engineering it. 



> [!TIP]
> if you `Queue::forward('A', to: 'B')` and then run `queue:work --queue=A` alongside `queue:work --queue=B`, both workers resolve to the exact same underlying physical queue - so I wouldn't suggest using it in this manor.. If you forward A to B, assume A is dead and stop using it.