### PR TITLE
[12.x] Backport #60908: Avoid quadratic wildcard rule expansion

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -176,11 +176,13 @@ class ValidationRuleParser
                             [$attribute => [$key]]
                         );
 
-                        $results = $this->mergeRules($results, $compiled->rules);
+                        foreach ($compiled->rules as $compiledAttribute => $compiledRules) {
+                            $this->mergeRulesForAttributeInto($results, $compiledAttribute, $compiledRules);
+                        }
                     } else {
                         $this->implicitAttributes[$attribute][] = $key;
 
-                        $results = $this->mergeRules($results, $key, $rule);
+                        $this->mergeRulesForAttributeInto($results, $key, $rule);
                     }
                 }
             }
@@ -222,13 +224,26 @@ class ValidationRuleParser
      */
     protected function mergeRulesForAttribute($results, $attribute, $rules)
     {
+        $this->mergeRulesForAttributeInto($results, $attribute, $rules);
+
+        return $results;
+    }
+
+    /**
+     * Merge additional rules into a given attribute by reference.
+     *
+     * @param  array  $results
+     * @param  string  $attribute
+     * @param  string|array  $rules
+     * @return void
+     */
+    private function mergeRulesForAttributeInto(&$results, $attribute, $rules)
+    {
         $merge = head($this->explodeRules([$rules]));
 
         $results[$attribute] = array_merge(
             isset($results[$attribute]) ? $this->explodeExplicitRule($results[$attribute], $attribute) : [], $merge
         );
-
-        return $results;
     }
 
     /**


### PR DESCRIPTION
This cherry-picks the fix from #60908 into the 12.x branch.

The affected wildcard rule expansion code is unchanged between 12.x and the parent of the original 13.x commit, allowing the commit to be applied without conflicts or compatibility changes.

The fix has already been reviewed and accepted for 13.x. It prevents `ValidationRuleParser::explodeWildcardRules()` from repeatedly copying the accumulated rule set when expanding wildcard rules over large arrays.

I'm aware that the bug fix support window for Laravel 12 has ended. However, given the significant performance improvement and the absence of compatibility changes, I believe this backport may still be valuable to applications remaining on Laravel 12.

Thanks for taking a look, guys! 💪