### PR TITLE
[13.x] Remove PailServiceProvider check from DevCommands

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\NodePackageManager;
-use Laravel\Pail\PailServiceProvider;
 use ReflectionClass;
 
 /**
@@ -97,10 +96,6 @@ class DevCommands
 
         self::artisan('serve', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
-
-        if (function_exists('pcntl_fork') && app()->providerIsLoaded(PailServiceProvider::class)) {
-            self::artisan('pail --timeout=0', 'logs');
-        }
 
         if (File::exists(base_path('package.json'))) {
             self::node('dev', 'vite');


### PR DESCRIPTION
Remove the framework's hard-coded Pail startup logic now that Pail handles its own dev command registration.

This removes the framework's direct dependency on `PailServiceProvider` and keeps Pail-specific behavior inside the Pail package.

Related: Laravel Pail PR #79.
