### PR TITLE
[13.x] Use PHPUnit 13.3 for CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           - php: 8.3
             phpunit: '13.0.3'
 
-    name: PHP ${{ matrix.php }} - PHPUnit ~${{ matrix.phpunit }} - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - PHPUnit ^${{ matrix.phpunit }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -66,7 +66,7 @@ jobs:
           ini-values: error_reporting=E_ALL
           redis-configure-opts: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
           redis-libs: liblz4-dev, liblzf-dev, libzstd-dev
-          composer-command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:~${{ matrix.phpunit }}"
+          composer-command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:^${{ matrix.phpunit }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation ${{ matrix.stability == 'prefer-stable' && '--fail-on-deprecation' || '' }} --no-coverage
@@ -100,7 +100,7 @@ jobs:
           - php: 8.3
             phpunit: '13.0.3'
 
-    name: PHP ${{ matrix.php }} - PHPUnit ~${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
+    name: PHP ${{ matrix.php }} - PHPUnit ^${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
 
     steps:
       - name: Set git to use LF
@@ -118,7 +118,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp, intl, :php-psr
-          composer-command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:~${{ matrix.phpunit }}"
+          composer-command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:^${{ matrix.phpunit }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           - php: 8.3
             phpunit: '13.0.3'
 
-    name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - PHPUnit ~${{ matrix.phpunit }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -100,7 +100,7 @@ jobs:
           - php: 8.3
             phpunit: '13.0.3'
 
-    name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
+    name: PHP ${{ matrix.php }} - PHPUnit ~${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
 
     steps:
       - name: Set git to use LF


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR ensures the latest PHPUnit minor (13.3) is used for CI tests. For improved clarity about the used version inside CI jobs, a `~` is added to the job name (corresponding with composer behavior of the test) and the latest patch versions for previous majors are bumped (corresponding to the currently used version in practice).