### PR TITLE
[13.x] Preserve input key order when merging files in Request::all()

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -86,7 +86,9 @@ trait InteractsWithInput
      */
     public function all($keys = null)
     {
-        $input = array_replace_recursive($this->allFiles(), $this->input());
+        $input = $this->input();
+
+        $input = array_replace_recursive($input, $this->allFiles(), $input);
 
         if (! $keys) {
             return $input;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1378,6 +1378,22 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf(UploadedFile::class, $request->file('email'));
     }
 
+    public function testAllInputPreservesInputKeyOrderWhenFilesAreMerged()
+    {
+        $file = new SymfonyUploadedFile(__FILE__, 'photo.jpg');
+        $request = Request::create('/', 'POST', [
+            'items' => [0 => ['name' => 'first'], 1 => ['name' => 'second']],
+        ], [], [
+            'items' => [1 => ['photo' => $file]],
+        ]);
+
+        $items = $request->all()['items'];
+
+        $this->assertSame([0, 1], array_keys($items));
+        $this->assertSame('second', $items[1]['name']);
+        $this->assertInstanceOf(UploadedFile::class, $items[1]['photo']);
+    }
+
     public function testAllInputReturnsInputAfterReplace()
     {
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']]);


### PR DESCRIPTION
Since v13.25.0 (#61099) `Request::all()` computes `array_replace_recursive($this->allFiles(), $this->input())`. 

Because `array_replace_recursive` preserves the base array's key order and the files array is now the base, any nested array that mixes uploaded files with text fields is silently reordered and file-carrying indices move to the front:

```php
$file = new \Symfony\Component\HttpFoundation\File\UploadedFile(__FILE__, 'photo.jpg');

$request = Request::create('/', 'POST',
    ['items' => [0 => ['name' => 'a'], 1 => ['name' => 'b']]],
    [], ['items' => [1 => ['photo' => $file]]]);

array_keys($request->all()['items']);
// v13.24.0: [0, 1]
// v13.25.0: [1, 0]
```


Applications that derive meaning from payload order (positions, sequences, first-entry-wins logic) process entries in the wrong order without any error. In our application this silently dropped a database row, because an entry's auto-assigned position collided with another entry's explicit one after the reorder.

This PR keeps the intent of #61099; text input still wins over uploaded files on colliding keys but uses the text input as the merge base so its key order is preserved:

```php
$input = $this->input();

$input = array_replace_recursive($input, $this->allFiles(), $input);
```


All tests introduced in #61099 still pass + a regression test for the key order is included.
