### PR TITLE
[13.x] Re-introduce orWhereKey() and orWhereKeyNot() without breaking Builder subclasses

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -327,6 +327,28 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "or where" clause on the primary key to the query.
+     *
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function orWhereKey($id)
+    {
+        return $this->where(fn (self $query) => $query->whereKey($id), null, null, 'or');
+    }
+
+    /**
+     * Add an "or where not" clause on the primary key to the query.
+     *
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function orWhereKeyNot($id)
+    {
+        return $this->where(fn (self $query) => $query->whereKeyNot($id), null, null, 'or');
+    }
+
+    /**
      * Exclude the given models from the query results.
      *
      * @param  iterable|mixed  $models

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2452,6 +2452,83 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
+    public function testOrWhereKeyMethodWithInt()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(2);
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" = ?)', $query->toSql());
+        $this->assertEquals([1, 2], $query->getBindings());
+    }
+
+    public function testOrWhereKeyMethodWithArray()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKey([2, 3]);
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testOrWhereKeyMethodWithCollection()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(new Collection([2, 3]));
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testOrWhereKeyNotMethodWithInt()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot(2);
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" != ?)', $query->toSql());
+        $this->assertEquals([1, 2], $query->getBindings());
+    }
+
+    public function testOrWhereKeyNotMethodWithArray()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot([2, 3]);
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" not in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testOrWhereKeyNotMethodWithCollection()
+    {
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKeyNot(new Collection([2, 3]));
+
+        $this->assertSame('select * from "table" where "table"."id" = ? or ("table"."id" not in (2, 3))', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testOrWhereKeyMethodsHonorWhereKeyOverrides()
+    {
+        $model = new EloquentBuilderTestWhereKeyOverrideStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereKey(1)->orWhereKey(2)->orWhereKeyNot(3);
+
+        $this->assertSame('select * from "table" where ("tenant_id" = ? and "local_id" = ?) or (("tenant_id" = ? and "local_id" = ?)) or (not ("tenant_id" = ? and "local_id" = ?))', $query->toSql());
+        $this->assertEquals([1, 1, 2, 2, 3, 3], $query->getBindings());
+    }
+
     public function testExceptMethodWithModel()
     {
         $model = new EloquentBuilderTestStubStringPrimaryKey;
@@ -3241,6 +3318,29 @@ class EloquentBuilderTestStubStringPrimaryKey extends Model
     protected $table = 'foo_table';
 
     protected $keyType = 'string';
+}
+
+class EloquentBuilderTestWhereKeyOverrideStub extends Model
+{
+    protected $table = 'table';
+
+    public function newEloquentBuilder($query)
+    {
+        return new EloquentBuilderTestWhereKeyOverrideBuilder($query);
+    }
+}
+
+class EloquentBuilderTestWhereKeyOverrideBuilder extends Builder
+{
+    public function whereKey($id)
+    {
+        return $this->where(fn ($query) => $query->where('tenant_id', '=', $id)->where('local_id', '=', $id));
+    }
+
+    public function whereKeyNot($id)
+    {
+        return $this->whereNot(fn ($query) => $query->where('tenant_id', '=', $id)->where('local_id', '=', $id));
+    }
 }
 
 class EloquentBuilderTestWhereBelongsToStub extends Model


### PR DESCRIPTION
This re-introduces `orWhereKey()` / `orWhereKeyNot()` from #61154 (by @calebdw), which was reverted in #61236 because changing the `whereKey()` / `whereKeyNot()` signatures fatally broke subclasses overriding them (#61233), for example composite primary key builders.

This implementation adds the same feature without touching any existing method. The `or` variants delegate through a nested where group:

```php
public function orWhereKey($id)
{
    return $this->where(fn (self $query) => $query->whereKey($id), null, null, 'or');
}
```

- `whereKey()` and `whereKeyNot()` keep their existing signatures and bodies, so nothing that extends the builder can break.
- Because the `or` variants call `whereKey()` / `whereKeyNot()` polymorphically, subclasses that override them automatically get correct `orWhereKey()` behavior, covered by a dedicated test with a composite key style builder.
- Generated SQL uses a parenthesized group, e.g. `or ("users"."id" = ?)`, which is semantically identical to a bare `or` clause.

Tests assert the generated SQL and bindings for int, array, and collection keys, plus the subclass override case.
