### PR TITLE
[13.x] Throw exception when an invalid relationship is passed to `whenLoaded()` in `JsonResource`

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -272,11 +272,11 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenLoaded($relationship, $value = null, $default = new MissingValue)
     {
-        if (! $this->resource->isRelation($relationship)) {
-            throw RelationNotFoundException::make($this->resource, $relationship);
-        }
-
         if (! $this->resource->relationLoaded($relationship)) {
+            if (! $this->resource->isRelation($relationship)) {
+                throw RelationNotFoundException::make($this->resource, $relationship);
+            }
+
             return value($default);
         }
 

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Resources;
 
+use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Http\Resources\Attributes\PreserveKeys;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Stringable;
@@ -271,6 +272,10 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenLoaded($relationship, $value = null, $default = new MissingValue)
     {
+        if (! $this->resource->isRelation($relationship)) {
+            throw RelationNotFoundException::make($this->resource, $relationship);
+        }
+
         if (! $this->resource->relationLoaded($relationship)) {
             return value($default);
         }

--- a/tests/Integration/Http/Fixtures/Comment.php
+++ b/tests/Integration/Http/Fixtures/Comment.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Author extends Model
+class Comment extends Model
 {
     /**
      * The attributes that aren't mass assignable.
@@ -12,9 +12,4 @@ class Author extends Model
      * @var string[]
      */
     protected $guarded = [];
-
-    public function posts()
-    {
-        return $this->hasMany(Post::class);
-    }
 }

--- a/tests/Integration/Http/Fixtures/Post.php
+++ b/tests/Integration/Http/Fixtures/Post.php
@@ -22,4 +22,14 @@ class Post extends Model
     {
         return true;
     }
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
 }


### PR DESCRIPTION
## What does this PR do?

This PR improves the developer experience of the `whenLoaded` method in `JsonResource` by ensuring that invalid or non-existent relationship names throw a `RelationNotFoundException` instead of silently returning the default value (or `null`).

Currently, passing an incorrect relation name to `whenLoaded` causes it to behave as if the relation is simply not loaded, which often masks typos and leads to "silent failures" that are time-consuming to debug.

## Why is this needed?

1. **Debugging Efficiency:** Developers will now be alerted immediately if a typo exists in a relationship name within their API resources.
2. **Predictability:** It enforces strictness when defining resource data, ensuring that developers are explicitly aware of the relationships they are attempting to load.

## Implementation Details

I have updated the logic to verify the existence of the relationship using `isRelation()` when it has not yet been loaded.

```php
if (! $this->resource->relationLoaded($relationship)) {
    // If the relation is not loaded, verify if it exists on the model
    if (! $this->resource->isRelation($relationship)) {
        throw RelationNotFoundException::make($this->resource, $relationship);
    }

    return value($default);
}
```

## Why this specific check & handling for `setRelation`?

Placing the `isRelation()` check inside the `! $this->resource->relationLoaded($relationship)` condition is intentional.

The goal is to make `whenLoaded` **strict by default**: if a relationship is neither loaded nor defined on the model, it should be treated as an invalid relationship name and immediately throw a `RelationNotFoundException`.

However, there is one intentional exception to this strict behavior: **fake or dynamically injected relationships**.

Even if a relationship is not initially present in the database or loaded through standard eager-loading, developers frequently use `setRelation()` to dynamically inject "fake" or computed relations onto a model at runtime.

By checking `isRelation()` only when the relationship isn't already loaded, we ensure that:

* **Invalid relation strings**, such as typos or non-existent relationships, immediately trigger a `RelationNotFoundException`.
* **Real relationships** continue to follow the expected strict behavior.
* **Fake or dynamically injected relationships**, set through `setRelation()`, continue to work seamlessly without triggering false-positive exceptions.

In other words, the behavior is intentionally **strict unless the relationship has been explicitly loaded/set on the model**. This gives us the safety and predictability of strict relationship validation while preserving the flexibility needed for `setRelation()` and custom/fake relationships.

This approach avoids silently accepting invalid relationship names while still allowing legitimate runtime-defined relationships to work as expected.
