### PR TITLE
[14.x] Add Arr::before() and Arr::after() helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -75,6 +75,70 @@ class Arr
     }
 
     /**
+     * Get the item before the given item.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  TValue|(callable(TValue, TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public static function before($array, $value, $strict = false)
+    {
+        $key = ! is_string($value) && is_callable($value)
+            ? array_find_key($array, $value)
+            : array_search($value, $array, $strict);
+
+        if ($key === false || $key === null) {
+            return null;
+        }
+
+        $keys = array_keys($array);
+
+        $position = array_search($key, $keys, true);
+
+        if ($position === 0) {
+            return null;
+        }
+
+        return $array[$keys[$position - 1]];
+    }
+
+    /**
+     * Get the item after the given item.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  TValue|(callable(TValue, TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public static function after($array, $value, $strict = false)
+    {
+        $key = ! is_string($value) && is_callable($value)
+            ? array_find_key($array, $value)
+            : array_search($value, $array, $strict);
+
+        if ($key === false || $key === null) {
+            return null;
+        }
+
+        $keys = array_keys($array);
+
+        $position = array_search($key, $keys, true);
+
+        if ($position === count($keys) - 1) {
+            return null;
+        }
+
+        return $array[$keys[$position + 1]];
+    }
+
+    /**
      * Get an array item from an array using "dot" notation.
      *
      * @throws \InvalidArgumentException

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -71,6 +71,98 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['category' => ['type' => 'Table']], Arr::add(['category' => ['type' => 'Table']], 'category.type', 'Chair'));
     }
 
+    public function testBeforeReturnsItemBeforeTheGivenItem()
+    {
+        $array = [1, 2, 3, 4, 5, 2, 5, 'name' => 'taylor', 'framework' => 'laravel'];
+
+        $this->assertEquals(1, Arr::before($array, 2));
+        $this->assertEquals(1, Arr::before($array, '2'));
+        $this->assertEquals(5, Arr::before($array, 'taylor'));
+        $this->assertSame('taylor', Arr::before($array, 'laravel'));
+        $this->assertEquals(4, Arr::before($array, fn ($value) => $value > 4));
+        $this->assertEquals(5, Arr::before($array, fn ($value) => ! is_numeric($value)));
+    }
+
+    public function testBeforeInStrictMode()
+    {
+        $array = [false, 0, 1, [], ''];
+
+        $this->assertNull(Arr::before($array, 'false', true));
+        $this->assertNull(Arr::before($array, '1', true));
+        $this->assertNull(Arr::before($array, false, true));
+        $this->assertEquals(false, Arr::before($array, 0, true));
+        $this->assertEquals(0, Arr::before($array, 1, true));
+        $this->assertEquals(1, Arr::before($array, [], true));
+        $this->assertSame([], Arr::before($array, '', true));
+    }
+
+    public function testBeforeReturnsNullWhenItemIsNotFound()
+    {
+        $array = [1, 2, 3, 4, 5, 'foo' => 'bar'];
+
+        $this->assertNull(Arr::before($array, 6));
+        $this->assertNull(Arr::before($array, 'foo'));
+        $this->assertNull(Arr::before($array, fn ($value) => $value < 1 && is_numeric($value)));
+        $this->assertNull(Arr::before($array, fn ($value) => $value === 'nope'));
+    }
+
+    public function testBeforeReturnsNullWhenItemOnTheFirstItem()
+    {
+        $array = [1, 2, 3, 4, 5, 'foo' => 'bar'];
+
+        $this->assertNull(Arr::before($array, 1));
+        $this->assertNull(Arr::before($array, fn ($value) => $value < 2 && is_numeric($value)));
+
+        $this->assertNull(Arr::before(['foo' => 'bar', 1, 2, 3, 4, 5], 'bar'));
+    }
+
+    public function testAfterReturnsItemAfterTheGivenItem()
+    {
+        $array = [1, 2, 3, 4, 2, 5, 'name' => 'taylor', 'framework' => 'laravel'];
+
+        $this->assertEquals(2, Arr::after($array, 1));
+        $this->assertEquals(3, Arr::after($array, 2));
+        $this->assertEquals(4, Arr::after($array, 3));
+        $this->assertEquals(2, Arr::after($array, 4));
+        $this->assertSame('taylor', Arr::after($array, 5));
+        $this->assertSame('laravel', Arr::after($array, 'taylor'));
+
+        $this->assertEquals(4, Arr::after($array, fn ($value) => $value > 2));
+        $this->assertSame('laravel', Arr::after($array, fn ($value) => ! is_numeric($value)));
+    }
+
+    public function testAfterInStrictMode()
+    {
+        $array = [false, 0, 1, [], ''];
+
+        $this->assertNull(Arr::after($array, 'false', true));
+        $this->assertNull(Arr::after($array, '1', true));
+        $this->assertNull(Arr::after($array, '', true));
+        $this->assertEquals(0, Arr::after($array, false, true));
+        $this->assertSame([], Arr::after($array, 1, true));
+        $this->assertSame('', Arr::after($array, [], true));
+    }
+
+    public function testAfterReturnsNullWhenItemIsNotFound()
+    {
+        $array = [1, 2, 3, 4, 5, 'foo' => 'bar'];
+
+        $this->assertNull(Arr::after($array, 6));
+        $this->assertNull(Arr::after($array, 'foo'));
+        $this->assertNull(Arr::after($array, fn ($value) => $value < 1 && is_numeric($value)));
+        $this->assertNull(Arr::after($array, fn ($value) => $value === 'nope'));
+    }
+
+    public function testAfterReturnsNullWhenItemOnTheLastItem()
+    {
+        $array = [1, 2, 3, 4, 5, 'foo' => 'bar'];
+
+        $this->assertNull(Arr::after($array, 'bar'));
+        $this->assertNull(Arr::after($array, fn ($value) => $value > 4 && ! is_numeric($value)));
+
+        $this->assertNull(Arr::after(['foo' => 'bar', 1, 2, 3, 4, 5], 5));
+    }
+
     public function testPush()
     {
         $array = [];


### PR DESCRIPTION
This PR adds `before()` and `after()` methods to the `Arr` helper, mirroring the
existing `Collection::before()` and `Collection::after()` methods. They return the
item immediately before / after a given value in an array, closing an API-parity gap
between `Arr` and `Collection`.

Like their `Collection` counterparts, both accept either a value or a callable
predicate, and support strict comparison.

```php
use Illuminate\Support\Arr;

$array = [1, 2, 3, 4, 5];

Arr::before($array, 3); // 2
Arr::after($array, 3);  // 4

// Callable predicate
Arr::after($array, fn ($value) => $value > 2); // 4
// Strict comparison
Arr::before([false, 0, 1], 1, strict: true); // 0

// null at the boundaries or when not found
Arr::before($array, 1); // null (first item)
Arr::after($array, 5);  // null (last item)
Arr::after($array, 99); // null (not found)

Works with string and mixed keys as well, and returns null when the value is the
first/last element or isn't present — matching Collection behavior exactly.

A few notes:
- Laravel prefers a **concise** description with a usage example — the above fits that style. Keep it short; Taylor often trims further.
- If GitHub's template asks, there are **no breaking changes** (purely additive) and it targets `master`.
- Tests are included (`tests/Support/SupportArrTest.php`), so no separate note needed, but you can mention "Tests included" if you like.

