### PR TITLE
[13.x] Add getRelatedClass to Relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -72,8 +72,8 @@ class PendingHasThroughRelationship
 
         if ($distantRelation instanceof HasMany || $this->localRelationship instanceof HasMany) {
             $returnedRelation = $this->rootModel->hasManyThrough(
-                $distantRelation->getRelated()::class,
-                $this->localRelationship->getRelated()::class,
+                $distantRelation->getRelatedClass(),
+                $this->localRelationship->getRelatedClass(),
                 $this->localRelationship->getForeignKeyName(),
                 $distantRelation->getForeignKeyName(),
                 $this->localRelationship->getLocalKeyName(),
@@ -81,8 +81,8 @@ class PendingHasThroughRelationship
             );
         } else {
             $returnedRelation = $this->rootModel->hasOneThrough(
-                $distantRelation->getRelated()::class,
-                $this->localRelationship->getRelated()::class,
+                $distantRelation->getRelatedClass(),
+                $this->localRelationship->getRelatedClass(),
                 $this->localRelationship->getForeignKeyName(),
                 $distantRelation->getForeignKeyName(),
                 $this->localRelationship->getLocalKeyName(),

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -439,6 +439,16 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Get the class name of the related model.
+     *
+     * @return class-string<TRelatedModel>
+     */
+    public function getRelatedClass()
+    {
+        return $this->related::class;
+    }
+
+    /**
      * Get the name of the "created at" column.
      *
      * @return string


### PR DESCRIPTION
We have custom logic in userland for the way we sync and update based on relationships, I reached for the equivalent to `getMorphClass()`/`getPivotClass()` in the related model's class itself, right now you have to do `$relation->getRelated()::class`

This PR adds `getRelatedClass()` I also noticed its used in the framework, so I've used the new method there also

It felt weird to me when I reviewed it internally, so thought I'd try a (potential) DX improvement here