### PR TITLE
[13.x] Skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   mysql_innovation:
+    if: github.repository == 'laravel/framework'
+
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -41,6 +43,8 @@ jobs:
           DB_CONNECTION: mysql
 
   mariadb:
+    if: github.repository == 'laravel/framework'
+
     runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 10

--- a/.github/workflows/install-nightly.yml
+++ b/.github/workflows/install-nightly.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   install:
+    if: github.repository == 'laravel/framework'
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   linux_tests:
+    if: github.event_name != 'schedule' || github.repository == 'laravel/framework'
+
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -87,6 +89,8 @@ jobs:
             !vendor/**/.gitignore
 
   windows_tests:
+    if: github.event_name != 'schedule' || github.repository == 'laravel/framework'
+
     runs-on: windows-2022
     timeout-minutes: 10
 


### PR DESCRIPTION
### Description

Scheduled GitHub Actions workflows currently run daily on every fork of this repository, wasting GitHub Actions compute (and billing for contributors who have Actions enabled on their forks).

I forked this repo for a few days, and the billing is $11.11, which is included in GitHub as open source, but is it needed? No, and it should not run on forks.
<img width="1211" height="476" alt="image" src="https://github.com/user-attachments/assets/422078d4-069d-461e-b320-227c32738192" />
