### PR TITLE
[13.x] Rebuild the phpredis client after a cluster response error

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use RedisClusterException;
 use RedisException;
 use Throwable;
 
@@ -604,6 +605,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  array  $parameters
      * @return mixed
      *
+     * @throws \RedisClusterException
      * @throws \RedisException
      */
     public function command($method, array $parameters = [])
@@ -616,8 +618,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         while (true) {
             try {
                 return parent::command($method, $parameters);
-            } catch (RedisException $e) {
-                if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost'])) {
+            } catch (RedisClusterException|RedisException $e) {
+                if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost', 'Error processing response from Redis node'])) {
                     throw $e;
                 }
 

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -411,6 +411,21 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(3, $reconnects);
     }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionRebuildsItsClientAfterAClusterResponseError()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('get')->with('foo')->willThrowException(new \RedisClusterException('Error processing response from Redis node!'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+        $this->assertSame($healthyClient, $connection->client());
+    }
 }
 
 class ClusterStubPhpRedisConnector extends PhpRedisConnector


### PR DESCRIPTION
`PhpRedisConnection::command()` catches `RedisException`, but phpredis registers `RedisClusterException` under `RuntimeException` rather than under `RedisException`, so no cluster error has ever reached the reconnect branch - the connector #61161 gave cluster connections is unreachable for the one exception class `RedisCluster` throws. 
In practice a desynced connection throws `RedisClusterException: Error processing response from Redis node!`, nothing rebuilds the client, and every later command on it fails the same way for the life of the process. This widens the catch and adds that message to the existing list, so the client is rebuilt and the command retried.