### PR TITLE
[13.x] Add a worker heartbeat event

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -50,6 +50,7 @@ class WorkCommand extends Command
                             {--rest=0 : The number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : The number of times to attempt a job before logging it failed}
+                            {--heartbeat=0 : The number of seconds between worker heartbeat events}
                             {--json : Output the queue worker information as JSON}';
 
     /**
@@ -173,6 +174,7 @@ class WorkCommand extends Command
             $this->option('max-time'),
             $this->option('rest'),
             $this->option('stop-when-empty-for'),
+            $this->option('heartbeat'),
         );
     }
 

--- a/src/Illuminate/Queue/Events/WorkerHeartbeat.php
+++ b/src/Illuminate/Queue/Events/WorkerHeartbeat.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Queue\WorkerOptions;
+
 class WorkerHeartbeat
 {
     /**
@@ -9,18 +11,18 @@ class WorkerHeartbeat
      *
      * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
-     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
+     * @param  \Illuminate\Queue\WorkerOptions  $workerOptions  The worker options.
      * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
      * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
      * @param  int|float|null  $memoryUsage  The memory usage of the worker in MB.
      */
     public function __construct(
-        public $connectionName,
-        public $queue,
-        public $workerOptions = null,
-        public $jobsProcessed = null,
-        public $lastJobProcessedAt = null,
-        public $memoryUsage = null,
+        public string $connectionName,
+        public string $queue,
+        public WorkerOptions $workerOptions,
+        public ?int $jobsProcessed = null,
+        public int|float|null $lastJobProcessedAt = null,
+        public int|float|null $memoryUsage = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerHeartbeat.php
+++ b/src/Illuminate/Queue/Events/WorkerHeartbeat.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerHeartbeat
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName  The connection name.
+     * @param  string  $queue  The queue name.
+     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
+     * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
+     * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
+     * @param  int|float|null  $memoryUsage  The memory usage of the worker in MB.
+     */
+    public function __construct(
+        public $connectionName,
+        public $queue,
+        public $workerOptions = null,
+        public $jobsProcessed = null,
+        public $lastJobProcessedAt = null,
+        public $memoryUsage = null,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -18,6 +18,7 @@ use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\WorkerHeartbeat;
 use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerPausing;
@@ -225,11 +226,26 @@ class Worker
 
         $startTime = $this->currentTime();
 
+        $lastHeartbeat = $this->currentTime();
+
         $this->jobsProcessed = 0;
 
         $this->raiseWorkerStartingEvent($connectionName, $queue, $options);
 
         while (true) {
+            // If a heartbeat interval is configured, we will dispatch a heartbeat event
+            // once enough time has elapsed. This runs before the pause check so that a
+            // paused or maintenance-mode worker still reports that it is alive.
+            if ($options->heartbeat > 0 &&
+                $this->currentTime() - $lastHeartbeat >= $options->heartbeat) {
+                $this->events->dispatch(new WorkerHeartbeat(
+                    $connectionName, $queue, $options,
+                    $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()
+                ));
+
+                $lastHeartbeat = $this->currentTime();
+            }
+
             // Before reserving any jobs, we will make sure this queue is not paused and
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -236,8 +236,7 @@ class Worker
             // If a heartbeat interval is configured, we will dispatch a heartbeat event
             // once enough time has elapsed. This runs before the pause check so that a
             // paused or maintenance-mode worker still reports that it is alive.
-            if ($options->heartbeat > 0 &&
-                $this->currentTime() - $lastHeartbeat >= $options->heartbeat) {
+            if ($options->heartbeat > 0 && $this->currentTime() - $lastHeartbeat >= $options->heartbeat) {
                 $this->events->dispatch(new WorkerHeartbeat(
                     $connectionName, $queue, $options,
                     $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -89,6 +89,13 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * The number of seconds between worker heartbeat events. Zero disables it.
+     *
+     * @var int
+     */
+    public $heartbeat;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -103,6 +110,7 @@ class WorkerOptions
      * @param  int  $maxTime
      * @param  int  $rest
      * @param  int  $stopWhenEmptyFor
+     * @param  int  $heartbeat
      */
     public function __construct(
         $name = 'default',
@@ -117,6 +125,7 @@ class WorkerOptions
         $maxTime = 0,
         $rest = 0,
         $stopWhenEmptyFor = 0,
+        $heartbeat = 0,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -130,5 +139,6 @@ class WorkerOptions
         $this->stopWhenEmptyFor = $stopWhenEmptyFor;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->heartbeat = $heartbeat;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -89,7 +89,7 @@ class WorkerOptions
     public $maxTime;
 
     /**
-     * The number of seconds between worker heartbeat events. Zero disables it.
+     * The number of seconds between worker heartbeat events.
      *
      * @var int
      */

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -16,6 +16,7 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Illuminate\Queue\Events\WorkerHeartbeat;
 use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
@@ -541,6 +542,54 @@ class QueueWorkerTest extends TestCase
                 && $event->queue === 'queue'
                 && $event->workerOptions === $workerOptions;
         }))->once();
+    }
+
+    public function testWorkerHeartbeatIsDispatchedOnceIntervalElapses()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->heartbeat = 5;
+        $workerOptions->stopWhenEmptyFor = 10;
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $worker->currentTime = 0;
+
+        $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
+            return $event instanceof WorkerHeartbeat
+                && $event->connectionName === 'default'
+                && $event->queue === 'queue'
+                && $event->workerOptions === $workerOptions
+                && $event->jobsProcessed === 0
+                && $event->lastJobProcessedAt === null;
+        }))->once();
+    }
+
+    public function testWorkerHeartbeatIsNotDispatchedBeforeIntervalElapses()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->heartbeat = 100;
+        $workerOptions->stopWhenEmptyFor = 5;
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $worker->currentTime = 0;
+
+        $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(WorkerHeartbeat::class)]);
+    }
+
+    public function testWorkerHeartbeatIsDisabledByDefault()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmptyFor = 10;
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $worker->currentTime = 0;
+
+        $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(WorkerHeartbeat::class)]);
     }
 
     public function testWorkerStoppingIsDispatched()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -544,7 +544,7 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
-    public function testWorkerHeartbeatIsDispatchedOnceIntervalElapses()
+    public function testWorkerHeartbeatIsDispatched()
     {
         $workerOptions = new WorkerOptions();
         $workerOptions->heartbeat = 5;
@@ -565,7 +565,7 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
-    public function testWorkerHeartbeatIsNotDispatchedBeforeIntervalElapses()
+    public function testWorkerHeartbeatIsNotDispatched()
     {
         $workerOptions = new WorkerOptions();
         $workerOptions->heartbeat = 100;
@@ -579,7 +579,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(WorkerHeartbeat::class)]);
     }
 
-    public function testWorkerHeartbeatIsDisabledByDefault()
+    public function testWorkerHeartbeatIsDisabled()
     {
         $workerOptions = new WorkerOptions();
         $workerOptions->stopWhenEmptyFor = 10;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -555,7 +555,7 @@ class QueueWorkerTest extends TestCase
 
         $worker->daemon('default', 'queue', $workerOptions);
 
-        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::on(function ($event) use ($workerOptions) {
             return $event instanceof WorkerHeartbeat
                 && $event->connectionName === 'default'
                 && $event->queue === 'queue'
@@ -576,7 +576,7 @@ class QueueWorkerTest extends TestCase
 
         $worker->daemon('default', 'queue', $workerOptions);
 
-        $this->events->shouldNotHaveReceived('dispatch', [m::type(WorkerHeartbeat::class)]);
+        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(WorkerHeartbeat::class)]);
     }
 
     public function testWorkerHeartbeatIsDisabled()
@@ -589,7 +589,7 @@ class QueueWorkerTest extends TestCase
 
         $worker->daemon('default', 'queue', $workerOptions);
 
-        $this->events->shouldNotHaveReceived('dispatch', [m::type(WorkerHeartbeat::class)]);
+        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(WorkerHeartbeat::class)]);
     }
 
     public function testWorkerStoppingIsDispatched()


### PR DESCRIPTION
This PR adds a new `WorkerHeartbeat` event which dispatches at a specified interval via a new `--heartbeat` flag.  This is useful for apps and packages that need to keep track of queue workers.  There are existing `Looping` and `WorkerIdle` events, however these would need to be rate limited, and cannot easily be configured for different queue workers, so this new event fills that gap, and is more flexible.

If a job takes longer than the specified heartbeat interval to run, the event won't be dispatched until the worker loops back around again.  This seems like a reasonable trade off though, as the interval can be configured per queue worker, so the workload can be anticipated.  The heartbeat event also fires when the worker is paused or in maintenance mode.

<details>
<summary>Here's a demo with a job that randomly sleeps for 5 - 10 seconds, with a worker dispatching a heartbeat every 5 seconds:</summary>

https://github.com/user-attachments/assets/576dc4f9-75f9-4cbf-aaa1-8574764a4c32
</details>

<details>
<summary>A quick example of how you might use the events:</summary>

```php
Event::listen(function (WorkerHeartbeat $event) {
    DB::table('worker_heartbeats')->upsert([
        'host' => gethostname(),
        'pid' => getmypid(),
        'connection' => $event->connectionName,
        'queue' => $event->queue,
        'name' => $event->workerOptions->name,
        'heartbeat' => $event->workerOptions->heartbeat,
        'last_seen_at' => now(),
    ], ['host', 'pid'], ['connection', 'queue', 'name', 'last_seen_at']);
});

Event::listen(function (WorkerStopping $event) {
    DB::table('worker_heartbeats')
        ->where('host', gethostname())
        ->where('pid', getmypid())
        ->delete();
});

DB::table('worker_heartbeats')
    ->whereRaw('last_seen_at < DATE_SUB(NOW(), INTERVAL heartbeat * 5 SECOND)')
    ->delete();
```
</details>

Note: The CI failures don't appear related to this work.