### PR TITLE
[13.x] fix: `expectsQuestion()` docblock to allow array answers

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -98,7 +98,7 @@ class PendingCommand
      * Specify an expected question that will be asked when the command runs.
      *
      * @param  string  $question
-     * @param  string|array|bool  $answer
+     * @param  array|string|bool  $answer
      * @return $this
      */
     public function expectsQuestion($question, $answer)

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -98,7 +98,7 @@ class PendingCommand
      * Specify an expected question that will be asked when the command runs.
      *
      * @param  string  $question
-     * @param  string|bool  $answer
+     * @param  string|array|bool  $answer
      * @return $this
      */
     public function expectsQuestion($question, $answer)


### PR DESCRIPTION
`PendingCommand::expectsQuestion()` stores `$answer` and replays it unchanged via Mockery's `andReturnUsing()`. It's never coerced or validated. This makes it a legitimate way to stub Laravel Prompts' `multiselect()`, which expects an array of selected options as its answer. The method's docblock, however, only declared `string|bool`, so static analysis tools (e.g. PHPStan) flag passing an array as a type error even though it works correctly at runtime.

This PR widens the `@param` type for `$answer` to `string|array|bool`, matching the existing type declarations on `expectsChoice()` and `expectsSearch()`, which already allow `string|array`.