### PR TITLE
[13.x] Fix uncaptured setTestNow now() reuse in tests

### DIFF
--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -6,6 +6,7 @@ namespace Illuminate\Tests;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
@@ -21,6 +22,7 @@ final class AfterEachTestSubscriber implements FinishedSubscriber
             \Mockery::close();
         }
 
+        Date::useDefault();
         Carbon::setTestNow();
         CarbonImmutable::setTestNow();
         date_default_timezone_set('UTC');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -24,7 +24,6 @@ use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
@@ -2196,7 +2195,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
-    public function testTimestampsUsingOldSqlServerDateFormatFallbackToDefaultParsing()
+    public function testTimestampsUsingOldSqlServerDateFormatFallbackToDefaultParsing(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format
@@ -2209,8 +2208,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('2017-11-14 08:23:19.000', $model->fromDateTime($date), 'the format should trims it');
         // No longer throwing exception since Laravel 7,
         // but Date::hasFormat() can be used instead to check date formatting:
-        $this->assertTrue(Date::hasFormat('2017-11-14 08:23:19.000', $model->getDateFormat()));
-        $this->assertFalse(Date::hasFormat('2017-11-14 08:23:19.734', $model->getDateFormat()));
+        $this->assertTrue(Carbon::hasFormat('2017-11-14 08:23:19.000', $model->getDateFormat()));
+        $this->assertFalse(Carbon::hasFormat('2017-11-14 08:23:19.734', $model->getDateFormat()));
     }
 
     public function testSpecialFormats()

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use Carbon\Carbon;
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
-use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\UnableToReadFile;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -10,11 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class WormholeTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Date::useDefault();
-    }
-
     public function testCanTravelBackToPresent()
     {
         // Preserve the timelines we want to compare the reality with...

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -132,12 +132,14 @@ class DatabaseLockTest extends DatabaseTestCase
         $firstLock->release();
     }
 
-    public function testExpiredLockCannotBeRefreshedByPreviousOwner()
+    public function testExpiredLockCannotBeRefreshedByPreviousOwner(): void
     {
+        Carbon::setTestNow($now = Carbon::now());
+
         $lock = Cache::driver('database')->lock('foo', 10);
         $this->assertTrue($lock->get());
 
-        DB::table('cache_locks')->update(['expiration' => now()->subDay()->getTimestamp()]);
+        DB::table('cache_locks')->update(['expiration' => $now->subDay()->getTimestamp()]);
 
         $this->assertFalse($lock->refresh(20));
     }

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -270,12 +270,12 @@ class SleepTest extends TestCase
         ]);
     }
 
-    public function testItSleepsForZeroTimeWithNegativeDateTime()
+    public function testItSleepsForZeroTimeWithNegativeDateTime(): void
     {
         Sleep::fake();
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
-        Sleep::until(Carbon::now()->subMinutes(100));
+        Sleep::until($now->copy()->subMinutes(100));
 
         Sleep::assertSequence([
             Sleep::for(0)->seconds(),


### PR DESCRIPTION
Freeze `now()` into a variable and reuse it instead of calling `now()` again later in the same test.