### PR TITLE
[13.x] Add pauseMany, pauseManyFor, resumeMany

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -234,6 +234,20 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Pause many queues.
+     *
+     * @param  string  $connection
+     * @param  string[]  $queues
+     * @return void
+     */
+    public function pauseMany($connection, $queues)
+    {
+        foreach ($queues as $queue) {
+            $this->pause($connection, $queue);
+        }
+    }
+
+    /**
      * Pause a queue by its connection and name for a given amount of time.
      *
      * @param  string  $connection
@@ -250,6 +264,20 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['events']->dispatch(
             new Events\QueuePaused($connection, $queue, $ttl)
         );
+    }
+
+    /**
+     * Pause many queues for a given amount of time.
+     *
+     * @param  string  $connection
+     * @param  array<string, \DateTimeInterface|\DateInterval|int>  $queues
+     * @return void
+     */
+    public function pauseManyFor($connection, $queues)
+    {
+        foreach ($queues as $queue => $ttl) {
+            $this->pauseFor($connection, $queue, $ttl);
+        }
     }
 
     /**
@@ -284,6 +312,20 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['events']->dispatch(
             new Events\QueueResumed($connection, $queue)
         );
+    }
+
+    /**
+     * Resume many queues.
+     *
+     * @param  string  $connection
+     * @param  string[]  $queues
+     * @return void
+     */
+    public function resumeMany($connection, $queues)
+    {
+        foreach ($queues as $queue) {
+            $this->resume($connection, $queue);
+        }
     }
 
     /**

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Queue;
 
+use DateInterval;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Events\Dispatcher;
@@ -80,6 +81,76 @@ class QueuePauseResumeTest extends TestCase
 
         $this->manager->resume('redis', 'default');
         $this->assertFalse($this->manager->isPaused('redis', 'default'));
+    }
+
+    public function testPauseManyQueues(): void
+    {
+        $this->manager->pauseMany('redis', ['emails', 'notifications']);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+        $this->assertFalse($this->manager->isPaused('redis', 'default'));
+    }
+
+    public function testPauseManyQueuesForTTL(): void
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $this->manager->pauseManyFor('redis', ['emails' => 30, 'notifications' => 60]);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+
+        Carbon::setTestNow($now->addSeconds(45));
+        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+    }
+
+    public function testPauseManyQueuesForDateTimeInterfaceTTL(): void
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $this->manager->pauseManyFor('redis', [
+            'emails' => $now->copy()->addSeconds(30),
+            'notifications' => $now->copy()->addSeconds(60),
+        ]);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+
+        Carbon::setTestNow($now->addSeconds(45));
+        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+    }
+
+    public function testPauseManyQueuesForDateIntervalTTL(): void
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $this->manager->pauseManyFor('redis', [
+            'emails' => new DateInterval('PT30S'),
+            'notifications' => new DateInterval('PT60S'),
+        ]);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+
+        Carbon::setTestNow($now->addSeconds(45));
+        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+    }
+
+    public function testResumeManyQueues(): void
+    {
+        $this->manager->pauseMany('redis', ['emails', 'notifications']);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+
+        $this->manager->resumeMany('redis', ['emails', 'notifications']);
+
+        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
+        $this->assertFalse($this->manager->isPaused('redis', 'notifications'));
     }
 
     public function testPausingQueueOnOneConnectionDoesNotAffectAnother()


### PR DESCRIPTION
Adds `QueueManager::pauseMany()`, `pauseManyFor()`, and `resumeMany()` to pause/resume several queues at once.