### PR TITLE
More Mockery cleanup

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -244,7 +244,7 @@ class AuthenticateMiddlewareTest extends TestCase
     {
         return new RequestGuard(function () use ($authenticated) {
             return $authenticated ? new stdClass : null;
-        }, Mockery::mock(Request::class), Mockery::mock(EloquentUserProvider::class));
+        }, new Request, Mockery::mock(EloquentUserProvider::class));
     }
 
     /**

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -133,8 +133,8 @@ class ConsoleApplicationTest extends TestCase
     public function testCallFullyStringCommandLine()
     {
         $artisan = new Application(
-            Mockery::mock(ApplicationContract::class, ['version' => '6.0']),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            $app = Mockery::mock(ApplicationContract::class, ['version' => '6.0']),
+            new EventsDispatcher($app),
             'testing'
         );
 
@@ -161,7 +161,7 @@ class ConsoleApplicationTest extends TestCase
     {
         $artisan = new Application(
             $laravel = new FoundationApplication(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            new EventsDispatcher($laravel),
             'testing'
         );
 
@@ -179,8 +179,8 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputDoesntPromptWhenRequiredArgumentIsPassed()
     {
         $artisan = new Application(
-            new FoundationApplication(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            $laravel = new FoundationApplication(__DIR__),
+            new EventsDispatcher($laravel),
             'testing'
         );
 
@@ -199,7 +199,7 @@ class ConsoleApplicationTest extends TestCase
     {
         $artisan = new Application(
             $laravel = new FoundationApplication(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            new EventsDispatcher($laravel),
             'testing'
         );
 
@@ -217,8 +217,8 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputDoesntPromptWhenRequiredArgumentsArePassed()
     {
         $artisan = new Application(
-            new FoundationApplication(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            $laravel = new FoundationApplication(__DIR__),
+            new EventsDispatcher($laravel),
             'testing'
         );
 
@@ -237,7 +237,7 @@ class ConsoleApplicationTest extends TestCase
     {
         $artisan = new Application(
             $laravel = new FoundationApplication(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null]),
+            new EventsDispatcher($laravel),
             'testing'
         );
 

--- a/tests/Console/Fixtures/FakeEventMutex.php
+++ b/tests/Console/Fixtures/FakeEventMutex.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\EventMutex;
+
+class FakeEventMutex implements EventMutex
+{
+    public function create(Event $event)
+    {
+    }
+
+    public function exists(Event $event)
+    {
+    }
+
+    public function forget(Event $event)
+    {
+    }
+}

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -3,9 +3,8 @@
 namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
-use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Support\Carbon;
-use Mockery;
+use Illuminate\Tests\Console\Fixtures\FakeEventMutex;
 use PHPUnit\Framework\TestCase;
 
 class FrequencyTest extends TestCase
@@ -15,10 +14,7 @@ class FrequencyTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->event = new Event(
-            Mockery::mock(EventMutex::class),
-            'php foo'
-        );
+        $this->event = new Event(new FakeEventMutex, 'php foo');
     }
 
     public function testEveryMinute()

--- a/tests/Foundation/Console/ChannelListCommandTest.php
+++ b/tests/Foundation/Console/ChannelListCommandTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Console\Application;
 use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application as FoundationApplication;
 use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Support\Collection;
@@ -49,7 +48,7 @@ class ChannelListCommandTest extends TestCase
 
         $artisan = new Application(
             $laravel,
-            Mockery::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            new \Illuminate\Events\Dispatcher($laravel),
             'testing'
         );
 

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -3,11 +3,9 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Console\Application;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Routing\Router;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class RouteListCommandTest extends TestCase
@@ -18,11 +16,11 @@ class RouteListCommandTest extends TestCase
     {
         $this->app = new Application(
             $laravel = new \Illuminate\Foundation\Application(__DIR__),
-            Mockery::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            new \Illuminate\Events\Dispatcher($laravel),
             'testing',
         );
 
-        $router = new Router(Mockery::mock('Illuminate\Events\Dispatcher'));
+        $router = new Router(new \Illuminate\Events\Dispatcher($laravel));
 
         $kernel = new class($laravel, $router) extends Kernel
         {
@@ -250,7 +248,7 @@ class RouteListCommandTest extends TestCase
     public function testControllerRoutePathIsNull()
     {
         $laravel = new \Illuminate\Foundation\Application(__DIR__);
-        $router = new Router(Mockery::mock('Illuminate\Events\Dispatcher'));
+        $router = new Router(new \Illuminate\Events\Dispatcher($laravel));
 
         $kernel = new class($laravel, $router) extends Kernel
         {
@@ -266,7 +264,7 @@ class RouteListCommandTest extends TestCase
 
         $app = new Application(
             $laravel,
-            Mockery::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            new \Illuminate\Events\Dispatcher($laravel),
             'testing',
         );
         $app->addCommands([$command]);

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Encryption\Encrypter;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
-use Mockery;
 use Orchestra\Testbench\TestCase;
 
 class EnvironmentDecryptCommandTest extends TestCase
@@ -16,10 +14,9 @@ class EnvironmentDecryptCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->filesystem = Mockery::spy(Filesystem::class);
+        $this->filesystem = File::spy();
         $this->filesystem->shouldReceive('put')
             ->andReturn(true);
-        File::swap($this->filesystem);
     }
 
     public function testItFailsWithInvalidCipherFails(): void

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -16,10 +16,9 @@ class EnvironmentEncryptCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->filesystem = Mockery::spy(Filesystem::class);
+        $this->filesystem = File::spy();
         $this->filesystem->shouldReceive('get')->andReturn(true);
         $this->filesystem->shouldReceive('put')->andReturn('APP_NAME=Laravel');
-        File::swap($this->filesystem);
     }
 
     public function testItFailsWithInvalidCipherFails(): void
@@ -134,17 +133,18 @@ class EnvironmentEncryptCommandTest extends TestCase
 
     public function testItEncryptsInReadableFormat(): void
     {
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn("APP_NAME=Laravel\nAPP_ENV=local");
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) {
                 $lines = explode("\n", rtrim($content));
 
@@ -153,7 +153,6 @@ class EnvironmentEncryptCommandTest extends TestCase
                     && str_starts_with($lines[1], 'APP_ENV=');
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
             ->expectsOutputToContain('Environment successfully encrypted')
@@ -162,17 +161,18 @@ class EnvironmentEncryptCommandTest extends TestCase
 
     public function testItSkipsCommentsAndBlankLinesInReadableFormat(): void
     {
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn("# Comment\nAPP_NAME=Laravel\n\nAPP_ENV=local");
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) {
                 $lines = explode("\n", rtrim($content));
 
@@ -182,7 +182,6 @@ class EnvironmentEncryptCommandTest extends TestCase
                     && str_starts_with($lines[1], 'APP_ENV=');
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
             ->expectsOutputToContain('Environment successfully encrypted')
@@ -205,24 +204,24 @@ ENV;
 
         $encryptedOutput = null;
 
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn($originalContent);
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) use (&$encryptedOutput) {
                 $encryptedOutput = $content;
 
                 return true;
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
             ->expectsOutputToContain('Environment successfully encrypted')
@@ -255,24 +254,24 @@ ENV;
 
         $encryptedOutput = null;
 
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn($originalContent);
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) use (&$encryptedOutput) {
                 $encryptedOutput = $content;
 
                 return true;
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
             ->expectsOutputToContain('Environment successfully encrypted')
@@ -306,24 +305,24 @@ ENV;
 
         $encryptedOutput = null;
 
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn($originalContent);
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) use (&$encryptedOutput) {
                 $encryptedOutput = $content;
 
                 return true;
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
             ->expectsOutputToContain('Environment successfully encrypted')
@@ -356,24 +355,24 @@ ENV;
 
         $encryptedOutput = null;
 
-        $filesystem = Mockery::mock(Filesystem::class);
-        $filesystem->expects('exists')
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
             ->with(base_path('.env'))
             ->andReturn(true);
-        $filesystem->expects('exists')
+        File::expects('exists')
             ->with(base_path('.env.encrypted'))
             ->andReturn(false);
-        $filesystem->expects('get')
+        File::expects('get')
             ->with(base_path('.env'))
             ->andReturn($originalContent);
-        $filesystem->expects('put')
+        File::expects('put')
             ->with(base_path('.env.encrypted'), Mockery::on(function ($content) use (&$encryptedOutput) {
                 $encryptedOutput = $content;
 
                 return true;
             }))
             ->andReturn(true);
-        File::swap($filesystem);
 
         $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
             ->expectsOutputToContain('Environment successfully encrypted')

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -6,16 +6,25 @@ use Exception;
 use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Support\Stringable;
-use Mockery;
+use Illuminate\Tests\Console\Fixtures\FakeEventMutex;
 use Orchestra\Testbench\TestCase;
 
 class CallbackEventTest extends TestCase
 {
+    private EventMutex $mutex;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mutex = new FakeEventMutex;
+    }
+
     public function testDefaultResultIsSuccess()
     {
         $success = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
         }))->onSuccess(function () use (&$success) {
             $success = true;
         })->onFailure(function () use (&$success) {
@@ -31,7 +40,7 @@ class CallbackEventTest extends TestCase
     {
         $success = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
             return false;
         }))->onSuccess(function () use (&$success) {
             $success = true;
@@ -48,7 +57,7 @@ class CallbackEventTest extends TestCase
     {
         $success = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
             throw new Exception;
         }))->onSuccess(function () use (&$success) {
             $success = true;
@@ -66,7 +75,7 @@ class CallbackEventTest extends TestCase
 
     public function testExceptionBubbles()
     {
-        $event = new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = new CallbackEvent($this->mutex, function () {
             throw new Exception;
         });
 
@@ -79,7 +88,7 @@ class CallbackEventTest extends TestCase
     {
         $callbackEvent = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
         }))->onSuccess(function (CallbackEvent $event) use (&$callbackEvent) {
             $callbackEvent = $event;
         });
@@ -93,7 +102,7 @@ class CallbackEventTest extends TestCase
     {
         $callbackEvent = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
             return false;
         }))->onFailure(function (CallbackEvent $event) use (&$callbackEvent) {
             $callbackEvent = $event;
@@ -109,7 +118,7 @@ class CallbackEventTest extends TestCase
         $callbackEvent = null;
         $outputValue = null;
 
-        $event = (new CallbackEvent(Mockery::mock(EventMutex::class), function () {
+        $event = (new CallbackEvent($this->mutex, function () {
         }))->onSuccess(function (Stringable $output, CallbackEvent $event) use (&$callbackEvent, &$outputValue) {
             $callbackEvent = $event;
             $outputValue = (string) $output;

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -8,9 +8,9 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Console\Scheduling\Event;
-use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Tests\Console\Fixtures\FakeEventMutex;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 
@@ -30,7 +30,7 @@ class EventPingTest extends TestCase
 
         $this->swap(HttpClient::class, $httpMock);
 
-        $event = new Event(Mockery::mock(EventMutex::class), 'php -i');
+        $event = new Event(new FakeEventMutex, 'php -i');
 
         $thenCalled = false;
 

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Cookie;
 
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Response;
 use Illuminate\Session\NullSessionHandler;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
-use Mockery;
 use Orchestra\Testbench\TestCase;
 
 class CookieTest extends TestCase
@@ -44,10 +43,7 @@ class CookieTest extends TestCase
 
     protected function defineEnvironment($app)
     {
-        $handler = Mockery::mock(ExceptionHandler::class)->shouldIgnoreMissing();
-        $app->instance(ExceptionHandler::class, $handler);
-
-        $handler->shouldReceive('render')->andReturn(new Response);
+        Exceptions::spy()->shouldReceive('render')->andReturn(new Response);
 
         $app['config']->set('app.key', Str::random(32));
         $app['config']->set('session.driver', 'fake-null');

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Foundation\Exceptions\Renderer\Listener;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
 use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Mockery;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
@@ -102,7 +103,7 @@ class RendererTest extends TestCase
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
+        Event::swap(Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -127,7 +128,7 @@ class RendererTest extends TestCase
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
+        Event::swap(Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -143,7 +144,7 @@ class RendererTest extends TestCase
         $listener->expects('registerListeners');
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
+        Event::swap(Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -16,7 +16,7 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
-use Mockery as m;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -53,7 +53,7 @@ class MaintenanceModeTest extends TestCase
 
     public function testCacheMaintenanceModeAllowsRequestWhenDeactivatedWhileReadingPayload()
     {
-        $cache = m::mock(Factory::class, Repository::class);
+        $cache = Mockery::mock(Factory::class, Repository::class);
         $cache->shouldReceive('store')->with('maintenance')->andReturnSelf();
         $cache->shouldReceive('has')->with('framework:down')->andReturn(true, false);
         $cache->shouldReceive('get')->once()->with('framework:down')->andReturnNull();

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -12,6 +11,7 @@ use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Queue;
 use Mockery;
@@ -198,11 +198,8 @@ class WorkCommandTest extends QueueTestCase
         $cache->expects('get')->with('illuminate:queues:paused')->andReturn(null);
         $cache->expects('many')->andReturn([]);
 
-        $cacheManager = Mockery::mock(CacheManager::class);
-        $cacheManager->expects('driver')->times(2)->andReturn($cache);
-        $cacheManager->expects('store')->andReturn($cache);
-
-        $this->app->instance('cache', $cacheManager);
+        Cache::expects('driver')->times(2)->andReturn($cache);
+        Cache::expects('store')->andReturn($cache);
 
         Queue::push(new FirstJob);
 
@@ -228,11 +225,8 @@ class WorkCommandTest extends QueueTestCase
         $cache->expects('get')->times(2)->with('illuminate:queue:restart')->andReturn(null);
         $cache->shouldNotReceive('many');
 
-        $cacheManager = Mockery::mock(CacheManager::class);
-        $cacheManager->expects('driver')->times(2)->andReturn($cache);
-        $cacheManager->shouldNotReceive('store');
-
-        $this->app->instance('cache', $cacheManager);
+        Cache::expects('driver')->times(2)->andReturn($cache);
+        Cache::shouldNotReceive('store');
 
         Queue::push(new FirstJob);
 

--- a/tests/Integration/Session/SessionPersistenceTest.php
+++ b/tests/Integration/Session/SessionPersistenceTest.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Session;
 
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Response;
 use Illuminate\Session\NullSessionHandler;
 use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
-use Mockery;
 use Orchestra\Testbench\TestCase;
 
 class SessionPersistenceTest extends TestCase
@@ -33,10 +32,7 @@ class SessionPersistenceTest extends TestCase
 
     protected function defineEnvironment($app)
     {
-        $handler = Mockery::mock(ExceptionHandler::class)->shouldIgnoreMissing();
-        $app->instance(ExceptionHandler::class, $handler);
-
-        $handler->expects('render')->andReturn(new Response);
+        Exceptions::spy()->expects('render')->andReturn(new Response);
 
         $app['config']->set('app.key', Str::random(32));
         $app['config']->set('session.driver', 'fake-null');

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\Component;
-use Mockery;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Finder\Finder;
@@ -249,10 +248,7 @@ class BladeTest extends TestCase
         View::addNamespace('templates', join_paths(__DIR__, 'templates'));
         View::addNamespace('components', join_paths(__DIR__, 'templates', 'components'));
 
-        $compiler = Mockery::mock(app('blade.compiler'))->makePartial();
-        $compiler->expects('compile')->with(realpath(__DIR__.'/templates/components/panel.blade.php'));
-
-        $this->instance('blade.compiler', $compiler);
+        Blade::partialMock()->expects('compile')->with(realpath(__DIR__.'/templates/components/panel.blade.php'));
 
         $this->artisan('view:cache');
     }

--- a/tests/Integration/View/ClearCommandTest.php
+++ b/tests/Integration/View/ClearCommandTest.php
@@ -2,44 +2,24 @@
 
 namespace Illuminate\Tests\Integration\View;
 
-use Illuminate\Container\Container;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Console\ViewClearCommand;
-use Mockery;
+use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase;
 
 class ClearCommandTest extends TestCase
 {
-    private $files;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->files = Mockery::mock(Filesystem::class);
-        Container::setInstance($this->app);
-        $this->app->instance('files', $this->files);
-    }
-
-    protected function tearDown(): void
-    {
-        Container::setInstance(null);
-
-        parent::tearDown();
-    }
-
     public function test_clear_view_command_should_remove_parallel_test_directories()
     {
         $globResult = [
             '/views/cache/path/filehash123.php',
             '/views/cache/path/test_33',
         ];
-        $this->files->expects('glob')->andReturn($globResult);
+        File::expects('glob')->andReturn($globResult);
 
-        $this->files->expects('isDirectory')->with($globResult[0])->andreturn(false);
-        $this->files->expects('isDirectory')->with($globResult[1])->andreturn(true);
-        $this->files->expects('delete')->with($globResult[0]);
-        $this->files->expects('deleteDirectory')->with($globResult[1]);
+        File::expects('isDirectory')->with($globResult[0])->andreturn(false);
+        File::expects('isDirectory')->with($globResult[1])->andreturn(true);
+        File::expects('delete')->with($globResult[0]);
+        File::expects('deleteDirectory')->with($globResult[1]);
 
         $this->artisan(ViewClearCommand::class);
     }


### PR DESCRIPTION
This PR includes more "Mockery cleanup" by leveraging Laravel facade's directly for testing, instead of creating a mock. While using a Facade still indirectly uses Mockery, these changes increase testing coverage for Facades and decrease direct Mockery usage.

There were also a few instances where simply using "the real thing" is fine for testing.