### PR TITLE
[13.x] Add process fake assertion helpers

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -249,6 +249,58 @@ class Factory
     }
 
     /**
+     * Assert how many processes have been recorded.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function assertRanCount(int $count)
+    {
+        PHPUnit::assertCount($count, $this->recorded);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given processes were run in the given order.
+     *
+     * @param  list<\Closure|string>  $callbacks
+     * @return $this
+     */
+    public function assertRanInOrder(array $callbacks)
+    {
+        $this->assertRanCount(count($callbacks));
+
+        foreach ($callbacks as $index => $callback) {
+            $callback = $callback instanceof Closure
+                ? $callback
+                : fn ($process) => $process->command === $callback;
+
+            PHPUnit::assertTrue(
+                $callback($this->recorded[$index][0], $this->recorded[$index][1]),
+                'An expected process (#'.($index + 1).') was not invoked.'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get a collection of the process / result pairs matching the given truth test.
+     *
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Support\Collection<int, array{0: \Illuminate\Process\PendingProcess, 1: \Illuminate\Contracts\Process\ProcessResult}>
+     */
+    public function recorded(?Closure $callback = null)
+    {
+        $recorded = new Collection($this->recorded);
+
+        return $callback
+            ? $recorded->filter(fn ($pair) => $callback($pair[0], $pair[1]))->values()
+            : $recorded;
+    }
+
+    /**
      * Assert that no processes were recorded.
      *
      * @return $this

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -218,6 +218,43 @@ class Factory
     }
 
     /**
+     * Assert that the given processes were run in the given order.
+     *
+     * @param  list<\Closure|string>  $callbacks
+     * @return $this
+     */
+    public function assertRanInOrder(array $callbacks)
+    {
+        $this->assertRanCount(count($callbacks));
+
+        foreach ($callbacks as $index => $callback) {
+            $callback = $callback instanceof Closure
+                ? $callback
+                : fn ($process) => $process->command === $callback;
+
+            PHPUnit::assertTrue(
+                $callback($this->recorded[$index][0], $this->recorded[$index][1]),
+                'An expected process (#'.($index + 1).') was not invoked.'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert how many processes have been recorded.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    protected function assertRanCount(int $count)
+    {
+        PHPUnit::assertCount($count, $this->recorded);
+
+        return $this;
+    }
+
+    /**
      * Assert that a process was not recorded matching a given truth test.
      *
      * @param  \Closure|string  $callback
@@ -246,58 +283,6 @@ class Factory
     public function assertDidntRun(Closure|string $callback)
     {
         return $this->assertNotRan($callback);
-    }
-
-    /**
-     * Assert how many processes have been recorded.
-     *
-     * @param  int  $count
-     * @return $this
-     */
-    public function assertRanCount(int $count)
-    {
-        PHPUnit::assertCount($count, $this->recorded);
-
-        return $this;
-    }
-
-    /**
-     * Assert that the given processes were run in the given order.
-     *
-     * @param  list<\Closure|string>  $callbacks
-     * @return $this
-     */
-    public function assertRanInOrder(array $callbacks)
-    {
-        $this->assertRanCount(count($callbacks));
-
-        foreach ($callbacks as $index => $callback) {
-            $callback = $callback instanceof Closure
-                ? $callback
-                : fn ($process) => $process->command === $callback;
-
-            PHPUnit::assertTrue(
-                $callback($this->recorded[$index][0], $this->recorded[$index][1]),
-                'An expected process (#'.($index + 1).') was not invoked.'
-            );
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get a collection of the process / result pairs matching the given truth test.
-     *
-     * @param  \Closure|null  $callback
-     * @return \Illuminate\Support\Collection<int, array{0: \Illuminate\Process\PendingProcess, 1: \Illuminate\Contracts\Process\ProcessResult}>
-     */
-    public function recorded(?Closure $callback = null)
-    {
-        $recorded = new Collection($this->recorded);
-
-        return $callback
-            ? $recorded->filter(fn ($pair) => $callback($pair[0], $pair[1]))->values()
-            : $recorded;
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -9,6 +9,7 @@ use Illuminate\Process\Exceptions\ProcessIdleTimedOutException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
 use OutOfBoundsException;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -1171,6 +1172,85 @@ class ProcessTest extends TestCase
         $factory->start('0')->wait();
 
         $factory->assertRan('0');
+    }
+
+    public function testAssertingHowManyProcessesRan()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('one');
+        $factory->run('two');
+
+        $factory->assertRanCount(2);
+    }
+
+    public function testAssertingProcessesRanInOrder()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('git fetch');
+        $factory->run('git reset --hard origin/main');
+        $factory->run('composer install --no-dev');
+
+        $factory->assertRanInOrder([
+            'git fetch',
+            'git reset --hard origin/main',
+            fn ($process) => str_starts_with($process->command, 'composer install'),
+        ]);
+    }
+
+    public function testAssertingProcessesRanInOrderFailsWhenOutOfOrder()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('composer install');
+        $factory->run('git fetch');
+
+        $factory->assertRanInOrder(['git fetch', 'composer install']);
+    }
+
+    public function testAssertingProcessesRanInOrderFailsWhenCountDiffers()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('git fetch');
+
+        $factory->assertRanInOrder(['git fetch', 'composer install']);
+    }
+
+    public function testRecordedProcessesCanBeRetrieved()
+    {
+        $factory = new Factory;
+        $factory->fake([
+            'fails' => $factory->result(exitCode: 1),
+            '*' => $factory->result(),
+        ]);
+
+        $factory->run('passes');
+        $factory->run('fails');
+
+        $this->assertCount(2, $factory->recorded());
+
+        $failed = $factory->recorded(fn ($process, $result) => $result->failed());
+
+        $this->assertCount(1, $failed);
+        $this->assertSame('fails', $failed[0][0]->command);
+    }
+
+    public function testRecordedProcessesAreEmptyWhenNothingRan()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $this->assertTrue($factory->recorded()->isEmpty());
     }
 
     public function testAssertingThatNothingRan()

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1174,17 +1174,6 @@ class ProcessTest extends TestCase
         $factory->assertRan('0');
     }
 
-    public function testAssertingHowManyProcessesRan()
-    {
-        $factory = new Factory;
-        $factory->fake();
-
-        $factory->run('one');
-        $factory->run('two');
-
-        $factory->assertRanCount(2);
-    }
-
     public function testAssertingProcessesRanInOrder()
     {
         $factory = new Factory;
@@ -1224,33 +1213,6 @@ class ProcessTest extends TestCase
         $factory->run('git fetch');
 
         $factory->assertRanInOrder(['git fetch', 'composer install']);
-    }
-
-    public function testRecordedProcessesCanBeRetrieved()
-    {
-        $factory = new Factory;
-        $factory->fake([
-            'fails' => $factory->result(exitCode: 1),
-            '*' => $factory->result(),
-        ]);
-
-        $factory->run('passes');
-        $factory->run('fails');
-
-        $this->assertCount(2, $factory->recorded());
-
-        $failed = $factory->recorded(fn ($process, $result) => $result->failed());
-
-        $this->assertCount(1, $failed);
-        $this->assertSame('fails', $failed[0][0]->command);
-    }
-
-    public function testRecordedProcessesAreEmptyWhenNothingRan()
-    {
-        $factory = new Factory;
-        $factory->fake();
-
-        $this->assertTrue($factory->recorded()->isEmpty());
     }
 
     public function testAssertingThatNothingRan()


### PR DESCRIPTION
This PR adds three assertion helpers to the process fake

Assert how many processes ran:

```php
Process::assertRanCount(2);
```

Assert processes ran in a given order:

```php
Process::assertRanInOrder([
    'git fetch',
    'composer install',
]);
```

And retrieve the recorded process / result pairs:

```php
$failed = Process::recorded(fn ($process, $result) => $result->failed());
```