### PR TITLE
[13.x] Include response headers in truncated RequestException messages

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use GuzzleHttp\Psr7\Message;
+use GuzzleHttp\Psr7\Utils;
 
 class RequestException extends HttpClientException
 {
@@ -114,6 +115,10 @@ class RequestException extends HttpClientException
 
         if (is_int($truncateExceptionsAt)) {
             $summary = Message::bodySummary($psrResponse, $truncateExceptionsAt);
+
+            if (! is_null($summary)) {
+                $summary = Message::toString($psrResponse->withBody(Utils::streamFor(''))).$summary;
+            }
         } elseif (($body = $psrResponse->getBody())->isSeekable() && $body->isReadable()) {
             $summary = Message::toString($psrResponse);
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1742,6 +1742,27 @@ class HttpClientTest extends TestCase
         throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
     }
 
+    public function testTruncatedRequestExceptionMessageIncludesResponseHeaders()
+    {
+        RequestException::truncateAt(60);
+
+        $this->factory->fake([
+            '*' => $this->factory::response(str_repeat('a', 100), 403, ['Content-Type' => 'text/plain']),
+        ]);
+
+        $exception = null;
+        try {
+            $this->factory->throw()->get('http://foo.com/json');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertSame(
+            "HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\n\r\n".str_repeat('a', 60)." (truncated...)\n",
+            $exception->getMessage()
+        );
+    }
+
     public function testRequestLevelTruncationLevelOnRequestException()
     {
         RequestException::truncateAt(60);
@@ -1758,12 +1779,12 @@ class HttpClientTest extends TestCase
         }
 
         // Ensure the exception message is truncated according to the request level truncation setting.
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $exception->report();
 
         // Ensure that the truncation level is not changed when reporting the exception.
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertEquals(60, RequestException::$truncateAt);
     }
@@ -1808,7 +1829,7 @@ class HttpClientTest extends TestCase
 
         $exception->report();
 
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertFalse(RequestException::$truncateAt);
     }
@@ -1825,7 +1846,7 @@ class HttpClientTest extends TestCase
         $exception->report();
 
         $this->assertInstanceOf(RequestException::class, $exception);
-        $this->assertSame("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"er (truncated...)\n", $exception->getMessage());
         $this->assertFalse(RequestException::$truncateAt);
     }
 


### PR DESCRIPTION
With exception-message truncation active — the default, or via `truncateAt()` / per-request `truncateExceptionsAt()` — a `RequestException` message loses the response status line and headers entirely, while the same request with `dontTruncate()` includes them. The inconsistency comes from `prepareMessage()` using two different Guzzle formatters: the truncated branch builds the message from `Message::bodySummary()`, which only ever returns the body, while the untruncated branch uses `Message::toString()`, which renders the whole message including headers. So header context (content type, rate-limit headers, server identity) disappears exactly when truncation is on, which is most of the time when debugging failed requests.

This PR keeps the status line and headers in truncated messages and truncates only the body, so both modes carry the same information:

```
// truncateAt(60), before:
HTTP request returned status code 403:
["e (truncated...)

// truncateAt(60), after:
HTTP request returned status code 403:
HTTP/1.1 403 Forbidden
Content-Type: application/json

["e (truncated...)
```

`dontTruncate()` output is unchanged and the configured length still bounds only the body. When `Message::bodySummary()` returns `null` (empty, non-seekable, unreadable, or binary body) the message stays the bare status-code line exactly as today, so the existing streaming and empty-body tests pass unchanged. One thing worth weighing in review: headers can carry sensitive values (e.g. `Set-Cookie`) into logs under default truncation — this matches what `dontTruncate()` already exposes today, but it does make that exposure the default behavior too.

A regression test is included (it fails on current `13.x`), and the three existing exact-message truncation assertions are updated to the new shape.

Fixes #61216
