### PR TITLE
[13.x] QueueForwarded event

### DIFF
--- a/src/Illuminate/Queue/Events/QueueForwarded.php
+++ b/src/Illuminate/Queue/Events/QueueForwarded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class QueueForwarded
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $connectionName  The queue connection the queue was forwarded on.
+     * @param  string  $from  The queue that was forwarded.
+     * @param  string  $to  The queue that was forwarded to.
+     */
+    public function __construct(
+        public ?string $connectionName,
+        public string $from,
+        public string $to,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -21,6 +21,7 @@ use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
+use Illuminate\Queue\Events\QueueForwarded;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
@@ -28,6 +29,8 @@ use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Throwable;
+
+use function Illuminate\Support\enum_value;
 
 abstract class Queue
 {
@@ -372,6 +375,8 @@ abstract class Queue
 
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($queue, $job, $payload, $delay, $callback) {
+                    $this->raiseQueueForwardedEvent($queue);
+
                     $this->raiseJobQueueingEvent($queue, $job, $payload, $delay);
 
                     return tap($callback($payload, $queue, $delay), function ($jobId) use ($queue, $job, $payload, $delay) {
@@ -380,6 +385,8 @@ abstract class Queue
                 }
             );
         }
+
+        $this->raiseQueueForwardedEvent($queue);
 
         $this->raiseJobQueueingEvent($queue, $job, $payload, $delay);
 
@@ -484,6 +491,27 @@ abstract class Queue
             $delay = ! is_null($delay) ? $this->secondsUntil($delay) : $delay;
 
             $this->container['events']->dispatch(new JobQueued($this->connectionName, $queue, $jobId, $job, $payload, $delay));
+        }
+    }
+
+    /**
+     * Raise the queue forwarded event.
+     *
+     * @param  \UnitEnum|string|null  $queue
+     * @return void
+     */
+    protected function raiseQueueForwardedEvent($queue)
+    {
+        $from = enum_value($queue) ?: ($this->default ?? null);
+
+        if (is_null($from)) {
+            return;
+        }
+
+        $to = $this->resolveQueue($from);
+
+        if ($to !== $from && $this->container->bound('events')) {
+            $this->container['events']->dispatch(new QueueForwarded($this->connectionName, $from, $to));
         }
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -382,6 +382,8 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function sendBatchedMessages(array $messages, $queue)
     {
+        $this->raiseQueueForwardedEvent($queue);
+
         $entries = [];
 
         foreach ($messages as $id => $message) {

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -10,7 +10,9 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
+use Illuminate\Queue\Events\QueueForwarded;
 use Illuminate\Queue\Queue;
+use Illuminate\Queue\QueueRoutes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
@@ -287,5 +289,29 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
         $this->assertIsArray($jobQueuedEvent->payload());
         $this->assertSame('expected-job-uuid', $jobQueuedEvent->payload()['uuid']);
+    }
+
+    public function testQueueForwardedEventIsDispatchedWhenQueueIsForwarded()
+    {
+        $queueForwardedEvent = null;
+
+        Container::setInstance($this->container);
+
+        $this->container->instance('queue.routes', tap(new QueueRoutes, function ($routes) {
+            $routes->forward('jobs', 'processing');
+        }));
+
+        $this->container['events']->listen(function (QueueForwarded $e) use (&$queueForwardedEvent) {
+            $queueForwardedEvent = $e;
+        });
+
+        $this->queue->push('MyJob', [
+            'laravel' => 'Framework',
+        ], 'jobs');
+
+        $this->assertSame('jobs', $queueForwardedEvent->from);
+        $this->assertSame('processing', $queueForwardedEvent->to);
+
+        Container::setInstance(null);
     }
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Events\QueueForwarded;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -1120,6 +1121,37 @@ class QueueSqsQueueTest extends TestCase
         $this->assertCount(2, $queueingEvents);
         $this->assertCount(2, $queuedEvents);
         $this->assertSame(['mid-0', 'mid-1'], array_map(fn ($e) => $e->id, array_values($queuedEvents)));
+    }
+
+    public function testBulkRaisesQueueForwardedEventOnceForTheBatch()
+    {
+        Container::setInstance($container = new Container);
+        $routes = new QueueRoutes;
+        $routes->forward($this->queueName, 'processing', 'sqs');
+        $container->instance('queue.routes', $routes);
+
+        $forwarded = [];
+        $events = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $events->allows('dispatch')->andReturnUsing(function ($event) use (&$forwarded) {
+            if ($event instanceof QueueForwarded) {
+                $forwarded[] = $event;
+            }
+        });
+        $container->instance('events', $events);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+
+        $this->sqs->expects('sendMessageBatch')->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk(['a', 'b'], 'data', $this->queueName);
+
+        $this->assertCount(1, $forwarded);
+        $this->assertSame($this->queueName, $forwarded[0]->from);
+        $this->assertSame('processing', $forwarded[0]->to);
+
+        Container::setInstance(null);
     }
 
     public function testBulkHonoursPerJobDelay()


### PR DESCRIPTION
Since Queue:forward is now a thing, this lets us use our own logic in userland when a queue is forwarded. 

This helps avoid any confusion or misdirection that could be caused.

SQS' bulk doesnt use `enqueueUsing` like the others, So.. I had to do that separately.

Could be worth putting this somewhere else, but I felt it was a pain putting this event on every driver, so this worked.