### PR TITLE
[13.x] Prevent duplicate scoped instance registrations

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -527,7 +527,9 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function scoped($abstract, $concrete = null)
     {
-        $this->scopedInstances[] = $abstract;
+        if (! in_array($abstract, $this->scopedInstances, true)) {
+            $this->scopedInstances[] = $abstract;
+        }
 
         $this->singleton($abstract, $concrete);
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -15,6 +15,7 @@ use LogicException;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
+use ReflectionProperty;
 use stdClass;
 use TypeError;
 
@@ -168,6 +169,42 @@ class ContainerTest extends TestCase
         });
         $this->assertSame('foo', $container->make('class'));
         $this->assertNotSame('bar', $container->make('class'));
+    }
+
+    public function testScopedDoesNotRegisterDuplicateScopedInstances()
+    {
+        $container = new Container;
+        $container->scoped('class', function () {
+            return new stdClass;
+        });
+        $container->scoped('class', function () {
+            return new stdClass;
+        });
+
+        $this->assertSame(['class'], (new ReflectionProperty($container, 'scopedInstances'))->getValue($container));
+    }
+
+    public function testScopedIfDoesNotRegisterDuplicateScopedInstancesWhenRebound()
+    {
+        $container = new Container;
+        $container->scopedIf('class', function () {
+            return new stdClass;
+        });
+
+        unset($container['class']);
+
+        $container->scopedIf('class', function () {
+            return new stdClass;
+        });
+
+        $this->assertSame(['class'], (new ReflectionProperty($container, 'scopedInstances'))->getValue($container));
+
+        $container->forgetScopedInstances();
+
+        $firstInstantiation = $container->make('class');
+        $container->forgetScopedInstances();
+
+        $this->assertNotSame($firstInstantiation, $container->make('class'));
     }
 
     public function testScopedClosureResets()


### PR DESCRIPTION
`Container::scoped()` appends to `$scopedInstances` unconditionally, so registering the same abstract more than once records it more than once.

```php
$container->scoped('foo', fn () => new stdClass);
$container->scoped('foo', fn () => new stdClass);

// $scopedInstances is now ['foo', 'foo']
```

`scopedIf()` avoids this while the abstract stays bound, but not once the binding is removed: `offsetUnset()` clears `bindings`, `instances` and `resolved` and leaves `scopedInstances` alone, so `scopedIf()` sees the binding as gone and re-registers through `scoped()`. Anywhere that happens repeatedly in a long-lived process, the array grows without bound and every `forgetScopedInstances()` walks the duplicates.

`resolve()` already guards the equivalent append for the `#[Scoped]` attribute, added in #56334. This applies the same guard to `scoped()`. Behaviour is unchanged, since `forgetScopedInstances()` unsets an instance by abstract and unsetting the same one twice was already a no-op.