### PR TITLE
Add MariaDB support for vector distance queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\Paginator;
@@ -519,7 +518,7 @@ class Builder implements BuilderContract
         $as = $this->getGrammar()->wrap($as ?? $column.'_distance');
 
         return $this->addSelect(
-            new Expression("({$this->getGrammar()->wrap($column)} <=> ?) as {$as}")
+            new Expression("{$this->getGrammar()->compileVectorDistanceExpression($column)} as {$as}")
         );
     }
 
@@ -1254,7 +1253,7 @@ class Builder implements BuilderContract
         }
 
         return $this->whereRaw(
-            "({$this->getGrammar()->wrap($column)} <=> ?) <= ?",
+            "{$this->getGrammar()->compileVectorDistanceExpression($column)} <= ?",
             [
                 json_encode(
                     $vector instanceof Arrayable
@@ -3061,7 +3060,7 @@ class Builder implements BuilderContract
         );
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
-            'column' => new Expression("({$this->getGrammar()->wrap($column)} <=> ?)"),
+            'column' => new Expression($this->getGrammar()->compileVectorDistanceExpression($column)),
             'direction' => 'asc',
         ];
 
@@ -4775,8 +4774,8 @@ class Builder implements BuilderContract
      */
     protected function ensureConnectionSupportsVectors()
     {
-        if (! $this->connection instanceof PostgresConnection) {
-            throw new RuntimeException('Vector distance queries are only supported by Postgres.');
+        if (! $this->getGrammar()->supportsVectorDistance()) {
+            throw new RuntimeException('Vector distance queries are only supported by Postgres and MariaDB.');
         }
     }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -850,6 +850,29 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        throw new RuntimeException('This database engine does not support vector distance queries.');
+    }
+
+    /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return false;
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -1060,29 +1083,6 @@ class Grammar extends BaseGrammar
     public function compileRandom($seed)
     {
         return 'RANDOM()';
-    }
-
-    /**
-     * Determine if the grammar supports vector distance queries.
-     *
-     * @return bool
-     */
-    public function supportsVectorDistance()
-    {
-        return false;
-    }
-
-    /**
-     * Compile a vector distance expression for the given column.
-     *
-     * @param  string  $column
-     * @return string
-     *
-     * @throws \RuntimeException
-     */
-    public function compileVectorDistanceExpression($column)
-    {
-        throw new RuntimeException('This database engine does not support vector distance queries.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1063,6 +1063,29 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return false;
+    }
+
+    /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        throw new RuntimeException('This database engine does not support vector distance queries.');
+    }
+
+    /**
      * Compile the "limit" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -66,4 +66,25 @@ class MariaDbGrammar extends MySqlGrammar
 
         return 'json_value('.$field.$path.')';
     }
+
+    /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return true;
+    }
+
+    /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        return "vec_distance_cosine({$this->wrap($column)}, ?)";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -44,6 +44,27 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        return "vec_distance_cosine({$this->wrap($column)}, ?)";
+    }
+
+    /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return true;
+    }
+
+    /**
      * Determine whether to use a legacy group limit clause for MySQL < 8.0.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -65,26 +86,5 @@ class MariaDbGrammar extends MySqlGrammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_value('.$field.$path.')';
-    }
-
-    /**
-     * Determine if the grammar supports vector distance queries.
-     *
-     * @return bool
-     */
-    public function supportsVectorDistance()
-    {
-        return true;
-    }
-
-    /**
-     * Compile a vector distance expression for the given column.
-     *
-     * @param  string  $column
-     * @return string
-     */
-    public function compileVectorDistanceExpression($column)
-    {
-        return "vec_distance_cosine({$this->wrap($column)}, ?)";
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -226,6 +226,27 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        return "({$this->wrap($column)} <=> ?)";
+    }
+
+    /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return true;
+    }
+
+    /**
      * Compile the "select *" portion of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -880,26 +901,5 @@ class PostgresGrammar extends Grammar
     public static function cascadeOnTrucate(bool $value = true)
     {
         self::cascadeOnTruncate($value);
-    }
-
-    /**
-     * Determine if the grammar supports vector distance queries.
-     *
-     * @return bool
-     */
-    public function supportsVectorDistance()
-    {
-        return true;
-    }
-
-    /**
-     * Compile a vector distance expression for the given column.
-     *
-     * @param  string  $column
-     * @return string
-     */
-    public function compileVectorDistanceExpression($column)
-    {
-        return "({$this->wrap($column)} <=> ?)";
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -881,4 +881,25 @@ class PostgresGrammar extends Grammar
     {
         self::cascadeOnTruncate($value);
     }
+
+    /**
+     * Determine if the grammar supports vector distance queries.
+     *
+     * @return bool
+     */
+    public function supportsVectorDistance()
+    {
+        return true;
+    }
+
+    /**
+     * Compile a vector distance expression for the given column.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function compileVectorDistanceExpression($column)
+    {
+        return "({$this->wrap($column)} <=> ?)";
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7789,6 +7789,75 @@ SQL;
         $this->assertSame([], $clone->getBindings());
     }
 
+    public function testWhereVectorSimilarToOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('documents')->whereVectorSimilarTo('embedding', [1, 2, 3], minSimilarity: 0.4)->limit(10);
+
+        $this->assertSame(
+            'select * from "documents" where ("embedding" <=> ?) <= ? order by ("embedding" <=> ?) asc limit 10',
+            $builder->toSql()
+        );
+        $this->assertEquals(['[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
+    }
+
+    public function testWhereVectorSimilarToOnMariaDb()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->select('*')->from('documents')->whereVectorSimilarTo('embedding', [1, 2, 3], minSimilarity: 0.4)->limit(10);
+
+        $this->assertSame(
+            'select * from `documents` where vec_distance_cosine(`embedding`, ?) <= ? order by vec_distance_cosine(`embedding`, ?) asc limit 10',
+            $builder->toSql()
+        );
+        $this->assertEquals(['[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
+    }
+
+    public function testWhereVectorSimilarToThrowsOnUnsupportedGrammar()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Vector distance queries are only supported by Postgres and MariaDB.');
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('documents')->whereVectorSimilarTo('embedding', [1, 2, 3]);
+    }
+
+    public function testWhereVectorDistanceLessThanOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('documents')->whereVectorDistanceLessThan('embedding', [1, 2, 3], 0.5);
+
+        $this->assertSame('select * from "documents" where ("embedding" <=> ?) <= ?', $builder->toSql());
+        $this->assertEquals(['[1,2,3]', 0.5], $builder->getBindings());
+    }
+
+    public function testWhereVectorDistanceLessThanOnMariaDb()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->select('*')->from('documents')->whereVectorDistanceLessThan('embedding', [1, 2, 3], 0.5);
+
+        $this->assertSame('select * from `documents` where vec_distance_cosine(`embedding`, ?) <= ?', $builder->toSql());
+        $this->assertEquals(['[1,2,3]', 0.5], $builder->getBindings());
+    }
+
+    public function testOrderByVectorDistanceOnMariaDb()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->select('*')->from('documents')->orderByVectorDistance('embedding', [1, 2, 3]);
+
+        $this->assertSame('select * from `documents` order by vec_distance_cosine(`embedding`, ?) asc', $builder->toSql());
+        $this->assertEquals(['[1,2,3]'], $builder->getBindings());
+    }
+
+    public function testSelectVectorDistanceOnMariaDb()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->from('documents')->selectVectorDistance('embedding', [1, 2, 3]);
+
+        $this->assertSame('select vec_distance_cosine(`embedding`, ?) as `embedding_distance` from `documents`', $builder->toSql());
+        $this->assertEquals(['[1,2,3]'], $builder->getBindings());
+    }
+
     public function testToRawSql()
     {
         $connection = $this->getConnection();


### PR DESCRIPTION
## Summary

Laravel's vector similarity search (`whereVectorSimilarTo`, `whereVectorDistanceLessThan`, `orderByVectorDistance`, `selectVectorDistance`) currently only works on PostgreSQL. `Query\Builder::ensureConnectionSupportsVectors()` hard-codes an `instanceof PostgresConnection` check, and the distance SQL itself (`"{$col} <=> ?"`) is inlined directly in `Query\Builder` using the pgvector-specific `<=>` operator.

MariaDB 11.7+ (Community) / 11.4.5-3+ (Enterprise) ships a native `VECTOR` column type and native distance functions (`VEC_DISTANCE_COSINE`, `VEC_DISTANCE_EUCLIDEAN`, `VEC_DISTANCE`). The schema side already partially supports this (`Schema\Grammars\MariaDbGrammar` has had `typeVector()` and `compileVectorIndex()` for a while - #60334), but the query side never got wired up.

This PR:
- Moves the "does this driver support vector distance?" check from the connection class to the grammar, following the exact pattern already used for `compileRandom()` / `supportsSavepoints()` (a base implementation on `Query\Grammars\Grammar`, overridden per-driver).
- Adds a `compileVectorDistanceExpression($column)` method to `Grammar`, overridden in `PostgresGrammar` (unchanged SQL) and newly implemented in `MariaDbGrammar` (using `vec_distance_cosine`).
- Updates `Query\Builder` to call the grammar instead of hard-coding Postgres SQL.
- Adds the first unit tests for this area (there were none before), covering Postgres (non-regression), MariaDB (new), and plain MySQL (still throws, with an updated message).

### Out of scope

Plain MySQL (Community/Enterprise, non-HeatWave) has no native vector distance function. `DISTANCE()`/`VECTOR_DISTANCE()` is only available on MySQL HeatWave (OCI) / MySQL AI, not in the standard MySQL binaries. So `whereVectorSimilarTo()` on a plain MySQL connection still throws a `RuntimeException` (message updated to mention MariaDB). A PHP-side fallback (fetch + compute similarity in memory) was considered but deliberately left out: it would silently defeat `limit()`/pagination semantics and changes the performance contract of the query in a way that deserves its own discussion/PR rather than being bundled here.

## Test plan
- [x] New unit tests in `tests/Database/DatabaseQueryBuilderTest.php` (Postgres/MariaDB/MySQL cases).
- [x] `vendor/bin/phpunit tests/Database/DatabaseQueryBuilderTest.php`
- [x] `vendor/bin/pint`