### PR TITLE
[13.x] Fix BC break: restore whereKey() and whereKeyNot() signatures

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -271,9 +271,10 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the primary key to the query.
      *
+     * @param  mixed  $id
      * @return $this
      */
-    public function whereKey(mixed $id, string $boolean = 'and', bool $not = false): static
+    public function whereKey($id)
     {
         if ($id instanceof Model) {
             $id = $id->getKey();
@@ -281,9 +282,9 @@ class Builder implements BuilderContract
 
         if (is_array($id) || $id instanceof Arrayable) {
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
-                $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id, $boolean, $not);
+                $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id);
             } else {
-                $this->query->whereIn($this->model->getQualifiedKeyName(), $id, $boolean, $not);
+                $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
             }
 
             return $this;
@@ -293,37 +294,58 @@ class Builder implements BuilderContract
             $id = (string) $id;
         }
 
-        return $this->where($this->model->getQualifiedKeyName(), $not ? '!=' : '=', $id, $boolean);
+        return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 
     /**
      * Add a where clause on the primary key to the query.
      *
+     * @param  mixed  $id
      * @return $this
      */
-    public function whereKeyNot(mixed $id, string $boolean = 'and'): static
+    public function whereKeyNot($id)
     {
-        return $this->whereKey($id, $boolean, true);
+        if ($id instanceof Model) {
+            $id = $id->getKey();
+        }
+
+        if (is_array($id) || $id instanceof Arrayable) {
+            if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
+                $this->query->whereIntegerNotInRaw($this->model->getQualifiedKeyName(), $id);
+            } else {
+                $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
+            }
+
+            return $this;
+        }
+
+        if ($id !== null && $this->model->getKeyType() === 'string') {
+            $id = (string) $id;
+        }
+
+        return $this->where($this->model->getQualifiedKeyName(), '!=', $id);
     }
 
     /**
      * Add an "or where" clause on the primary key to the query.
      *
+     * @param  mixed  $id
      * @return $this
      */
-    public function orWhereKey(mixed $id): static
+    public function orWhereKey($id)
     {
-        return $this->whereKey($id, 'or');
+        return $this->where(fn (self $query) => $query->whereKey($id), null, null, 'or');
     }
 
     /**
      * Add an "or where not" clause on the primary key to the query.
      *
+     * @param  mixed  $id
      * @return $this
      */
-    public function orWhereKeyNot(mixed $id): static
+    public function orWhereKeyNot($id)
     {
-        return $this->whereKeyNot($id, 'or');
+        return $this->where(fn (self $query) => $query->whereKeyNot($id), null, null, 'or');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -33,7 +33,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('first')->with(['column'])->andReturn('baz');
 
         $result = $builder->find('bar', ['column']);
@@ -46,7 +46,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('sole')->with(['column'])->andReturn('baz');
 
         $result = $builder->findSole('bar', ['column']);
@@ -60,7 +60,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', ['one', 'two'], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', ['one', 'two']);
         $builder->expects('get')->with(['column'])->andReturn(['baz']);
 
         $result = $builder->findMany(['one', 'two'], ['column']);
@@ -98,7 +98,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('first')->with(['column'])->andReturn('baz');
 
         $expected = $model->findOrNew('bar', ['column']);
@@ -114,7 +114,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('first')->with(['column'])->andReturn(null);
 
         $result = $model->findOrNew('bar', ['column']);
@@ -131,7 +131,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('first')->with(['column'])->andReturn(null);
         $builder->findOrFail('bar', ['column']);
     }
@@ -164,7 +164,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail([1, 2], ['column']);
     }
@@ -179,7 +179,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail(new Collection([1, 2]), ['column']);
     }
@@ -190,8 +190,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->times(3)->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 1, 'and')->times(2);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 2, 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 1)->times(2);
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 2);
         $builder->expects('first')->andReturn($model);
         $builder->expects('first')->with(['column'])->andReturn($model);
         $builder->expects('first')->andReturn(null);
@@ -209,8 +209,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1->expects('getKeyType')->times(3)->andReturn('int');
         $model2->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model1);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false)->times(2);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->times(2);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->andReturn(null);
@@ -237,8 +237,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1->expects('getKeyType')->times(3)->andReturn('int');
         $model2->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model1);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false)->times(2);
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->times(2);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->andReturn(null);
@@ -272,7 +272,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
         $builder->setModel($model);
         $builder->expects('get')->with(['column'])->andReturn('baz');
 
@@ -286,7 +286,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = Mockery::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2], 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2]);
         $builder->setModel($model);
         $builder->expects('get')->with(['column'])->andReturn('baz');
 
@@ -384,7 +384,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->expects('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar', 'and');
+        $builder->getQuery()->expects('where')->with('foo_table.foo', '=', 'bar');
         $builder->expects('first')->with(['column'])->andReturn(null);
         $builder->whereKey('bar')->valueOrFail('column');
     }
@@ -2293,7 +2293,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $int = 1;
 
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '=', $int, 'and');
+        $builder->getQuery()->expects('where')->with($keyName, '=', $int);
 
         $builder->whereKey($int);
     }
@@ -2306,7 +2306,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->expects('where')->with($keyName, '=', (string) $int, 'and');
+        $builder->getQuery()->expects('where')->with($keyName, '=', (string) $int);
 
         $builder->whereKey($int);
     }
@@ -2319,7 +2319,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '=', Mockery::on(function ($argument) {
             return $argument === null;
-        }), 'and');
+        }));
 
         $builder->whereKey(null);
     }
@@ -2333,7 +2333,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $array = [1, 2, 3];
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array);
 
         $builder->whereKey($array);
     }
@@ -2347,7 +2347,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $collection = new Collection([1, 2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'and', false);
+        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection);
 
         $builder->whereKey($collection);
     }
@@ -2360,7 +2360,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }), 'and');
+        }));
 
         $builder->whereKey(new class extends Model
         {
@@ -2376,7 +2376,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->expects('where')->with($keyName, '!=', (string) $int, 'and');
+        $builder->getQuery()->expects('where')->with($keyName, '!=', (string) $int);
 
         $builder->whereKeyNot($int);
     }
@@ -2389,7 +2389,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === null;
-        }), 'and');
+        }));
 
         $builder->whereKeyNot(null);
     }
@@ -2403,7 +2403,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $int = 1;
 
         $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '!=', $int, 'and');
+        $builder->getQuery()->expects('where')->with($keyName, '!=', $int);
 
         $builder->whereKeyNot($int);
     }
@@ -2417,7 +2417,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $array = [1, 2, 3];
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'and', true);
+        $builder->getQuery()->expects('whereIntegerNotInRaw')->with($keyName, $array);
 
         $builder->whereKeyNot($array);
     }
@@ -2431,7 +2431,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $collection = new Collection([1, 2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'and', true);
+        $builder->getQuery()->expects('whereIntegerNotInRaw')->with($keyName, $collection);
 
         $builder->whereKeyNot($collection);
     }
@@ -2444,7 +2444,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }), 'and');
+        }));
 
         $builder->whereKeyNot(new class extends Model
         {
@@ -2454,86 +2454,79 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testOrWhereKeyMethodWithInt()
     {
-        $model = $this->getMockModel();
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $int = 1;
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(2);
 
-        $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '=', $int, 'or');
-
-        $builder->orWhereKey($int);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" = ?)', $query->toSql());
+        $this->assertEquals([1, 2], $query->getBindings());
     }
 
     public function testOrWhereKeyMethodWithArray()
     {
-        $model = $this->getMockModel();
-        $model->expects('getKeyType')->andReturn('int');
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $array = [1, 2, 3];
+        $query = $model->newQuery()->whereKey(1)->orWhereKey([2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'or', false);
-
-        $builder->orWhereKey($array);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
     }
 
     public function testOrWhereKeyMethodWithCollection()
     {
-        $model = $this->getMockModel();
-        $model->expects('getKeyType')->andReturn('int');
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $collection = new Collection([1, 2, 3]);
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(new Collection([2, 3]));
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'or', false);
-
-        $builder->orWhereKey($collection);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
     }
 
     public function testOrWhereKeyNotMethodWithInt()
     {
-        $model = $this->getMockModel();
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $int = 1;
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot(2);
 
-        $model->expects('getKeyType')->andReturn('int');
-        $builder->getQuery()->expects('where')->with($keyName, '!=', $int, 'or');
-
-        $builder->orWhereKeyNot($int);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" != ?)', $query->toSql());
+        $this->assertEquals([1, 2], $query->getBindings());
     }
 
     public function testOrWhereKeyNotMethodWithArray()
     {
-        $model = $this->getMockModel();
-        $model->expects('getKeyType')->andReturn('int');
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $array = [1, 2, 3];
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot([2, 3]);
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $array, 'or', true);
-
-        $builder->orWhereKeyNot($array);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" not in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
     }
 
     public function testOrWhereKeyNotMethodWithCollection()
     {
-        $model = $this->getMockModel();
-        $model->expects('getKeyType')->andReturn('int');
-        $builder = $this->getBuilder()->setModel($model);
-        $keyName = $model->getQualifiedKeyName();
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
 
-        $collection = new Collection([1, 2, 3]);
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot(new Collection([2, 3]));
 
-        $builder->getQuery()->expects('whereIntegerInRaw')->with($keyName, $collection, 'or', true);
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" not in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
 
-        $builder->orWhereKeyNot($collection);
+    public function testWhereKeyOverriddenWithLegacySignatureIsHonoredByOrVariants()
+    {
+        $model = new EloquentBuilderTestWhereKeyOverrideStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(2)->orWhereKeyNot(3);
+
+        $this->assertSame('select * from "table" where ("tenant_id" = ? and "local_id" = ?) or (("tenant_id" = ? and "local_id" = ?)) or (not ("tenant_id" = ? and "local_id" = ?))', $query->toSql());
+        $this->assertEquals([1, 1, 2, 2, 3, 3], $query->getBindings());
     }
 
     public function testExceptMethodWithModel()
@@ -2544,7 +2537,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->getQuery()->expects('where')->with($keyName, '!=', Mockery::on(function ($argument) {
             return $argument === '1';
-        }), 'and');
+        }));
 
         $builder->except(new class extends Model
         {
@@ -2558,9 +2551,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $builder->getQuery()->expects('whereIn')->with($keyName, Mockery::on(function ($argument) {
+        $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
             return $argument === [1, 2];
-        }), 'and', true);
+        }));
 
         $models = new Collection([
             new class extends Model
@@ -2582,9 +2575,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $builder->getQuery()->expects('whereIn')->with($keyName, Mockery::on(function ($argument) {
+        $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
             return $argument === [1, 2];
-        }), 'and', true);
+        }));
 
         $models = [
             new class extends Model
@@ -3325,6 +3318,29 @@ class EloquentBuilderTestStubStringPrimaryKey extends Model
     protected $table = 'foo_table';
 
     protected $keyType = 'string';
+}
+
+class EloquentBuilderTestWhereKeyOverrideStub extends Model
+{
+    protected $table = 'table';
+
+    public function newEloquentBuilder($query)
+    {
+        return new EloquentBuilderTestWhereKeyOverrideBuilder($query);
+    }
+}
+
+class EloquentBuilderTestWhereKeyOverrideBuilder extends Builder
+{
+    public function whereKey($id)
+    {
+        return $this->where(fn ($query) => $query->where('tenant_id', '=', $id)->where('local_id', '=', $id));
+    }
+
+    public function whereKeyNot($id)
+    {
+        return $this->whereNot(fn ($query) => $query->where('tenant_id', '=', $id)->where('local_id', '=', $id));
+    }
 }
 
 class EloquentBuilderTestWhereBelongsToStub extends Model


### PR DESCRIPTION
Fixes #61233.

## Problem

#61154 (shipped in v13.26.0) changed the signatures of two public methods on `Illuminate\Database\Eloquent\Builder`:

```php
// v13.25.0
public function whereKey($id)
public function whereKeyNot($id)

// v13.26.0
public function whereKey(mixed $id, string $boolean = 'and', bool $not = false): static
public function whereKeyNot(mixed $id, string $boolean = 'and'): static
```

Any class extending the builder and overriding either method now fails with a fatal error at class resolution time, taking down every request or test that touches the model:

```
Fatal error: Declaration of App\MyBuilder::whereKey($id) must be compatible with
Illuminate\Database\Eloquent\Builder::whereKey(mixed $id, string $boolean = 'and',
bool $not = false): static
```

Overriding these methods is not exotic: it is the only way to support composite primary keys, since the base implementation is structurally single column (it resolves one qualified key name and emits one where clause). Several published packages and any app mapping a legacy schema rely on it.

## Fix

Restore `whereKey()` and `whereKeyNot()` to their exact pre-13.26.0 signatures and bodies, and keep the new `orWhereKey()` / `orWhereKeyNot()` methods by delegating through a nested where group instead of threading `$boolean` / `$not` parameters:

```php
public function orWhereKey($id)
{
    return $this->where(fn (self $query) => $query->whereKey($id), null, null, 'or');
}
```

This also fixes a second problem with the original approach: the `or` variants now route through the (possibly overridden) `whereKey()` / `whereKeyNot()`, so a subclass gets correct `orWhereKey()` behavior for free. Under the v13.26.0 implementation, a subclass adopting the new signature but ignoring `$boolean` would have `orWhereKey()` silently emit `AND` instead of `OR`.

The generated SQL for the `or` variants gains a parenthesized group, e.g. `or ("users"."id" = ?)` instead of `or "users"."id" = ?`, which is semantically identical.

No framework code passed the removed `$boolean` / `$not` arguments outside these four methods.

## Tests

- Rewrote the six `orWhereKey()` / `orWhereKeyNot()` tests as real SQL assertions instead of mock expectations.
- Restored the pre-13.26.0 mock expectations that had been updated for the new signatures.
- Added a regression test with a builder subclass overriding `whereKey($id)` / `whereKeyNot($id)` using the legacy signature (mimicking a composite key builder). Loading that class alone would fatal before this change, and the test proves the `or` variants honor the override.
