### PR TITLE
[12.x] Escape single quotes in Postgres JSON path attributes

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -761,9 +761,17 @@ class PostgresGrammar extends Grammar
             ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
             ->collapse()
             ->map(function ($attribute) use ($quote) {
-                return filter_var($attribute, FILTER_VALIDATE_INT) !== false
-                    ? $attribute
-                    : $quote.$attribute.$quote;
+                if (filter_var($attribute, FILTER_VALIDATE_INT) !== false) {
+                    return $attribute;
+                }
+
+                $attribute = str_replace("'", "''", $attribute);
+
+                if ($quote !== "'") {
+                    $attribute = str_replace($quote, $quote.$quote, $attribute);
+                }
+
+                return $quote.$attribute.$quote;
             })
             ->all();
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5199,6 +5199,36 @@ SQL;
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
     }
 
+    public function testPostgresJsonPathEscaping()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select("json->'))#");
+        $this->assertSame('select "json"->>\'\'\'))#\'', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where("json->'))#", '=', 1);
+        $this->assertSame('select * from "users" where "json"->>\'\'\'))#\' = ?', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->orderBy("json->'))#");
+        $this->assertSame('select * from "users" order by "json"->>\'\'\'))#\' asc', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereJsonLength("json->'))#", 1);
+        $this->assertSame('select * from "users" where jsonb_array_length(("json"->\'\'\'))#\')::jsonb) = ?', $builder->toSql());
+    }
+
+    public function testPostgresUpdateJsonPathEscaping()
+    {
+        // The update path delimits its attributes with double quotes, but the
+        // resulting path is still nested within a single quoted string literal,
+        // so single quotes must be escaped there as well...
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"\'\'))#"}\', ?)', ['"John"']);
+        $builder->from('users')->update(["options->'))#" => 'John']);
+    }
+
     public function testMySqlWrappingJson()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
`PostgresGrammar::wrapJsonPathAttributes()` interpolates JSON path attributes into single quoted SQL string literals without escaping single quotes, so a quote in a JSON path terminates the literal early.

The equivalent path is already escaped for every other driver by `CompilesJsonPaths::wrapJsonPath()` (#28160), and within this same grammar by `compileJsonContainsKey()`, which uses `str_replace("'", "''", ...)`.

`compileJsonUpdateColumn()` delimits path attributes with double quotes but still nests the result inside a `'{...}'` literal, so single quotes are escaped regardless of the configured delimiter.

Backport https://github.com/laravel/framework/pull/60923 PR to `12.x` release

---------

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
