### PR TITLE
[13.x] Add a `MessageFailed` event

### DIFF
--- a/src/Illuminate/Mail/Events/MessageFailed.php
+++ b/src/Illuminate/Mail/Events/MessageFailed.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+use Symfony\Component\Mime\Email;
+use Throwable;
+
+class MessageFailed
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Symfony\Component\Mime\Email  $message  The Symfony Email instance.
+     * @param  \Throwable  $exception  The exception that was thrown while sending the message.
+     * @param  array  $data  The message data.
+     */
+    public function __construct(
+        public Email $message,
+        public Throwable $exception,
+        public array $data = [],
+    ) {
+    }
+}

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Queue\Factory as QueueContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Events\MessageFailed;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailables\Address;
@@ -21,6 +22,7 @@ use InvalidArgumentException;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Email;
+use Throwable;
 
 class Mailer implements MailerContract, MailQueueContract
 {
@@ -329,7 +331,13 @@ class Mailer implements MailerContract, MailQueueContract
         $symfonyMessage = $message->getSymfonyMessage();
 
         if ($this->shouldSendMessage($symfonyMessage, $data)) {
-            $symfonySentMessage = $this->sendSymfonyMessage($symfonyMessage);
+            try {
+                $symfonySentMessage = $this->sendSymfonyMessage($symfonyMessage);
+            } catch (Throwable $e) {
+                $this->dispatchFailedEvent($symfonyMessage, $e, $data);
+
+                throw $e;
+            }
 
             if ($symfonySentMessage) {
                 $sentMessage = new SentMessage($symfonySentMessage);
@@ -621,6 +629,21 @@ class Mailer implements MailerContract, MailQueueContract
     {
         $this->events?->dispatch(
             new MessageSent($message, $data)
+        );
+    }
+
+    /**
+     * Dispatch the message failed event.
+     *
+     * @param  \Symfony\Component\Mime\Email  $message
+     * @param  \Throwable  $exception
+     * @param  array  $data
+     * @return void
+     */
+    protected function dispatchFailedEvent($message, $exception, $data = [])
+    {
+        $this->events?->dispatch(
+            new MessageFailed($message, $exception, $data)
         );
     }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Mail;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Events\MessageFailed;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailer;
@@ -13,6 +14,8 @@ use Illuminate\Support\HtmlString;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Address;
 
 class MailMailerTest extends TestCase
@@ -332,6 +335,45 @@ class MailMailerTest extends TestCase
         $mailer->send('foo', ['data'], function (Message $message) {
             $message->to('taylor@laravel.com')->from('hello@laravel.com');
         });
+    }
+
+    public function testFailedEventIsDispatchedWhenSendingFails(): void
+    {
+        $view = Mockery::mock(Factory::class);
+        $view->expects('make')->andReturn($view);
+        $view->expects('render')->andReturn('rendered.view');
+
+        $exception = new RuntimeException('Connection could not be established.');
+
+        $transport = Mockery::mock(TransportInterface::class);
+        $transport->expects('send')->andThrow($exception);
+
+        $event = null;
+
+        $events = Mockery::mock(Dispatcher::class);
+        $events->expects('until')->with(Mockery::type(MessageSending::class));
+        $events->expects('dispatch')
+            ->with(Mockery::type(MessageFailed::class))
+            ->andReturnUsing(function ($dispatched) use (&$event) {
+                $event = $dispatched;
+            });
+
+        $mailer = new Mailer('array', $view, $transport, $events);
+
+        try {
+            $mailer->send('foo', ['data'], function (Message $message) {
+                $message->to('taylor@laravel.com')->from('hello@laravel.com');
+            });
+
+            $this->fail('The transport exception was not re-thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame($exception, $e);
+        }
+
+        $this->assertInstanceOf(MessageFailed::class, $event);
+        $this->assertSame($exception, $event->exception);
+        $this->assertSame('taylor@laravel.com', $event->message->getTo()[0]->getAddress());
+        $this->assertSame('array', $event->data['mailer']);
     }
 
     public function testMacroable(): void


### PR DESCRIPTION
This PR adds a `MessageFailed` event that is dispatched when the transport throws while sending a message.

`MessageSending` and `MessageSent` already exist, but there is currently no way to observe a failed send without wrapping every call in a try / catch:

```php
Event::listen(function (MessageFailed $event) {
    Log::error('Mail delivery failed.', [
        'to' => $event->message->getTo(),
        'error' => $event->exception->getMessage(),
    ]);
});
```

The exception is always re-thrown, so nothing changes for applications that don't listen for the event.