### PR TITLE
[13.x] Support persistent connections and AWS SDK transport sharing

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Bus\QueueingDispatcher as QueueingDispatcherContract;
 use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use Illuminate\Support\ServiceProvider;
 
 class BusServiceProvider extends ServiceProvider implements DeferrableProvider
@@ -67,6 +68,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
                 'region' => $config['region'],
                 'version' => 'latest',
                 'endpoint' => $config['endpoint'] ?? null,
+                'transport_sharing' => $config['transport_sharing'] ?? null,
             ];
 
             if (! empty($config['key']) && ! empty($config['secret'])) {
@@ -79,7 +81,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
 
             return new DynamoBatchRepository(
                 $app->make(BatchFactory::class),
-                new DynamoDbClient($dynamoConfig),
+                new DynamoDbClient(AwsTransportSharing::apply($dynamoConfig)),
                 $app->config->get('app.name'),
                 $app->config->get('queue.batching.table', 'job_batches'),
                 ttl: $app->config->get('queue.batching.ttl', null),

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Cache\Factory as FactoryContract;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use Illuminate\Support\RebindsCallbacksToSelf;
 use InvalidArgumentException;
 use Mockery;
@@ -252,6 +253,7 @@ class CacheManager implements FactoryContract
             'region' => $config['region'],
             'version' => 'latest',
             'endpoint' => $config['endpoint'] ?? null,
+            'transport_sharing' => $config['transport_sharing'] ?? null,
         ];
 
         if (! empty($config['key']) && ! empty($config['secret'])) {
@@ -264,7 +266,7 @@ class CacheManager implements FactoryContract
             }
         }
 
-        return new DynamoDbClient($dynamoConfig);
+        return new DynamoDbClient(AwsTransportSharing::apply($dynamoConfig));
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -6,6 +6,7 @@ use Aws\S3\S3Client;
 use Closure;
 use Illuminate\Contracts\Filesystem\Factory as FactoryContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use Illuminate\Support\RebindsCallbacksToSelf;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -258,7 +259,7 @@ class FilesystemManager implements FactoryContract
 
         $streamReads = $s3Config['stream_reads'] ?? false;
 
-        $client = new S3Client($s3Config);
+        $client = new S3Client(AwsTransportSharing::apply($s3Config));
 
         $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, $config['options'] ?? [], $streamReads);
 

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -6,7 +6,6 @@ use Carbon\CarbonImmutable;
 use Closure;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\EachPromise;
-use GuzzleHttp\Utils;
 use Illuminate\Http\Client\Promises\LazyPromise;
 use Illuminate\Support\Defer\DeferredCallback;
 
@@ -128,7 +127,7 @@ class Batch
     public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory;
-        $this->handler = Utils::chooseHandler();
+        $this->handler = $this->factory->newHandler();
         $this->createdAt = new CarbonImmutable;
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -48,6 +49,13 @@ class Factory
      * @var \Closure|array
      */
     protected $globalOptions = [];
+
+    /**
+     * The persistent transport (connection sharing) mode to apply to every request.
+     *
+     * @var \Illuminate\Http\Client\PersistentTransport
+     */
+    protected PersistentTransport $globalPersistentTransport = PersistentTransport::None;
 
     /**
      * The stub callables that will handle requests.
@@ -156,7 +164,30 @@ class Factory
     }
 
     /**
-     * Execute a callback while requests are created without global middleware or global options.
+     * Set the persistent transport (connection sharing) mode to apply to every request.
+     *
+     * @param  \Illuminate\Http\Client\PersistentTransport  $mode
+     * @return $this
+     */
+    public function globalPersistentTransport(PersistentTransport $mode)
+    {
+        $this->globalPersistentTransport = $mode;
+
+        return $this;
+    }
+
+    /**
+     * Create a new base Guzzle handler honoring the global persistent transport mode.
+     *
+     * @return callable
+     */
+    public function newHandler()
+    {
+        return $this->globalPersistentTransport->handler() ?? Utils::chooseHandler();
+    }
+
+    /**
+     * Execute a callback while requests are created without global middleware, options, or persistent transport.
      *
      * @template TReturn
      *
@@ -165,14 +196,22 @@ class Factory
      */
     public function withoutGlobalConfiguration(Closure $callback)
     {
-        [$middleware, $options] = [$this->globalMiddleware, $this->globalOptions];
+        [$middleware, $options, $transport] = [
+            $this->globalMiddleware,
+            $this->globalOptions,
+            $this->globalPersistentTransport,
+        ];
 
-        [$this->globalMiddleware, $this->globalOptions] = [[], []];
+        [$this->globalMiddleware, $this->globalOptions, $this->globalPersistentTransport] = [
+            [], [], PersistentTransport::None,
+        ];
 
         try {
             return $callback();
         } finally {
-            [$this->globalMiddleware, $this->globalOptions] = [$middleware, $options];
+            [$this->globalMiddleware, $this->globalOptions, $this->globalPersistentTransport] = [
+                $middleware, $options, $transport,
+            ];
         }
     }
 
@@ -619,7 +658,9 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return (new PendingRequest($this, $this->globalMiddleware))->withOptions(value($this->globalOptions));
+        return (new PendingRequest($this, $this->globalMiddleware))
+            ->withOptions(value($this->globalOptions))
+            ->persistentTransport($this->globalPersistentTransport);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -64,6 +64,13 @@ class PendingRequest
     protected $handler;
 
     /**
+     * The persistent transport (connection sharing) mode for the request.
+     *
+     * @var \Illuminate\Http\Client\PersistentTransport
+     */
+    protected PersistentTransport $persistentTransport = PersistentTransport::None;
+
+    /**
      * The base URL for the request.
      *
      * @var string
@@ -1693,7 +1700,22 @@ class PendingRequest
      */
     public function buildHandlerStack()
     {
-        return $this->pushHandlers(HandlerStack::create($this->handler));
+        return $this->pushHandlers(HandlerStack::create($this->buildDefaultHandler()));
+    }
+
+    /**
+     * Resolve the base Guzzle handler, applying persistent transport sharing when enabled.
+     *
+     * @return callable|null
+     */
+    protected function buildDefaultHandler()
+    {
+        // Transport sharing can only be applied when Guzzle builds the handler.
+        if (! is_null($this->handler)) {
+            return $this->handler;
+        }
+
+        return $this->persistentTransport->handler();
     }
 
     /**
@@ -2135,6 +2157,19 @@ class PendingRequest
     public function setHandler($handler)
     {
         $this->handler = $handler;
+
+        return $this;
+    }
+
+    /**
+     * Set the persistent transport (connection sharing) mode for the request.
+     *
+     * @param  \Illuminate\Http\Client\PersistentTransport  $mode
+     * @return $this
+     */
+    public function persistentTransport(PersistentTransport $mode)
+    {
+        $this->persistentTransport = $mode;
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PersistentTransport.php
+++ b/src/Illuminate/Http/Client/PersistentTransport.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use GuzzleHttp\TransportSharing;
+use GuzzleHttp\Utils;
+use RuntimeException;
+
+enum PersistentTransport: string
+{
+    case None = 'none';
+    case Preferred = 'preferred';
+    case Required = 'required';
+
+    /**
+     * Create a Guzzle handler applying this transport mode, or null when sharing is disabled.
+     *
+     * The underlying handler is resolved lazily so requests answered before
+     * reaching the transport (fakes, stray request guards) never build it.
+     *
+     * @return callable|null
+     */
+    public function handler()
+    {
+        if ($this === self::None) {
+            return null;
+        }
+
+        return function ($request, $options) {
+            static $handler;
+
+            $handler ??= Utils::chooseHandler(array_filter([
+                'transport_sharing' => $this->transportSharingMode(),
+            ]));
+
+            return $handler($request, $options);
+        };
+    }
+
+    /**
+     * Resolve the Guzzle "transport_sharing" mode for this persistence level.
+     *
+     * @return string|null
+     *
+     * @throws \RuntimeException
+     */
+    public function transportSharingMode()
+    {
+        if ($this === self::None) {
+            return null;
+        }
+
+        $required = $this === self::Required;
+
+        // Guzzle 8: persistent (cross-request) sharing.
+        if (defined(TransportSharing::class.'::PERSISTENT_PREFER') && defined(TransportSharing::class.'::PERSISTENT_REQUIRE')) {
+            return $required ? TransportSharing::PERSISTENT_REQUIRE : TransportSharing::PERSISTENT_PREFER;
+        }
+
+        if ($required) {
+            throw new RuntimeException('Persistent HTTP transport sharing is set to "Required", but persistent cURL share handles require guzzlehttp/guzzle ^8.0.');
+        }
+
+        // Guzzle 7.11: handler-lifetime sharing only, best-effort.
+        if (class_exists(TransportSharing::class)) {
+            return TransportSharing::HANDLER_PREFER;
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use GuzzleHttp\Utils;
-
 /**
  * @mixin \Illuminate\Http\Client\Factory
  */
@@ -38,7 +36,7 @@ class Pool
     public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
-        $this->handler = Utils::chooseHandler();
+        $this->handler = $this->factory->newHandler();
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -14,6 +14,7 @@ use Illuminate\Mail\Transport\ResendTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\SesV2Transport;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use Illuminate\Support\ConfigurationUrlParser;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -265,7 +266,7 @@ class MailManager implements FactoryContract
         $config = Arr::except($config, ['transport']);
 
         return new SesTransport(
-            new SesClient($this->addSesCredentials($config)),
+            new SesClient(AwsTransportSharing::apply($this->addSesCredentials($config))),
             $config['options'] ?? []
         );
     }
@@ -287,7 +288,7 @@ class MailManager implements FactoryContract
         $config = Arr::except($config, ['transport']);
 
         return new SesV2Transport(
-            new SesV2Client($this->addSesCredentials($config)),
+            new SesV2Client(AwsTransportSharing::apply($this->addSesCredentials($config))),
             $config['options'] ?? []
         );
     }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -6,6 +6,7 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use InvalidArgumentException;
 
 class SqsConnector implements ConnectorInterface
@@ -32,7 +33,7 @@ class SqsConnector implements ConnectorInterface
 
         return new SqsQueue(
             new SqsClient(
-                Arr::except($config, ['token', 'overflow'])
+                AwsTransportSharing::apply(Arr::except($config, ['token', 'overflow']))
             ),
             $config['queue'],
             $config['prefix'] ?? '',

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -21,6 +21,7 @@ use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\AwsTransportSharing;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -372,6 +373,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             'region' => $config['region'],
             'version' => 'latest',
             'endpoint' => $config['endpoint'] ?? null,
+            'transport_sharing' => $config['transport_sharing'] ?? null,
         ];
 
         if (! empty($config['key']) && ! empty($config['secret'])) {
@@ -383,7 +385,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         }
 
         return new DynamoDbFailedJobProvider(
-            new DynamoDbClient($dynamoConfig),
+            new DynamoDbClient(AwsTransportSharing::apply($dynamoConfig)),
             $this->app['config']['app.name'],
             $config['table']
         );

--- a/src/Illuminate/Support/AwsTransportSharing.php
+++ b/src/Illuminate/Support/AwsTransportSharing.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Aws\Handler\HttpTransportSharing;
+use RuntimeException;
+
+class AwsTransportSharing
+{
+    /**
+     * Apply the AWS SDK "transport_sharing" option supported by the installed SDK.
+     *
+     * When the installed AWS SDK does not support the option, the "none" and
+     * "*_prefer" modes are removed from the configuration, while the
+     * "*_require" modes fail loudly.
+     *
+     * @param  array  $config
+     * @return array
+     *
+     * @throws \RuntimeException
+     */
+    public static function apply(array $config): array
+    {
+        $sharing = $config['transport_sharing'] ?? null;
+
+        if ($sharing === null) {
+            unset($config['transport_sharing']);
+
+            return $config;
+        }
+
+        if (class_exists(HttpTransportSharing::class)) {
+            return $config;
+        }
+
+        if (in_array($sharing, ['handler_require', 'persistent_require'], true)) {
+            throw new RuntimeException(sprintf(
+                'The "%s" transport sharing mode requires a version of aws/aws-sdk-php that supports the "transport_sharing" client option.',
+                $sharing
+            ));
+        }
+
+        unset($config['transport_sharing']);
+
+        return $config;
+    }
+}

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Factory globalRequestMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalResponseMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalOptions(\Closure|array $options)
+ * @method static \Illuminate\Http\Client\Factory globalPersistentTransport(\Illuminate\Http\Client\PersistentTransport $mode)
+ * @method static callable newHandler()
  * @method static mixed withoutGlobalConfiguration(\Closure $callback)
  * @method static \GuzzleHttp\Promise\PromiseInterface response(\Psr\Http\Message\StreamInterface|array|string|resource|null $body = null, int $status = 200, array $headers = [])
  * @method static \GuzzleHttp\Psr7\Response psr7Response(\Psr\Http\Message\StreamInterface|array|string|resource|null $body = null, int $status = 200, array $headers = [])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -27,6 +27,7 @@ use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\PersistentTransport;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
@@ -53,6 +54,7 @@ use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use ReflectionProperty;
 use RuntimeException;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -2355,6 +2357,16 @@ class HttpClientTest extends TestCase
 
         $this->assertSame('v4', $this->factory->createPendingRequest()->getOptions()['force_ip_resolve']);
         $this->assertSame([$middleware], $this->factory->getGlobalMiddleware());
+    }
+
+    public function testGlobalPersistentTransportIsDisabledForRequestsCreatedWithinWithoutGlobalConfigurationCallback()
+    {
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $request = $this->factory->withoutGlobalConfiguration(fn () => $this->factory->createPendingRequest());
+
+        $this->assertSame(PersistentTransport::None, (new ReflectionProperty($request, 'persistentTransport'))->getValue($request));
+        $this->assertSame(PersistentTransport::Required, (new ReflectionProperty($this->factory, 'globalPersistentTransport'))->getValue($this->factory));
     }
 
     public function testMultipleRequestsAreSentInThePool()
@@ -5020,6 +5032,107 @@ class HttpClientTest extends TestCase
         // body() should only be called once
         $response->json();
         $this->assertSame(1, $response->bodyCallCount);
+    }
+
+    public function testRequiredPersistentTransportDoesNotThrowWhenFaking()
+    {
+        $this->factory->fake();
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $response = $this->factory->get('https://example.com');
+
+        $this->assertSame(200, $response->status());
+    }
+
+    public function testGlobalRequiredPersistentTransportThrowsWhenPersistentSharingIsUnavailable()
+    {
+        if (defined('GuzzleHttp\TransportSharing::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is available.');
+        }
+
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $this->expectException(RuntimeException::class);
+
+        $this->factory->get('https://example.com');
+    }
+
+    public function testRequiredPersistentTransportCanBeSetPerRequest()
+    {
+        if (defined('GuzzleHttp\TransportSharing::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is available.');
+        }
+
+        $this->expectException(RuntimeException::class);
+
+        $this->factory->createPendingRequest()
+            ->persistentTransport(PersistentTransport::Required)
+            ->get('https://example.com');
+    }
+
+    public function testRequiredPersistentTransportAppliesToUnfakedRequests()
+    {
+        if (defined('GuzzleHttp\TransportSharing::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is available.');
+        }
+
+        $this->factory->fake(['https://faked.example/*' => $this->factory::response('ok')]);
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $this->assertSame('ok', $this->factory->get('https://faked.example/users')->body());
+
+        $this->expectException(RuntimeException::class);
+
+        $this->factory->get('https://example.com');
+    }
+
+    public function testRequiredPersistentTransportDoesNotThrowWhenPreventingStrayRequests()
+    {
+        $this->factory->preventStrayRequests();
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $this->expectException(StrayRequestException::class);
+
+        $this->factory->get('https://example.com');
+    }
+
+    public function testPoolRequiredPersistentTransportDoesNotThrowWhenFaking()
+    {
+        $this->factory->fake();
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            return [$pool->get('https://example.com')];
+        });
+
+        $this->assertSame(200, $responses[0]->status());
+    }
+
+    public function testPoolRequiredPersistentTransportThrowsWhenPersistentSharingIsUnavailable()
+    {
+        if (defined('GuzzleHttp\TransportSharing::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is available.');
+        }
+
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            return [$pool->get('https://example.com')];
+        });
+
+        $this->assertInstanceOf(RuntimeException::class, $responses[0]);
+    }
+
+    public function testBatchRequiredPersistentTransportDoesNotThrowWhenFaking()
+    {
+        $this->factory->fake();
+        $this->factory->globalPersistentTransport(PersistentTransport::Required);
+
+        $responses = $this->factory->batch(function (Batch $batch) {
+            return [$batch->get('https://example.com')];
+        })->send();
+
+        $this->assertSame(200, $responses[0]->status());
     }
 
     public function testNetworkExceptionIsConvertedToConnectionException()

--- a/tests/Support/SupportAwsTransportSharingTest.php
+++ b/tests/Support/SupportAwsTransportSharingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Aws\Handler\HttpTransportSharing;
+use Illuminate\Support\AwsTransportSharing;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SupportAwsTransportSharingTest extends TestCase
+{
+    public function testRemovesAbsentOrNullMode()
+    {
+        $this->assertSame(['region' => 'us-east-1'], AwsTransportSharing::apply(['region' => 'us-east-1']));
+        $this->assertSame(['region' => 'us-east-1'], AwsTransportSharing::apply(['region' => 'us-east-1', 'transport_sharing' => null]));
+    }
+
+    public function testForwardsModesWhenSdkSupportsTransportSharing()
+    {
+        if (! class_exists(HttpTransportSharing::class)) {
+            $this->markTestSkipped('The installed AWS SDK does not support transport sharing.');
+        }
+
+        $this->assertSame(
+            ['region' => 'us-east-1', 'transport_sharing' => 'persistent_require'],
+            AwsTransportSharing::apply(['region' => 'us-east-1', 'transport_sharing' => 'persistent_require'])
+        );
+    }
+
+    public function testRemovesPreferModesWhenSdkLacksTransportSharing()
+    {
+        if (class_exists(HttpTransportSharing::class)) {
+            $this->markTestSkipped('The installed AWS SDK supports transport sharing.');
+        }
+
+        $this->assertSame(['region' => 'us-east-1'], AwsTransportSharing::apply(['region' => 'us-east-1', 'transport_sharing' => 'none']));
+        $this->assertSame(['region' => 'us-east-1'], AwsTransportSharing::apply(['region' => 'us-east-1', 'transport_sharing' => 'handler_prefer']));
+        $this->assertSame(['region' => 'us-east-1'], AwsTransportSharing::apply(['region' => 'us-east-1', 'transport_sharing' => 'persistent_prefer']));
+    }
+
+    public function testRequireModesFailWhenSdkLacksTransportSharing()
+    {
+        if (class_exists(HttpTransportSharing::class)) {
+            $this->markTestSkipped('The installed AWS SDK supports transport sharing.');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "persistent_require" transport sharing mode requires a version of aws/aws-sdk-php that supports the "transport_sharing" client option.');
+
+        AwsTransportSharing::apply(['transport_sharing' => 'persistent_require']);
+    }
+}


### PR DESCRIPTION
When #60321 was merged, only the Guzzle 8 upgrade was retained and the persistent connection support originally included in that PR was reverted before it landed. The first commit here restores that work on top of 13.x, re-adding the shared transport support that enables persistent connection re-use across php-fpm requests on Guzzle 8 with PHP 8.5.

The second commit adds support for the AWS SDK's proposed `transport_sharing` client option (aws/aws-sdk-php#3335), which extends that connection re-use to the AWS SDK. The option is applied at every point the framework constructs an AWS SDK client, including the DynamoDB builders whose fixed key lists previously dropped the option. Because the AWS SDK is a suggested dependency, the framework cannot mandate a version that understands the option, and older SDKs silently ignore unknown configuration keys, which would turn the require modes, whose entire purpose is to fail loudly when connection re-use cannot be guaranteed, into silent no-ops. The new `Illuminate\Support\AwsTransportSharing` helper closes that gap: it forwards the configuration untouched when the installed SDK supports the option, strips the none and prefer modes when it does not so configuration stays portable, and throws for the require modes.

Replaces #61050; draft until the SDK change ships in a release.