### PR TITLE
[13.x] Make the Redis queue driver cluster-safe (`bulk()` node-less `MULTI`; `allQueueNames()` uses `KEYS`)

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -40,6 +40,30 @@ LUA;
     }
 
     /**
+     * Get the Lua script for pushing an array of jobs onto the queue.
+     *
+     * KEYS[1] - The queue to push the jobs onto, for example: queues:foo
+     * KEYS[2] - The notification list for the queue we are pushing jobs onto, for example: queues:foo:notify
+     * ARGV    - The job payloads
+     *
+     * @return string
+     */
+    public static function bulkPush()
+    {
+        return <<<'LUA'
+-- Push the jobs onto the queue in chunks of 100...
+for i = 1, #ARGV, 100 do
+    redis.call('rpush', KEYS[1], unpack(ARGV, i, math.min(i+99, #ARGV)))
+end
+
+-- Push a notification for every job that was pushed...
+for i = 1, #ARGV do
+    redis.call('rpush', KEYS[2], 1)
+end
+LUA;
+    }
+
+    /**
      * Get the Lua script for pushing delayed jobs onto the queue.
      *
      * KEYS[1] - The delayed queue to push the job onto, for example: queues:foo:delayed

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -284,8 +284,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
             return $connection->keys('queues:*');
         }
 
-        // Unlike keys(), phpredis does not apply the connection prefix to a SCAN match pattern...
-        $match = $connection->_prefix('queues:*');
+        $match = defined('Redis::SCAN_PREFIX') &&
+            $connection->client()->getOption(\Redis::OPT_SCAN) === \Redis::SCAN_PREFIX
+                ? 'queues:*'
+                : $connection->_prefix('queues:*');
 
         $keys = [];
         $cursor = version_compare(phpversion('redis'), '6.1.0', '>=') ? null : '0';

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -264,11 +264,48 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function allQueueNames(): Collection
     {
-        return (new Collection($this->getConnection()->keys('queues:*')))
+        return (new Collection($this->scanQueueKeys()))
             // Trim to ensure clusters get their braces removed...
             ->map(fn ($key) => trim(Str::between($key, 'queues:', ':'), '{}'))
             ->unique()
             ->values();
+    }
+
+    /**
+     * Get all of the queue keys from the underlying connection.
+     *
+     * @return array<int, string>
+     */
+    protected function scanQueueKeys(): array
+    {
+        $connection = $this->getConnection();
+
+        if (! $connection instanceof PhpRedisClusterConnection) {
+            return $connection->keys('queues:*');
+        }
+
+        // Unlike keys(), phpredis does not apply the connection prefix to a SCAN match pattern...
+        $match = $connection->_prefix('queues:*');
+
+        $keys = [];
+        $cursor = version_compare(phpversion('redis'), '6.1.0', '>=') ? null : '0';
+        $defaultCursorValue = $cursor;
+
+        do {
+            $result = $connection->scan($cursor, ['match' => $match, 'count' => 1000]);
+
+            if (! is_array($result)) {
+                break;
+            }
+
+            [$cursor, $batch] = $result;
+
+            if (is_array($batch)) {
+                $keys = array_merge($keys, $batch);
+            }
+        } while (((string) $cursor) !== ((string) $defaultCursorValue));
+
+        return array_values(array_unique($keys));
     }
 
     /**
@@ -315,11 +352,68 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         };
 
         if ($connection instanceof PhpRedisClusterConnection) {
-            $connection->transaction($bulk);
+            // A cluster MULTI must target a single node, but transaction()/multi() is node-less
+            // while the pushes inside route to the queue's own {hash tag} slot, so the
+            // transaction silently fails and drops every job. Since every job in the bulk
+            // targets the same queue - and therefore the same slot - the payloads are pushed
+            // in single slot Lua scripts instead, which the cluster routes correctly...
+            $this->bulkOnClusterConnection($jobs, $data, $queue);
         } elseif ($connection instanceof PredisClusterConnection) {
             $connection->pipeline($bulk);
         } else {
             $connection->pipeline(fn () => $connection->transaction($bulk));
+        }
+    }
+
+    /**
+     * Push an array of jobs onto the queue on a cluster connection.
+     *
+     * Every job in the bulk targets the same queue - and therefore the same key
+     * slot - so the payloads are collected and pushed with a single slot Lua
+     * script, keeping the events of pushing each job. Delayed jobs use a separate
+     * key and after-commit jobs must wait for their transaction to commit, so
+     * both are pushed through the usual per-job path.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  \UnitEnum|string|null  $queue
+     * @return void
+     */
+    protected function bulkOnClusterConnection($jobs, $data = '', $queue = null)
+    {
+        $payloads = [];
+
+        foreach ((array) $jobs as $job) {
+            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+            if (isset($delay)) {
+                $this->later($delay, $job, $data, $queue);
+            } elseif ($this->shouldDispatchAfterCommit($job)) {
+                $this->push($job, $data, $queue);
+            } else {
+                $this->enqueueUsing(
+                    $job,
+                    $this->createPayload($job, $this->getQueue($queue), $data),
+                    $queue,
+                    null,
+                    function ($payload) use (&$payloads) {
+                        $payloads[] = $payload;
+
+                        return json_decode($payload, true)['id'] ?? null;
+                    }
+                );
+            }
+        }
+
+        if (! empty($payloads)) {
+            $queueKey = $this->getQueueRedisKey($queue);
+
+            // Push the payloads in chunks so one very large bulk cannot occupy the node...
+            foreach (array_chunk($payloads, 1000) as $chunk) {
+                $this->getConnection()->eval(
+                    LuaScripts::bulkPush(), 2, $queueKey, $queueKey.':notify', ...$chunk
+                );
+            }
         }
     }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -354,11 +354,6 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         };
 
         if ($connection instanceof PhpRedisClusterConnection) {
-            // A cluster MULTI must target a single node, but transaction()/multi() is node-less
-            // while the pushes inside route to the queue's own {hash tag} slot, so the
-            // transaction silently fails and drops every job. Since every job in the bulk
-            // targets the same queue - and therefore the same slot - the payloads are pushed
-            // in single slot Lua scripts instead, which the cluster routes correctly...
             $this->bulkOnClusterConnection($jobs, $data, $queue);
         } elseif ($connection instanceof PredisClusterConnection) {
             $connection->pipeline($bulk);
@@ -372,9 +367,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * Every job in the bulk targets the same queue - and therefore the same key
      * slot - so the payloads are collected and pushed with a single slot Lua
-     * script, keeping the events of pushing each job. Delayed jobs use a separate
-     * key and after-commit jobs must wait for their transaction to commit, so
-     * both are pushed through the usual per-job path.
+     * script. Delayed jobs and "after commit" jobs are pushed like normal.
      *
      * @param  array  $jobs
      * @param  mixed  $data

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Queue;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Jobs\InspectedJob;
@@ -762,9 +763,104 @@ class RedisQueueTest extends TestCase
 
         $this->assertSame(2, $this->queue->totalReservedSize());
     }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testBulkPushesAllJobsOntoQueue($driver)
+    {
+        $this->setQueue($driver, 'default');
+
+        $this->queue->bulk([
+            new RedisQueueIntegrationTestJob(1),
+            new RedisQueueIntegrationTestJob(2),
+            new RedisQueueIntegrationTestJob(3),
+        ], '', 'bulk-test');
+
+        $this->assertSame(3, $this->queue->size('bulk-test'));
+
+        $seen = [];
+
+        for ($i = 0; $i < 3; $i++) {
+            $seen[] = unserialize(json_decode($this->queue->pop('bulk-test')->getRawBody())->data->command)->i;
+        }
+
+        sort($seen);
+
+        $this->assertSame([1, 2, 3], $seen);
+        $this->assertNull($this->queue->pop('bulk-test'));
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testBulkPushesDelayedJobsOntoDelayedQueue($driver)
+    {
+        $this->setQueue($driver, 'default');
+
+        $this->queue->bulk([
+            new RedisQueueIntegrationTestJob(1),
+            new RedisQueueIntegrationTestDelayedJob(2),
+        ], '', 'bulk-delay');
+
+        $redisKey = $this->getQueueRedisKey('bulk-delay');
+
+        $this->assertSame(1, $this->redis[$driver]->connection()->llen($redisKey));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testBulkPushesManyJobsOntoQueue($driver)
+    {
+        $this->setQueue($driver, 'default');
+
+        $jobs = [];
+
+        for ($i = 0; $i < 1050; $i++) {
+            $jobs[] = new RedisQueueIntegrationTestJob($i);
+        }
+
+        $this->queue->bulk($jobs, '', 'bulk-many');
+
+        $redisKey = $this->getQueueRedisKey('bulk-many');
+
+        $this->assertSame(1050, $this->queue->size('bulk-many'));
+        $this->assertSame(1050, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testAllQueueNamesReturnsQueuesAcrossMultipleQueues($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $this->queue->push(new RedisQueueIntegrationTestJob(1));
+        $this->queue->pushOn('emails', new RedisQueueIntegrationTestJob(2));
+        $this->queue->pushOn('notifications', new RedisQueueIntegrationTestJob(3));
+
+        $names = (new \ReflectionMethod($this->queue, 'allQueueNames'))
+            ->invoke($this->queue)
+            ->sort()
+            ->values()
+            ->all();
+
+        $this->assertSame([$default, 'emails', 'notifications'], $names);
+    }
 }
 
 class RedisQueueIntegrationTestJob
+{
+    public $i;
+
+    public function __construct($i)
+    {
+        $this->i = $i;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[Delay(60)]
+class RedisQueueIntegrationTestDelayedJob
 {
     public $i;
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -13,6 +13,7 @@ use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class QueueRedisQueueTest extends TestCase
@@ -456,6 +457,25 @@ class QueueRedisQueueTest extends TestCase
         $queue = new TestableRedisQueue($redis, 'default');
 
         $this->assertSame(['default', 'emails'], $queue->testAllQueueNames()->all());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testScanningQueueNamesDoesNotDoublePrefixTheMatchPattern()
+    {
+        $redis = Mockery::mock(Factory::class);
+        $connection = Mockery::mock(PhpRedisClusterConnection::class);
+        $client = Mockery::mock();
+
+        $redis->expects('connection')->andReturn($connection);
+        $connection->expects('client')->andReturn($client);
+        $client->expects('getOption')->with(\Redis::OPT_SCAN)->andReturn(\Redis::SCAN_PREFIX);
+        $connection->expects('scan')
+            ->with(null, ['match' => 'queues:*', 'count' => 1000])
+            ->andReturn([null, ['test_queues:{default}']]);
+
+        $queue = new TestableRedisQueue($redis, 'default');
+
+        $this->assertSame(['default'], $queue->testAllQueueNames()->all());
     }
 
     public function testSizeResolvesTheQueueNameFromAnEnum()


### PR DESCRIPTION
Fixes two Redis-Cluster issues in the queue driver, both gated to phpredis cluster connections so non-cluster behavior is unchanged:

1. **`RedisQueue::bulk()` silently drops batched jobs.** On a `PhpRedisClusterConnection` it wraps its pushes in `transaction()`, which calls `RedisCluster::multi()` with **no node**. A cluster transaction must bind to one node, but the pushes route to the queue's `{hash tag}` slot. So `exec()` returns `false` with **no exception**, the jobs never enqueue, and the connection is poisoned. `Bus::batch()` therefore reports success and records `pending_jobs`, but the batch is stuck forever. Only real multi-shard clusters hit it (a single-node cluster hides it).

    **Fix:** every job in a `bulk()` targets the same queue — and therefore the same key slot — so the cluster branch now collects the payloads and pushes them with a single-slot Lua script (`LuaScripts::bulkPush()`), in chunks of 1,000, which the cluster routes correctly. A script is used rather than pushing each job individually because `RedisCluster` cannot pipeline, so per-job pushes would cost one round trip per job — a `Bus::batch()` of thousands of jobs would take thousands of sequential round trips. Each payload is still routed through `enqueueUsing()`, so the `JobQueueing`/`JobQueued` events, after-commit deferral, and rollback callbacks of pushing each job are preserved (the existing `testBulkJobQueuedEvent` passes unchanged). Delayed (`#[Delay]`) jobs use a separate key and keep the usual per-job path. This is the same "special-case the cluster connection" pattern the framework already uses in `Cache\RedisStore::putMany()`, `RedisTaggedCache::flush()`, and `RedisBroadcaster`.

2. **`RedisQueue::allQueueNames()` uses `KEYS('queues:*')`**, which is unavailable on managed clusters (e.g. ElastiCache Serverless) and, where available, enumerates per-node (partial on multi-shard). Fix: on a cluster connection, `SCAN` across all master nodes instead. Since #61231, `allQueueNames()` also backs `totalPendingSize()` / `totalDelayedSize()` / `totalReservedSize()`, so this is no longer only reachable through `Queue::all*Jobs()`.

Non-cluster and Predis paths are untouched. Adds cluster + non-cluster tests for both, including a 1,050-job bulk that crosses the script's chunk boundaries and verifies `:notify` parity. Verified against a real 3-node Redis Cluster (both fixes) and standalone Redis.
