### PR TITLE
[13.x] Rebuild the phpredis client when discarding queued commands fails

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -472,7 +472,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return tap($pipeline, $callback)->exec();
         } catch (Throwable $e) {
-            rescue(fn () => $this->client()->discard(), null, false);
+            // Anything but a clean discard leaves queued commands on the client, so rebuild it...
+            if (rescue(fn () => $this->client()->discard(), false, false) !== true && $this->connector) {
+                $this->client = rescue(fn () => call_user_func($this->connector), $this->client, false);
+            }
 
             throw $e;
         }
@@ -495,7 +498,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return tap($transaction, $callback)->exec();
         } catch (Throwable $e) {
-            rescue(fn () => $this->client()->discard(), null, false);
+            // Anything but a clean discard leaves the client in MULTI, so rebuild it...
+            if (rescue(fn () => $this->client()->discard(), false, false) !== true && $this->connector) {
+                $this->client = rescue(fn () => call_user_func($this->connector), $this->client, false);
+            }
 
             throw $e;
         }

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -411,6 +411,46 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(3, $reconnects);
     }
+
+    #[RequiresPhpExtension('redis')]
+    public function testTransactionRebuildsTheClientWhenDiscardingQueuedCommandsReturnsFalse()
+    {
+        $client = $this->createMock(\Redis::class);
+        $client->method('multi')->willReturnSelf();
+        $client->expects($this->once())->method('discard')->willReturn(false);
+
+        $rebuilt = $this->createStub(\Redis::class);
+        $connection = new PhpRedisConnection($client, fn () => $rebuilt);
+
+        try {
+            $connection->transaction(fn () => throw new RedisException('Something went wrong.'));
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertSame('Something went wrong.', $e->getMessage());
+        }
+
+        $this->assertSame($rebuilt, $connection->client());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testPipelineRebuildsTheClientWhenDiscardingQueuedCommandsThrows()
+    {
+        $client = $this->createMock(\Redis::class);
+        $client->method('pipeline')->willReturnSelf();
+        $client->expects($this->once())->method('discard')->willThrowException(new RedisException('Connection lost'));
+
+        $rebuilt = $this->createStub(\Redis::class);
+        $connection = new PhpRedisConnection($client, fn () => $rebuilt);
+
+        try {
+            $connection->pipeline(fn () => throw new RedisException('Something went wrong.'));
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertSame('Something went wrong.', $e->getMessage());
+        }
+
+        $this->assertSame($rebuilt, $connection->client());
+    }
 }
 
 class ClusterStubPhpRedisConnector extends PhpRedisConnector


### PR DESCRIPTION
#61183 discards queued commands when a `pipeline()` or `transaction()` callback throws, but `rescue(fn () => $this->client()->discard(), null, false)` ignores the result, and phpredis reports some not-in-MULTI states by returning `false` rather than throwing - so when the DISCARD itself fails the client stays in MULTI and every subsequent command returns the client object instead of a value, surfacing much later as errors like `must be of type array, RedisCluster given`. 
Cluster connections have no `pipeline()`, so Horizon routes all of its writes through `transaction()` (`UsesClusterAwarePipeline`), where one aborted transaction is enough to wedge the master supervisor until it is killed. 
This treats anything but a strict `true` as a failed discard and rebuilds the client from the connector that #61161 now supplies to cluster connections, falling back to the existing client if that rebuild also fails.