### PR TITLE
[13.x] Support array commands in process fake assertions

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -177,12 +177,12 @@ class Factory
     /**
      * Assert that a process was recorded matching a given truth test.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|array<array-key, string>|string  $callback
      * @return $this
      */
-    public function assertRan(Closure|string $callback)
+    public function assertRan(Closure|array|string $callback)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
 
         PHPUnit::assertTrue(
             (new Collection($this->recorded))->contains(function ($pair) use ($callback) {
@@ -197,13 +197,13 @@ class Factory
     /**
      * Assert that a process was recorded a given number of times matching a given truth test.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|array<array-key, string>|string  $callback
      * @param  int  $times
      * @return $this
      */
-    public function assertRanTimes(Closure|string $callback, int $times = 1)
+    public function assertRanTimes(Closure|array|string $callback, int $times = 1)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
 
         $count = (new Collection($this->recorded))
             ->filter(fn ($pair) => $callback($pair[0], $pair[1]))
@@ -220,7 +220,7 @@ class Factory
     /**
      * Assert that the given processes were run in the given order.
      *
-     * @param  list<\Closure|string>  $callbacks
+     * @param  list<\Closure|array<array-key, string>|string>  $callbacks
      * @return $this
      */
     public function assertRanInOrder(array $callbacks)
@@ -257,12 +257,12 @@ class Factory
     /**
      * Assert that a process was not recorded matching a given truth test.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|array<array-key, string>|string  $callback
      * @return $this
      */
-    public function assertNotRan(Closure|string $callback)
+    public function assertNotRan(Closure|array|string $callback)
     {
-        $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
 
         PHPUnit::assertTrue(
             (new Collection($this->recorded))->doesntContain(function ($pair) use ($callback) {
@@ -277,10 +277,10 @@ class Factory
     /**
      * Assert that a process was not recorded matching a given truth test.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|array<array-key, string>|string  $callback
      * @return $this
      */
-    public function assertDidntRun(Closure|string $callback)
+    public function assertDidntRun(Closure|array|string $callback)
     {
         return $this->assertNotRan($callback);
     }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1215,6 +1215,20 @@ class ProcessTest extends TestCase
         $factory->assertRanInOrder(['git fetch', 'composer install']);
     }
 
+    public function testFakeAssertionsWithArrayCommands()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run(['php', 'artisan', 'migrate']);
+
+        $factory->assertRan(['php', 'artisan', 'migrate']);
+        $factory->assertRanTimes(['php', 'artisan', 'migrate'], 1);
+        $factory->assertNotRan(['php', 'artisan', 'migrate:rollback']);
+        $factory->assertDidntRun(['php', 'artisan', 'migrate:rollback']);
+        $factory->assertRanInOrder([['php', 'artisan', 'migrate']]);
+    }
+
     public function testAssertingThatNothingRan()
     {
         $factory = new Factory;


### PR DESCRIPTION
Processes may be invoked using an array of arguments, but the fake assertions only accept a command string. This PR allows them to accept the same array the process was invoked with:

```php
Process::run(['git', 'commit', '-m', $message]);

Process::assertRan(['git', 'commit', '-m', $message]);
```

Passing a string continues to work as before.