### PR TITLE
[13.x] Keep the original Redis exception when rebuilding the client fails

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -621,7 +621,12 @@ class PhpRedisConnection extends Connection implements ConnectionContract
                     throw $e;
                 }
 
-                $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+                try {
+                    // Rebuilding can fail on the same outage, so keep the client and report the original error...
+                    $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+                } catch (Throwable) {
+                    //
+                }
 
                 if ($retries-- === 0) {
                     throw $e;

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -411,6 +411,43 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(3, $reconnects);
     }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionReportsTheOriginalExceptionWhenRebuildingItsClientFails()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('incr')->with('foo')->willThrowException(new RedisException('Connection lost'));
+
+        $connection = new PhpRedisConnection($failedClient, function () {
+            throw new RedisException('Cluster is down');
+        });
+
+        $this->expectExceptionObject(new RedisException('Connection lost'));
+
+        $connection->command('incr', ['foo']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionRetriesWithTheExistingClientWhenRebuildingItFails()
+    {
+        $calls = 0;
+
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->exactly(2))->method('get')->with('foo')->willReturnCallback(function () use (&$calls) {
+            if ($calls++ === 0) {
+                throw new RedisException('Connection lost');
+            }
+
+            return 'bar';
+        });
+
+        $connection = new PhpRedisConnection($failedClient, function () {
+            throw new RedisException('Cluster is down');
+        });
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+        $this->assertSame($failedClient, $connection->client());
+    }
 }
 
 class ClusterStubPhpRedisConnector extends PhpRedisConnector


### PR DESCRIPTION
`PhpRedisConnection::command()` rebuilds the client from inside its `catch` block, but that rebuild is unguarded and runs during the very outage that triggered it.
`Redis::connect()` and `RedisCluster::__construct` both throw when they cannot reach the server, and #61161 widened this to cluster connections by giving them a connector. When the rebuild throws, its exception propagates in place of the original `RedisException` and the `throw $e` below is skipped, so callers see a misleading error from a moment later instead of the command that actually failed. 
This keeps the existing client when the rebuild fails, so the original error surfaces and any remaining retries still terminate on it.