### PR TITLE
[13.x] Pin rector version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^11.5.50 || ^12.5.8 || ^13.0.3",
         "predis/predis": "^2.3 || ^3.0",
-        "rector/rector": "^2.3",
+        "rector/rector": "2.6.3",
         "resend/resend-php": "^1.0",
         "symfony/cache": "^7.4.0 || ^8.0.0",
         "symfony/http-client": "^7.4.0 || ^8.0.0",

--- a/rector.php
+++ b/rector.php
@@ -7,7 +7,6 @@ use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
@@ -27,9 +26,7 @@ use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
-use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector;
@@ -70,7 +67,6 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         ...$skipPHPUnitSetList,
-        AddOverrideAttributeToOverriddenMethodsRector::class,
         AddTypeToConstRector::class,
         ArrayToFirstClassCallableRector::class,
         ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
@@ -82,7 +78,6 @@ return RectorConfig::configure()
         ClassPropertyAssignToConstructorPromotionRector::class,
         ClosureDelegatingCallToFirstClassCallableRector::class,
         ClosureToArrowFunctionRector::class,
-        DeprecatedAnnotationToDeprecatedAttributeRector::class,
         DynamicClassConstFetchRector::class,
         FunctionFirstClassCallableRector::class,
         GetDebugTypeRector::class,
@@ -98,7 +93,6 @@ return RectorConfig::configure()
     ])
     ->withRules([
         CompactToVariablesRector::class,
-        CountArrayToEmptyArrayComparisonRector::class,
         SortCallLikeNamedArgsRector::class,
         StrlenZeroToIdenticalEmptyStringRector::class,
     ])
@@ -115,7 +109,6 @@ return RectorConfig::configure()
     )
     ->withSets([
         PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
-        PHPUnitSetList::PHPUNIT_110,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_MOCK_TO_STUB,
     ])

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -48,7 +48,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithArrayCast();
         $this->assertEquals(['foo' => null], $instance->attributesToArray());
 
-        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
     }
 
     public function testUnsettingCachedAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3903,7 +3903,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
+        $this->assertNotSame(JSON_ERROR_NONE, json_last_error());
 
         $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2058,7 +2058,7 @@ class HttpRequestTest extends TestCase
 
         Request::create('', 'GET')->json();
 
-        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
     }
 
     public function testItClampsValues()

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -42,7 +42,7 @@ class JsonResourceTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
+        $this->assertNotSame(JSON_ERROR_NONE, json_last_error());
 
         $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -379,7 +379,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $columns = Schema::getColumns('foo');
 
         $this->assertCount(1, $columns);
-        $this->assertSame($columns[0]['name'], 'bar');
+        $this->assertSame('bar', $columns[0]['name']);
     }
 
     public function testGetIndexes()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1975,7 +1975,7 @@ class SupportStrTest extends TestCase
 
     public function testPasswordCreation()
     {
-        $this->assertSame(strlen(Str::password()), 32);
+        $this->assertSame(32, strlen(Str::password()));
 
         $this->assertStringNotContainsString(' ', Str::password());
         $this->assertStringContainsString(' ', Str::password(spaces: true));


### PR DESCRIPTION
Rector adds/deprecates rules between minor and patch releases, so a floating constraint gives inconsistent fixes across runs. This pins the version and updates `rector.php` + test output for it.