### PR TITLE
[13.x] Test on MySQL 9.7 (lts)

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -8,13 +8,13 @@ permissions:
   contents: read
 
 jobs:
-  mysql_9:
+  mysql_innovation:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     services:
       mysql:
-        image: mysql:9
+        image: mysql:innovation
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: laravel
@@ -22,7 +22,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    name: MySQL 9
+    name: MySQL Innovation
 
     steps:
       - name: Checkout code

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -44,13 +44,13 @@ jobs:
           DB_CONNECTION: mysql
           DB_COLLATION: utf8mb4_unicode_ci
 
-  mysql_8:
+  mysql_84:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     services:
       mysql:
-        image: mysql:8
+        image: mysql:8.4
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: laravel
@@ -58,7 +58,39 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    name: MySQL 8
+    name: MySQL 8.4
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP project
+        uses: ./.github/actions/setup-php-project
+        with:
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: mysql
+
+  mysql_97:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    services:
+      mysql:
+        image: mysql:9.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: laravel
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    name: MySQL 9.7
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 11211:11211
       mysql:
-        image: mysql:8
+        image: mysql:9.7
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: forge


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
MySQL has recently released a new LTS version, 9.7; see also https://blogs.oracle.com/mysql/mysql-9-7-lts-is-here-upgrade-and-modernize-on-a-stronger-community-edition.

Afterwards, the versioning schema has been revised; going forward new (innovation) release will use a calver-like system, rather than a semver-like system; see also https://blogs.oracle.com/mysql/a-more-predictable-mysql-release-model-calendar-versions-lts-and-innovation. This means the current latest innovation release is 26.7.

To account for this, this PR proposes the following changes:
- explicitly add the 9.7 lts to the set of database integration tests
  - for explicitness, 8 has been changed to the explicit 8.4, which is the latest and lts v8 version
- change the MySQL for the default CI jobs to the latest LTS, 9.7
  - note that effectively 9.7 is now doubly tested, similar to how 8(.4) was previously
- update the nightly database CI tests to use the floating `innovation` tag, to prevent repeated updates
  - alternatively the major `26` could be considered here, which would subsequently require yearly updates to remain up-to-date

Notes: 
1. 8.0 lts was not tested before and still is not. It is also EOL, but still considered supported by this project (as 5.7 is as well). Given that 5.7 and 8.4 are both tested, adding an explicit 8.0 test seems somewhat redundant, but could be considered.
2. If this should be targeted on an older branch to also update test strategy there, lmk.