### PR TITLE
[13.x] Prevent TypeError when JSON:API query parameters are arrays

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -25,7 +25,7 @@ class JsonApiRequest extends Request
     {
         if (is_null($this->cachedSparseFields)) {
             $this->cachedSparseFields = (new Collection($this->array('fields')))
-                ->transform(fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
+                ->transform(fn ($fieldsets) => ! is_string($fieldsets) || empty($fieldsets) ? [] : explode(',', $fieldsets))
                 ->all();
         }
 
@@ -50,7 +50,7 @@ class JsonApiRequest extends Request
     public function sparseIncluded(?string $key = null): ?array
     {
         if (is_null($this->cachedSparseIncluded)) {
-            $included = (string) $this->string('include', '');
+            $included = is_string($included = $this->input('include')) ? $included : '';
 
             $this->cachedSparseIncluded = (new Collection(empty($included) ? [] : explode(',', $included)))
                 ->transform(function ($item) {

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
@@ -42,6 +42,18 @@ class JsonApiRequestTest extends TestCase
         $this->assertFalse($request->hasSparseFieldset('posts'));
     }
 
+    public function testItIgnoresNonStringSparseFields()
+    {
+        $request = JsonApiRequest::create(uri: '/?'.http_build_query([
+            'fields' => [
+                'users' => ['name', 'email'],
+            ],
+        ]));
+
+        $this->assertSame([], $request->sparseFields('users'));
+        $this->assertTrue($request->hasSparseFieldset('users'));
+    }
+
     public function testItCanResolveSparseIncluded()
     {
         $request = JsonApiRequest::create(uri: '/?'.http_build_query([
@@ -73,5 +85,15 @@ class JsonApiRequestTest extends TestCase
         $request = JsonApiRequest::create(uri: '/');
 
         $this->assertSame([], $request->sparseIncluded());
+    }
+
+    public function testItIgnoresNonStringSparseIncluded()
+    {
+        $request = JsonApiRequest::create(uri: '/?'.http_build_query([
+            'include' => ['teams', 'posts'],
+        ]));
+
+        $this->assertSame([], $request->sparseIncluded());
+        $this->assertSame([], $request->sparseIncluded('teams'));
     }
 }


### PR DESCRIPTION
`?fields[posts][]=title` currently returns a 500 from any endpoint that returns a `JsonApiResource`:
```
explode(): Argument #2 ($string) must be of type string, array given
```
`sparseFields()` passes the raw value of `fields[TYPE]` to `explode()`, and a client can send it as an array. 
`?include[]=author` has a similar problem: `string()` casts the array via `Stringable`, which raises an "Array to string conversion" warning and resolves the relationship name to the string "Array".

JSON:API defines both parameters as comma-separated strings, so non-string values are now treated as invalid input: `include` is discarded entirely, and `fields[TYPE]` is treated as an empty fieldset — the same as `?fields[TYPE]=` today, so `hasSparseFieldset()` still reports the fieldset as provided.