### PR TITLE
[13.x] Limit included resources to the requested relationship paths

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -36,9 +36,14 @@ trait ResolvesJsonApiElements
     protected bool $includesPreviouslyLoadedRelationships = false;
 
     /**
+     * The relationship paths that may be included for the resource.
+     */
+    protected ?array $includedRelationshipPaths = null;
+
+    /**
      * Cached loaded relationships map.
      *
-     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool}>|null
+     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool, 4?: array<int, string>|null}>|null
      */
     public $loadedRelationshipsMap;
 
@@ -191,6 +196,8 @@ trait ResolvesJsonApiElements
 
         $sparseIncluded = match (true) {
             $this->includesPreviouslyLoadedRelationships => array_keys($this->resource->getRelations()),
+            ! is_null($this->includedRelationshipPaths) => (new Collection($this->includedRelationshipPaths))
+                ->map(fn ($path) => Str::before($path, '.'))->all(),
             default => $request->sparseIncluded(),
         };
 
@@ -209,10 +216,9 @@ trait ResolvesJsonApiElements
             foreach ($resourceRelationships as $relationName => $relationResolver) {
                 $relatedModels = $relationResolver->handle($this->resource);
 
-                if (! is_null($relatedModels) && $this->includesPreviouslyLoadedRelationships === false) {
-                    if (! empty($relations = $request->sparseIncluded($relationName))) {
-                        $relatedModels->loadMissing($relations);
-                    }
+                if (! is_null($relatedModels) &&
+                    ! empty($relations = $this->nestedRelationshipPaths($request, $relationName))) {
+                    $relatedModels->loadMissing($relations);
                 }
 
                 yield from $this->compileResourceRelationshipUsingResolver(
@@ -236,6 +242,7 @@ trait ResolvesJsonApiElements
     ): Generator {
         $relationName = $relationResolver->relationName;
         $resourceClass = $relationResolver->resourceClass();
+        $includedPaths = $this->nestedRelationshipPaths($request, $relationName);
 
         // Relationship is a collection of models...
         if ($relatedModels instanceof Collection) {
@@ -251,13 +258,13 @@ trait ResolvesJsonApiElements
 
             $isUnique = ! $relationship instanceof BelongsToMany;
 
-            yield $relationName => ['data' => $relatedModels->map(function ($relatedModel) use ($request, $resourceClass, $isUnique) {
+            yield $relationName => ['data' => $relatedModels->map(function ($relatedModel) use ($request, $resourceClass, $isUnique, $includedPaths) {
                 $relatedResource = rescue(fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
 
                 return transform(
                     [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-                    function ($uniqueKey) use ($relatedResource, $isUnique) {
-                        $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, $isUnique];
+                    function ($uniqueKey) use ($relatedResource, $isUnique, $includedPaths) {
+                        $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, $isUnique, $includedPaths];
 
                         return [
                             'id' => $uniqueKey[1],
@@ -288,8 +295,8 @@ trait ResolvesJsonApiElements
 
         yield $relationName => ['data' => transform(
             [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-            function ($uniqueKey) use ($relatedResource) {
-                $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, true];
+            function ($uniqueKey) use ($relatedResource, $includedPaths) {
+                $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, true, $includedPaths];
 
                 return [
                     'id' => $uniqueKey[1],
@@ -297,6 +304,30 @@ trait ResolvesJsonApiElements
                 ];
             }
         )];
+    }
+
+    /**
+     * Get the relationship paths that may be included for the given relationship.
+     *
+     * Returns `null` when every previously loaded relationship should be included.
+     *
+     * @return array<int, string>|null
+     */
+    protected function nestedRelationshipPaths(JsonApiRequest $request, string $relationName): ?array
+    {
+        if ($this->includesPreviouslyLoadedRelationships) {
+            return null;
+        }
+
+        if (is_null($this->includedRelationshipPaths)) {
+            return $request->sparseIncluded($relationName);
+        }
+
+        return (new Collection($this->includedRelationshipPaths))
+            ->filter(fn ($path) => str_starts_with($path, $relationName.'.'))
+            ->map(fn ($path) => Str::after($path, '.'))
+            ->values()
+            ->all();
     }
 
     /**
@@ -326,6 +357,10 @@ trait ResolvesJsonApiElements
         while ($index < count($this->loadedRelationshipsMap)) {
             [$resourceInstance, $type, $id, $isUnique] = $this->loadedRelationshipsMap[$index];
 
+            // A map assembled by hand may hold the original four element tuples, which carry no
+            // relationship paths. Those resources keep including everything they have loaded.
+            $includedPaths = $this->loadedRelationshipsMap[$index][4] ?? null;
+
             $underlyingResource = $resourceInstance->resource;
 
             if (is_object($underlyingResource)) {
@@ -343,8 +378,9 @@ trait ResolvesJsonApiElements
                 $resourceInstance = new JsonApiResource($resourceInstance->resource);
             }
 
-            $relationsData = $resourceInstance
-                ->includePreviouslyLoadedRelationships()
+            $relationsData = (is_null($includedPaths)
+                ? $resourceInstance->includePreviouslyLoadedRelationships()
+                : $resourceInstance->includeRelationshipPaths($includedPaths))
                 ->resolve($request);
 
             array_push($this->loadedRelationshipsMap, ...($resourceInstance->loadedRelationshipsMap ?? []));
@@ -415,6 +451,21 @@ trait ResolvesJsonApiElements
     public function includePreviouslyLoadedRelationships()
     {
         $this->includesPreviouslyLoadedRelationships = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine the relationship paths the resource may include.
+     *
+     * @internal
+     *
+     * @param  array<int, string>  $paths
+     * @return $this
+     */
+    public function includeRelationshipPaths(array $paths)
+    {
+        $this->includedRelationshipPaths = $paths;
 
         return $this;
     }

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -809,4 +809,31 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonPath('included.1.id', (string) $user->getKey())
             ->assertJsonCount(2, 'included');
     }
+
+    public function testItDoesNotIncludeEagerLoadedNestedRelationshipsThatWereNotRequested()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $comment = Comment::factory()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        // The route hands the resource a model with "comments.commenter" already loaded, while
+        // the request only asks for "comments". The commenter was never requested, so it should
+        // neither show up in "included" nor as a relationship of the comment.
+        $response = $this->getJson("/posts/{$post->getKey()}/with-nested-eager-loaded-relations?".http_build_query(['include' => 'comments']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $post->getKey())
+            ->assertJsonPath('data.relationships.comments.data.0.id', (string) $comment->getKey());
+
+        $included = $response->json('included');
+
+        $this->assertSame(['comments'], array_column($included, 'type'));
+        $this->assertArrayNotHasKey('relationships', $included[0]);
+    }
 }

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -687,14 +687,15 @@ class JsonApiResourceTest extends TestCase
             'user_id' => $user->getKey(),
         ]);
 
-        // The /with-chaperone-posts route loads chaperonePosts which uses chaperone()
-        // to automatically set the inverse 'author' relationship on each Post,
-        // creating circular object references (User -> Post -> User same instance).
+        // The /with-previously-loaded-chaperone-posts route loads chaperonePosts which uses
+        // chaperone() to automatically set the inverse 'author' relationship on each Post,
+        // creating circular object references (User -> Post -> User same instance). The
+        // resource includes previously loaded relationships, so nothing bounds the traversal.
         // Without the fix, this would hang forever due to infinite loop.
         // The same User model appears twice in included: once as "posts" (the Post)
         // and once as "authors" (Post's author via chaperone) - this is correct
         // because different resource types should not be deduplicated.
-        $this->getJson("/users/{$user->getKey()}/with-chaperone-posts?".http_build_query(['include' => 'chaperonePosts']))
+        $this->getJson("/users/{$user->getKey()}/with-previously-loaded-chaperone-posts")
             ->assertHeader('Content-type', 'application/vnd.api+json')
             ->assertJsonPath('data.id', (string) $user->getKey())
             ->assertJsonPath('data.type', 'users')
@@ -835,5 +836,31 @@ class JsonApiResourceTest extends TestCase
 
         $this->assertSame(['comments'], array_column($included, 'type'));
         $this->assertArrayNotHasKey('relationships', $included[0]);
+    }
+
+    public function testItIncludesPreviouslyLoadedNestedRelationshipsWhenAskedTo()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $comment = Comment::factory()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        // The route opts into "includePreviouslyLoadedRelationships", so the eager loaded
+        // commenter is included even though the request asks for nothing. The opt-in
+        // applies to the whole tree, not only to the relationships of the root.
+        $response = $this->getJson("/posts/{$post->getKey()}/with-previously-loaded-relations")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.relationships.comments.data.0.id', (string) $comment->getKey());
+
+        $included = $response->json('included');
+
+        $this->assertSame(['comments', 'users'], array_column($included, 'type'));
+        $this->assertSame((string) $user->getKey(), $included[0]['relationships']['commenter']['data']['id']);
     }
 }

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -49,6 +49,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return Post::find($postId)->toResource();
         });
 
+        $router->get('posts/{postId}/with-nested-eager-loaded-relations', function ($postId) {
+            return Post::find($postId)->load('comments.commenter')->toResource();
+        });
+
         $router->get('things/{id}', function ($id) {
             return new ArrayBackedJsonApiResource(['id' => (int) $id, 'name' => 'test']);
         });

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -41,6 +41,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return User::find($userId)->load('chaperonePosts')->toResource();
         });
 
+        $router->get('users/{userId}/with-previously-loaded-chaperone-posts', function ($userId) {
+            return User::find($userId)->load('chaperonePosts')->toResource()->includePreviouslyLoadedRelationships();
+        });
+
         $router->get('posts', function () {
             return Post::paginate(5)->toResourceCollection();
         });
@@ -51,6 +55,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $router->get('posts/{postId}/with-nested-eager-loaded-relations', function ($postId) {
             return Post::find($postId)->load('comments.commenter')->toResource();
+        });
+
+        $router->get('posts/{postId}/with-previously-loaded-relations', function ($postId) {
+            return Post::find($postId)->load('comments.commenter')->toResource()->includePreviouslyLoadedRelationships();
         });
 
         $router->get('things/{id}', function ($id) {


### PR DESCRIPTION
Fixes #60126.

When a model is handed to a `JsonApiResource` with its own eager loads, the nested resources in `included` come back with relationships the client never asked for. `?include=comments` on a `$post->load('comments.author')` returns the authors as well.

The reason is that `resolveIncludedResourceObjects()` resolves every included resource with `includePreviouslyLoadedRelationships()` forced on, and that mode takes the relationship list from `array_keys($resource->getRelations())`. It lines up with the request in the common case only because the level above has just loaded exactly the requested nested paths.

The flag can't simply be dropped: a nested resource cannot ask the request about its own depth, `sparseIncluded()` is grouped by the first segment. Instead each entry in `loadedRelationshipsMap` now carries the include paths that still apply to it, and the nested resource is limited to those. Entries without paths — a map assembled by hand, as two of the test routes do — keep the previous behaviour.

Calling `includePreviouslyLoadedRelationships()` yourself is unchanged and still applies to the whole tree. There was no test covering that, so this adds one.

`testItHandlesBidirectionalRelationshipsWithChaperoneWithoutInfiniteLoop` moved to a route that opts into previously loaded relationships. It was asking for `?include=chaperonePosts` and expecting the inverse `author` set by `chaperone()` to appear in `included`, which is the same leak seen from the other side. The opt-in mode is where the traversal is still unbounded, so that is where the cycle guard is worth testing; the assertions are unchanged. Commenting the `WeakMap` check out makes the moved test hang, so it does still cover it.
