### PR TITLE
[13.x] Fix CROSSSLOT errors in QueueManager::getPausedQueues() when using Redis cluster mode

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Closure;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Queue\Factory as FactoryContract;
 use Illuminate\Contracts\Queue\Monitor as MonitorContract;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
@@ -230,6 +231,33 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Get the correct prefix for paused queue cache keys.
+     *
+     * In Redis cluster mode, returns hash tag '{paused}' to ensure all
+     * pause-related keys hash to the same slot for Cache::many() operations.
+     *
+     * @return string
+     */
+    protected function getPausedQueueKeyPrefix()
+    {
+        $store = $this->app['cache']->store()->getStore();
+
+        return $store instanceof RedisStore && $store->connection()->isCluster() ? '{paused}' : 'paused';
+    }
+
+    /**
+     * Get the cache key for a paused queue.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @return string
+     */
+    protected function getPausedQueueCacheKey($connection, $queue)
+    {
+        return "illuminate:queue:{$this->getPausedQueueKeyPrefix()}:{$connection}:{$queue}";
+    }
+
+    /**
      * Pause a queue by its connection and name.
      *
      * @param  string  $connection
@@ -240,7 +268,7 @@ class QueueManager implements FactoryContract, MonitorContract
     {
         $this->app['cache']
             ->store()
-            ->forever("illuminate:queue:paused:{$connection}:{$queue}", true);
+            ->forever($this->getPausedQueueCacheKey($connection, $queue), true);
 
         $this->app['events']->dispatch(
             new Events\QueuePaused($connection, $queue)
@@ -259,7 +287,7 @@ class QueueManager implements FactoryContract, MonitorContract
     {
         $this->app['cache']
             ->store()
-            ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
+            ->put($this->getPausedQueueCacheKey($connection, $queue), true, $ttl);
 
         $this->app['events']->dispatch(
             new Events\QueuePaused($connection, $queue, $ttl)
@@ -293,7 +321,7 @@ class QueueManager implements FactoryContract, MonitorContract
     {
         $this->app['cache']
             ->store()
-            ->forget("illuminate:queue:paused:{$connection}:{$queue}");
+            ->forget($this->getPausedQueueCacheKey($connection, $queue));
 
         $this->app['events']->dispatch(
             new Events\QueueResumed($connection, $queue)
@@ -330,7 +358,7 @@ class QueueManager implements FactoryContract, MonitorContract
         $cache = $this->app['cache']->store();
 
         return (bool) ($cache->get('illuminate:queues:paused')
-            ?: $cache->get("illuminate:queue:paused:{$connection}:{$queue}"));
+            ?: $cache->get($this->getPausedQueueCacheKey($connection, $queue)));
     }
 
     /**
@@ -348,12 +376,13 @@ class QueueManager implements FactoryContract, MonitorContract
             return array_values($queues);
         }
 
-        $states = $cache->many(
-            array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues)
-        );
+        $prefix = $this->getPausedQueueKeyPrefix();
+        $key = fn ($queue) => "illuminate:queue:{$prefix}:{$connection}:{$queue}";
+
+        $states = $cache->many(array_map($key, $queues));
 
         return array_values(array_filter(
-            $queues, fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false
+            $queues, fn ($queue) => $states[$key($queue)] ?? false
         ));
     }
 

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
@@ -254,5 +255,116 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame(['redis', 'emails'], $parser->parse('emails'));
         $this->assertSame(['database', 'notifications'], $parser->parse('database:notifications'));
         $this->assertSame(['redis', 'foo:bar'], $parser->parse('redis:foo:bar'));
+    }
+
+    public function testPauseAndResumeUseHashTagsOnRedisCluster()
+    {
+        $storage = [];
+        $manager = $this->createManager(new Repository($this->createRedisStore(true, $storage)));
+
+        $manager->pause('redis', 'default');
+        $this->assertTrue($manager->isPaused('redis', 'default'));
+        $this->assertSame(['default'], $manager->getPausedQueues('redis', ['default', 'emails']));
+
+        $manager->resume('redis', 'default');
+        $this->assertFalse($manager->isPaused('redis', 'default'));
+        $this->assertSame([], $manager->getPausedQueues('redis', ['default', 'emails']));
+    }
+
+    public function testPauseForUsesHashTagsOnRedisCluster()
+    {
+        $manager = $this->createManager(new Repository($this->createRedisStore(true)));
+
+        $manager->pauseFor('redis', 'default', 60);
+
+        $this->assertTrue($manager->isPaused('redis', 'default'));
+    }
+
+    public function testPauseAndResumeDoNotUseHashTagsOnNonClusterRedis()
+    {
+        $storage = [];
+        $manager = $this->createManager(new Repository($this->createRedisStore(false, $storage)));
+
+        $manager->pause('redis', 'default');
+        $this->assertTrue($manager->isPaused('redis', 'default'));
+        $this->assertSame(['default'], $manager->getPausedQueues('redis', ['default', 'emails']));
+
+        $manager->resume('redis', 'default');
+        $this->assertFalse($manager->isPaused('redis', 'default'));
+        $this->assertSame([], $manager->getPausedQueues('redis', ['default', 'emails']));
+    }
+
+    public function testPauseForDoesNotUseHashTagsOnNonClusterRedis()
+    {
+        $manager = $this->createManager(new Repository($this->createRedisStore(false)));
+
+        $manager->pauseFor('redis', 'default', 60);
+
+        $this->assertTrue($manager->isPaused('redis', 'default'));
+    }
+
+    protected function createRedisStore(bool $cluster, &$storage = [])
+    {
+        return new class($cluster, $storage) extends RedisStore
+        {
+            protected $cluster;
+            protected $storage;
+
+            public function __construct(bool $cluster, &$storage)
+            {
+                $this->cluster = $cluster;
+                $this->storage = &$storage;
+            }
+
+            public function connection()
+            {
+                $cluster = $this->cluster;
+
+                return new class($cluster)
+                {
+                    public function __construct(protected bool $cluster)
+                    {
+                    }
+
+                    public function isCluster()
+                    {
+                        return $this->cluster;
+                    }
+                };
+            }
+
+            public function forever($key, $value)
+            {
+                $this->storage[$key] = $value;
+            }
+
+            public function put($key, $value, $seconds)
+            {
+                $this->storage[$key] = $value;
+            }
+
+            public function forget($key)
+            {
+                unset($this->storage[$key]);
+            }
+
+            public function get($key)
+            {
+                return $this->storage[$key] ?? null;
+            }
+
+            public function many(array $keys)
+            {
+                if ($this->cluster && count($keys) > 1) {
+                    foreach ($keys as $key) {
+                        if (! str_contains($key, '{paused}')) {
+                            throw new RuntimeException("CROSSSLOT Keys in request don't hash to the same slot");
+                        }
+                    }
+                }
+
+                return array_combine($keys, array_map(fn ($key) => $this->storage[$key] ?? null, $keys));
+            }
+        };
     }
 }


### PR DESCRIPTION
We are using non-Redis queues, but our application uses a Redis serverless cluster as its cache.
After the Laravel 13 update, our queue workers failed with CROSSSLOT errors:

```
[2026-08-18 17:37:15] @production.ERROR: CROSSSLOT Keys in request don't hash to the same slot
{"exception":"[object] (Predis\Response\ServerException(code: 0): CROSSSLOT Keys in request don't hash to the same slot at /var/www/vendor/predis/predis/src/Client.php:469) 

/var/www/vendor/predis/predis/src/Client.php(434): Predis\Client->onErrorResponse()
/var/www/vendor/predis/predis/src/Client.php(336): Predis\Client->executeCommand()                                                                                                                                                  
/var/www/vendor/laravel/framework/src/Illuminate/Redis/Connections/Connection.php(124): Predis\Client->__call()                                                                                                                     
/var/www/vendor/laravel/framework/src/Illuminate/Redis/Connections/Connection.php(113): Illuminate\Redis\Connections\Connection->__call()                                                                                           
/var/www/vendor/laravel/framework/src/Illuminate/Cache/RedisStore.php(67): Illuminate\Cache\RedisStore->many()                                                                                                                      
/var/www/vendor/laravel/framework/src/Illuminate/Cache/Repository.php(355): Illuminate\Cache\Repository->many()                                                                                                                     
/var/www/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php(409): Illuminate\Queue\QueueManager->getPausedQueues()                                                                                                      
/var/www/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(190): Illuminate\Queue\Worker->getPausedQueues()                                                                                                                  
/var/www/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(143): Illuminate\Queue\Worker->getNextJob()                                                                                                                       
/var/www/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(148): Illuminate\Queue\Worker->daemon()   
```

After investigating, we noticed the hash tags required by cluster-mode Redis are not applied during queue pausing, which causes the many() call in QueueManager::getPausedQueues() to fail.
This PR tries to fix this issue in tune with what was done in [PR #59533 ](https://github.com/laravel/framework/pull/59533)