### PR TITLE
[13.x] Exclude mockery 1.6.14 to fix broken CI matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
         "spatie/once": "*"
     },
     "conflict": {
+        "mockery/mockery": "1.6.14",
         "tightenco/collect": "<5.5.33"
     },
     "provide": {


### PR DESCRIPTION
mockery/mockery 1.6.14 (released 2026-08-18) regressed `makePartial()` mocks: an explicit `$mock->__construct(...)` no longer invokes the real constructor, and a real `__clone` method on the mocked class is shadowed and skipped. Reported upstream with a minimal reproduction in mockery/mockery#1514.

This breaks the framework's own test matrix on every `prefer-stable` run since the release. For example `DatabaseEloquentBelongsToManyCreateOrFirstTest` uses the partial-then-`__construct` pattern and its `firstOrCreate()` path relies on `Relation::__clone`, failing with:

```
Error: Call to a member function where() on null
```

and `DatabaseMigrationRefreshCommandTest` fails with:

```
Error: Typed property Symfony\Component\Console\Application::$defaultCommand must not be accessed before initialization
```

This PR pins the exact broken version via `conflict`, so 1.6.13 is resolved now and a fixed 1.6.15 will be picked up automatically without a follow-up change. Verified locally that the resolver falls back to 1.6.13 and the failing test files pass again.
