### PR TITLE
[13.x] Fix PHPUnit and Mockery deprecations in tests

### DIFF
--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -115,20 +115,20 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertSame('taylor', $result->username);
     }
 
-    public function testMorphToWithZeroMorphType()
+    public function testMorphToWithZeroMorphType(): void
     {
         $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttributeFromArray', 'morphEagerTo', 'morphInstanceTo'])->getMock();
-        $parent->method('getAttributeFromArray')->with('relation_type')->willReturn(0);
+        $parent->expects($this->once())->method('getAttributeFromArray')->with('relation_type')->willReturn(0);
         $parent->expects($this->once())->method('morphInstanceTo');
         $parent->expects($this->never())->method('morphEagerTo');
 
         $parent->relation();
     }
 
-    public function testMorphToWithEmptyStringMorphType()
+    public function testMorphToWithEmptyStringMorphType(): void
     {
         $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttributeFromArray', 'morphEagerTo', 'morphInstanceTo'])->getMock();
-        $parent->method('getAttributeFromArray')->with('relation_type')->willReturn('');
+        $parent->expects($this->once())->method('getAttributeFromArray')->with('relation_type')->willReturn('');
         $parent->expects($this->once())->method('morphEagerTo');
         $parent->expects($this->never())->method('morphInstanceTo');
 

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -102,15 +102,19 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
     }
 }
 
-class InputMatcher extends Mockery\Matcher\MatcherAbstract
+class InputMatcher implements \Mockery\Matcher\MatcherInterface
 {
+    public function __construct(protected $expected)
+    {
+    }
+
     /**
      * @param  \Symfony\Component\Console\Input\ArrayInput  $actual
      * @return bool
      */
     public function match(&$actual)
     {
-        return (string) $actual == $this->_expected;
+        return (string) $actual === $this->expected;
     }
 
     public function __toString()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1122,7 +1122,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertSame(['mid-0', 'mid-1'], array_map(fn ($e) => $e->id, array_values($queuedEvents)));
     }
 
-    public function testBulkHonoursPerJobDelay()
+    public function testBulkHonoursPerJobDelay(): void
     {
         $jobA = new FakeSqsJob;
         $jobA->delay = 30;
@@ -1136,7 +1136,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->setContainer(Mockery::spy(Container::class));
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->method('createPayload')->willReturnCallback(fn ($job, $q, $data, $delay) => 'payload-'.($delay ?? 'none'));
-        $queue->method('secondsUntil')->with(30)->willReturn(30);
+        $queue->expects($this->once())->method('secondsUntil')->with(30)->willReturn(30);
 
         $captured = null;
 
@@ -1152,7 +1152,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertArrayNotHasKey('DelaySeconds', $captured['Entries'][1]);
     }
 
-    public function testBulkHonoursDelayAttribute()
+    public function testBulkHonoursDelayAttribute(): void
     {
         $queue = $this->getMockBuilder(SqsQueue::class)
             ->onlyMethods(['getQueue', 'createPayload', 'secondsUntil'])
@@ -1161,7 +1161,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->setContainer(Mockery::spy(Container::class));
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->method('createPayload')->willReturnCallback(fn ($job, $q, $data, $delay) => 'payload-'.($delay ?? 'none'));
-        $queue->method('secondsUntil')->with(15)->willReturn(15);
+        $queue->expects($this->once())->method('secondsUntil')->with(15)->willReturn(15);
 
         $captured = null;
 


### PR DESCRIPTION
Fixes a few PHPUnit and Mockery deprecation warnings surfacing in the test suite.