### PR TITLE
[13.x] Keep the assertion failure message when session errors are JSON serialized

### DIFF
--- a/src/Illuminate/Testing/TestResponseAssert.php
+++ b/src/Illuminate/Testing/TestResponseAssert.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
+use Illuminate\Support\ViewErrorBag;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionProperty;
 
@@ -78,7 +79,17 @@ class TestResponseAssert
             $session = $this->response->baseResponse->getSession();
 
             if (! is_null($session) && $session->has('errors')) {
-                return $this->appendErrorsToException($session->get('errors')->all(), $exception);
+                $errors = $session->get('errors');
+
+                if (! $errors instanceof ViewErrorBag && ! $session->isStarted()) {
+                    $session->start();
+
+                    $errors = $session->get('errors');
+                }
+
+                if ($errors instanceof ViewErrorBag) {
+                    return $this->appendErrorsToException($errors->all(), $exception);
+                }
             }
         }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -3177,6 +3177,44 @@ EOT
         $response->assertStatus(200);
     }
 
+    public function testValidationErrorsAreIncludedInAssertionFailureWhenSessionIsJsonSerialized(): void
+    {
+        $session = new Store('test-session', new NullSessionHandler(), null, 'json');
+
+        $response = TestResponse::fromBaseResponse(
+            tap(new RedirectResponse('/'))
+                ->setSession($session)
+                ->withErrors([
+                    'first_name' => 'The first name field is required.',
+                    'last_name' => 'The last name field is required.',
+                ])
+        );
+
+        $session->save(); // Required to serialize error bag to JSON
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 302.*The first name field is required.*The last name field is required/s');
+
+        $response->assertStatus(200);
+    }
+
+    public function testValidationErrorsAreIncludedInAssertionFailureWhenJsonSerializedSessionIsNotSaved(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            tap(new RedirectResponse('/'))
+                ->setSession(new Store('test-session', new NullSessionHandler(), null, 'json'))
+                ->withErrors([
+                    'first_name' => 'The first name field is required.',
+                    'last_name' => 'The last name field is required.',
+                ])
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 302.*The first name field is required.*The last name field is required/s');
+
+        $response->assertStatus(200);
+    }
+
     public function testJsonErrorsAreIncludedInAssertionFailure(): void
     {
         $response = TestResponse::fromBaseResponse(new JsonResponse([


### PR DESCRIPTION
`Store::save()` replaces the in-memory `ViewErrorBag` with a plain array when the session serializes to JSON, and never puts the object back. `TestResponse::session()` hides this because it restarts the session, which runs `marshalErrorBag()` and rebuilds the bag, but `TestResponseAssert::injectResponseContext()` reads the redirect response's session directly and calls `->all()` on whatever is there.

So on a failing assertion against a redirect carrying validation errors, the helper throws `Error: Call to a member function all() on array` and that replaces the `ExpectationFailedException` it was meant to enrich. The real failure message, the expected and actual values and the validation messages are all gone, and the trail points at a framework internal rather than the test. It only shows up once an assertion is already failing, so a green suite never surfaces it, and `json` is the shipped default for new applications.

Starting the session before reading the errors lets the store marshal the bag back, so the assertion message keeps both the original failure and the validation errors.

Fixes #61200
