### PR TITLE
[13.x] Add `refreshForUpdate()` method to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2109,8 +2109,35 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this;
         }
 
+        return $this->refreshUsingQuery($this->newQueryWithoutScopes());
+    }
+
+    /**
+     * Reload the current model instance with fresh attributes from the database while locking it for updating.
+     *
+     * @return $this
+     */
+    public function refreshForUpdate()
+    {
+        if (! $this->exists) {
+            return $this;
+        }
+
+        return $this->refreshUsingQuery(
+            $this->newQueryWithoutScopes()->lockForUpdate()
+        );
+    }
+
+    /**
+     * Reload the current model instance using the given query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return $this
+     */
+    protected function refreshUsingQuery(Builder $query)
+    {
         $this->setRawAttributes(
-            $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+            $this->setKeysForSelectQuery($query)
                 ->useWritePdo()
                 ->firstOrFail()
                 ->attributes

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -719,6 +719,31 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelFindWithWritePdoStub::onWriteConnection()->find(1);
     }
 
+    public function testRefreshForUpdateUsesLockForUpdate()
+    {
+        $model = Mockery::mock(EloquentModelStub::class.'[newQueryWithoutScopes,load]');
+        $model->exists = true;
+        $model->setRawAttributes(['id' => 1, 'name' => 'Taylor'], true);
+
+        $freshModel = new EloquentModelStub;
+        $freshModel->setRawAttributes(['id' => 1, 'name' => 'Abigail']);
+
+        $query = Mockery::mock(Builder::class);
+        $model->expects('newQueryWithoutScopes')->once()->andReturn($query);
+        $query->expects('lockForUpdate')->once()->andReturnSelf();
+        $query->expects('where')->once()->with('id', '=', 1)->andReturnSelf();
+        $query->expects('useWritePdo')->once()->andReturnSelf();
+        $query->expects('firstOrFail')->once()->andReturn($freshModel);
+        $model->expects('load')->once()->with([])->andReturnSelf();
+
+        $result = $model->refreshForUpdate();
+
+        $this->assertSame($model, $result);
+        $this->assertSame('Abigail', $model->name);
+        $this->assertEmpty($model->getDirty());
+        $this->assertSame('Abigail', $model->getOriginal('name'));
+    }
+
     public function testDestroyMethodCallsQueryBuilderCorrectly()
     {
         EloquentModelDestroyStub::destroy(1, 2, 3);

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
@@ -64,6 +65,21 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $this->assertEmpty($post->getDirty());
         $this->assertEmpty($post->getPrevious());
+    }
+
+    public function testItRefreshesModelForUpdate()
+    {
+        $post = Post::create(['title' => 'pat']);
+
+        Post::whereKey($post)->update(['title' => 'patrick']);
+
+        DB::transaction(function () use ($post) {
+            $this->assertSame($post, $post->refreshForUpdate());
+        });
+
+        $this->assertSame('patrick', $post->title);
+        $this->assertEmpty($post->getDirty());
+        $this->assertSame('patrick', $post->getOriginal('title'));
     }
 
     public function testAsPivot()


### PR DESCRIPTION
This PR adds a `refreshForUpdate()` method to Eloquent models -- solving a bit of a convenience paper cut that I've experienced for a few years and never got around to PR'ing.

Models are often loaded before a transaction begins (ex. through route model binding). Acquiring a pessimistic lock currently requires us to create another query, look up the model by its primary key, and replace the existing instance.

For example, safely reducing a product's available stock currently requires:

```php
public function purchase(Product $product): Response
{
    DB::transaction(function () use ($product) {
        $product = Product::query()
            ->lockForUpdate()
            ->findOrFail($product->getKey());

        if ($product->stock === 0) {
            throw new RuntimeException('The product is out of stock.');
        }

        $product->decrement('stock');
    });

    // ...
}
```

With this change, the existing model can be refreshed and locked directly:

```php
public function purchase(Product $product): Response
{
    DB::transaction(function () use ($product) {
        $product->refreshForUpdate();

        if ($product->stock === 0) {
            throw new RuntimeException('The product is out of stock.');
        }

        $product->decrement('stock');
    });

    // ...
}
```

The method behaves like `refresh()`, but applies `lockForUpdate()` to the query used to reload the model. It refreshes the existing instance with the current database attributes, allowing it to be used without reassignment for the remainder of the transaction.

Let me know your thoughts! ❤️ 