### PR TITLE
[13.x] Don't force release a unique lock the job never acquired

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -435,9 +435,6 @@ abstract class Queue
     protected function registerRollbackCallbacksForJobsThatDispatchAfterCommit($job)
     {
         if ($job instanceof ShouldBeUnique) {
-            // Jobs pushed directly onto the queue never acquire the unique lock, so an
-            // empty owner means this job is not holding one. Releasing it here would
-            // force release a lock that another dispatch of the job is holding.
             $owner = isset(class_uses_recursive($job)[Queueable::class])
                 ? ($job->uniqueLockOwner ?? '')
                 : null;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Bus\DebounceLock;
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
@@ -434,8 +435,19 @@ abstract class Queue
     protected function registerRollbackCallbacksForJobsThatDispatchAfterCommit($job)
     {
         if ($job instanceof ShouldBeUnique) {
+            // Jobs pushed directly onto the queue never acquire the unique lock, so an
+            // empty owner means this job is not holding one. Releasing it here would
+            // force release a lock that another dispatch of the job is holding.
+            $owner = isset(class_uses_recursive($job)[Queueable::class])
+                ? ($job->uniqueLockOwner ?? '')
+                : null;
+
             $this->container->make('db.transactions')->addCallbackForRollback(
-                function () use ($job) {
+                function () use ($job, $owner) {
+                    if ($owner === '') {
+                        return;
+                    }
+
                     (new UniqueLock($this->container->make(Cache::class)))->release($job);
                 }
             );

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\Events\UniqueJobSkipped;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -272,6 +273,27 @@ class UniqueJobTest extends QueueTestCase
         Queue::assertPushedTimes(UniqueTestJob::class, 1);
     }
 
+    public function testRolledBackPushDoesNotReleaseAnotherDispatchesUniqueLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        dispatch($job = new UniqueTestAfterCommitJob);
+
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+
+        try {
+            DB::transaction(function () {
+                Queue::push(new UniqueTestAfterCommitJob);
+
+                throw new Exception('Rollback.');
+            });
+        } catch (Exception) {
+            //
+        }
+
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+    }
+
     protected function getLockKey($job)
     {
         return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job)).':';
@@ -461,5 +483,20 @@ class UniqueIdTestJobWithDisplayName extends UniqueTestJob
     public function displayName(): string
     {
         return 'App\\Actions\\UniqueTestAction';
+    }
+}
+
+class UniqueTestAfterCommitJob implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct()
+    {
+        $this->afterCommit = true;
+    }
+
+    public function handle()
+    {
+        //
     }
 }


### PR DESCRIPTION
Follow up to #60906.

`UniqueLock::release()` falls back to `forceRelease()` when a job has no owner token. That's right for a job that's actually holding the lock, but a job pushed straight onto the queue never acquires one, so on rollback it wipes out a lock a different dispatch is holding.

```php
ProcessPodcast::dispatch();          // acquires the unique lock

DB::transaction(function () {
    Queue::push(new ProcessPodcast); // never acquires it

    throw new Exception;             // rollback fires the release callback
});

// the first job's lock is gone, so duplicates can be queued while it's still pending
```

`Queue::push()` and `Queue::later()` register the rollback callback through `enqueueUsing()`, but they don't go through `PendingDispatch`, which is where the lock actually gets acquired.

Same failure mode you fixed for retries in #60906, just at a different call site. A job using `Queueable` always records an owner when it acquires, so an empty owner means it never had the lock and has nothing to release.

I kept the check in the rollback callback instead of putting it in `UniqueLock::release()`. Doing it in `release()` would also change the processing path, and since `uniqueFor` defaults to 0 the lock has no expiry, so a job serialized before #60906 (no owner in its payload) would leak its lock permanently after upgrading. `addCallbackForRollback` is still registered either way, so the `QueueConnectionTest` expectations are untouched.

Test sits with the other unique lock tests and fails without the change.
