### PR TITLE
[13.x] Convert foreach-loop tests to data providers

### DIFF
--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Generator;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SchemaBuilderTest extends DatabaseTestCase
 {
@@ -60,43 +62,56 @@ class SchemaBuilderTest extends DatabaseTestCase
     }
 
     #[RequiresDatabase(['mysql', 'mariadb'])]
-    public function testChangeToTextColumn()
+    #[DataProvider('dataProviderChangeToTextColumn')]
+    public function testChangeToTextColumn($type): void
     {
         Schema::create('test', function (Blueprint $table) {
             $table->integer('test_column');
         });
 
-        foreach (['tinyText', 'text', 'mediumText', 'longText'] as $type) {
-            $blueprint = new Blueprint($this->getConnection(), 'test', function ($table) use ($type) {
-                $table->$type('test_column')->change();
-            });
+        $blueprint = new Blueprint($this->getConnection(), 'test', function ($table) use ($type) {
+            $table->$type('test_column')->change();
+        });
 
-            $uppercase = strtolower($type);
+        $uppercase = strtolower($type);
 
-            $expected = ["alter table `test` modify `test_column` $uppercase not null"];
+        $expected = ["alter table `test` modify `test_column` $uppercase not null"];
 
-            $this->assertEquals($expected, $blueprint->toSql());
-        }
+        $this->assertEquals($expected, $blueprint->toSql());
+    }
+
+    public static function dataProviderChangeToTextColumn(): Generator
+    {
+        yield 'tinyText' => ['tinyText'];
+        yield 'text' => ['text'];
+        yield 'mediumText' => ['mediumText'];
+        yield 'longText' => ['longText'];
     }
 
     #[RequiresDatabase(['mysql', 'mariadb'])]
-    public function testChangeTextColumnToTextColumn()
+    #[DataProvider('dataProviderChangeTextColumnToTextColumn')]
+    public function testChangeTextColumnToTextColumn($type): void
     {
         Schema::create('test', static function (Blueprint $table) {
             $table->text('test_column');
         });
 
-        foreach (['tinyText', 'mediumText', 'longText'] as $type) {
-            $blueprint = new Blueprint($this->getConnection(), 'test', function ($table) use ($type) {
-                $table->$type('test_column')->change();
-            });
+        $blueprint = new Blueprint($this->getConnection(), 'test', function ($table) use ($type) {
+            $table->$type('test_column')->change();
+        });
 
-            $lowercase = strtolower($type);
+        $lowercase = strtolower($type);
 
-            $expected = ["alter table `test` modify `test_column` $lowercase not null"];
+        $expected = ["alter table `test` modify `test_column` $lowercase not null"];
 
-            $this->assertEquals($expected, $blueprint->toSql());
-        }
+        $this->assertEquals($expected, $blueprint->toSql());
+    }
+
+    public static function dataProviderChangeTextColumnToTextColumn(): Generator
+    {
+        yield 'tinyText' => ['tinyText'];
+        yield 'mediumText' => ['mediumText'];
+        yield 'longText' => ['longText'];
     }
 
     #[RequiresDatabase(['mysql', 'mariadb'])]

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
+use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
@@ -1997,76 +1998,68 @@ class SupportStrTest extends TestCase
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
 
-    public function testChopStart()
+    public static function dataProviderChopStart(): Generator
     {
-        foreach ([
-            '' => ['', ''],
-            'Laravel' => ['', 'Laravel'],
-            'Ship it' => [['', 'Ship '], 'it'],
-            'http://laravel.com' => ['http://', 'laravel.com'],
-            'http://-http://' => ['http://', '-http://'],
-            'http://laravel.com' => ['htp:/', 'http://laravel.com'],
-            'http://laravel.com' => ['http://www.', 'http://laravel.com'],
-            'http://laravel.com' => ['-http://', 'http://laravel.com'],
-            'http://laravel.com' => [['https://', 'http://'], 'laravel.com'],
-            'http://www.laravel.com' => [['http://', 'www.'], 'www.laravel.com'],
-            'http://http-is-fun.test' => ['http://', 'http-is-fun.test'],
-            // Multibyte emoji tests
-            '🌊✋' => ['🌊', '✋'],
-            '🌊✋' => ['✋', '🌊✋'],
-            '🚀🌟💫' => ['🚀', '🌟💫'],
-            '🚀🌟💫' => ['🚀🌟', '💫'],
-            // Multibyte character tests (Japanese, Chinese, Arabic, etc.)
-            'こんにちは世界' => ['こんにちは', '世界'],
-            '你好世界' => ['你好', '世界'],
-            'مرحبا بك' => ['مرحبا ', 'بك'],
-            // Mixed multibyte and ASCII
-            '🎉Laravel' => ['🎉', 'Laravel'],
-            'Hello🌍World' => ['Hello🌍', 'World'],
-            // Multiple needle array with multibyte
-            '🌊✋🎉' => [['🚀', '🌊'], '✋🎉'],
-            'こんにちは世界' => [['Hello', 'こんにちは'], '世界'],
-        ] as $subject => $value) {
-            [$needle, $expected] = $value;
-
-            $this->assertSame($expected, Str::chopStart($subject, $needle));
-        }
+        yield 'empty subject and needle' => ['', '', ''];
+        yield 'empty needle leaves subject' => ['Laravel', '', 'Laravel'];
+        yield 'first matching needle from array is removed' => ['Ship it', ['', 'Ship '], 'it'];
+        yield 'standard http prefix removed' => ['http://laravel.com', 'http://', 'laravel.com'];
+        yield 'prefix only removed once at start' => ['http://-http://', 'http://', '-http://'];
+        yield 'non-matching partial prefix is ignored' => ['http://laravel.com', 'htp:/', 'http://laravel.com'];
+        yield 'different non-matching prefix is ignored' => ['http://laravel.com', 'http://www.', 'http://laravel.com'];
+        yield 'prefix not at start is ignored' => ['http://laravel.com', '-http://', 'http://laravel.com'];
+        yield 'matching prefix selected from array' => ['http://laravel.com', ['https://', 'http://'], 'laravel.com'];
+        yield 'first matching prefix in ordered array used' => ['http://www.laravel.com', ['http://', 'www.'], 'www.laravel.com'];
+        yield 'http removed from complex host' => ['http://http-is-fun.test', 'http://', 'http-is-fun.test'];
+        yield 'emoji prefix removed' => ['🌊✋', '🌊', '✋'];
+        yield 'emoji needle without prefix match is ignored' => ['🌊✋', '✋', '🌊✋'];
+        yield 'first emoji removed from emoji sequence' => ['🚀🌟💫', '🚀', '🌟💫'];
+        yield 'multibyte emoji sequence prefix removed' => ['🚀🌟💫', '🚀🌟', '💫'];
+        yield 'japanese prefix removed' => ['こんにちは世界', 'こんにちは', '世界'];
+        yield 'chinese prefix removed' => ['你好世界', '你好', '世界'];
+        yield 'arabic prefix removed' => ['مرحبا بك', 'مرحبا ', 'بك'];
+        yield 'mixed emoji and ascii prefix removed' => ['🎉Laravel', '🎉', 'Laravel'];
+        yield 'mixed ascii and emoji prefix removed' => ['Hello🌍World', 'Hello🌍', 'World'];
+        yield 'multibyte prefix selected from array' => ['🌊✋🎉', ['🚀', '🌊'], '✋🎉'];
+        yield 'multibyte prefix selected from mixed array' => ['こんにちは世界', ['Hello', 'こんにちは'], '世界'];
     }
 
-    public function testChopEnd()
+    #[DataProvider('dataProviderChopStart')]
+    public function testChopStart($subject, $needle, $expected): void
     {
-        foreach ([
-            '' => ['', ''],
-            'Laravel' => ['', 'Laravel'],
-            'Ship it' => [['', ' it'], 'Ship'],
-            'path/to/file.php' => ['.php', 'path/to/file'],
-            '.php-.php' => ['.php', '.php-'],
-            'path/to/file.php' => ['.ph', 'path/to/file.php'],
-            'path/to/file.php' => ['foo.php', 'path/to/file.php'],
-            'path/to/file.php' => ['.php-', 'path/to/file.php'],
-            'path/to/file.php' => [['.html', '.php'], 'path/to/file'],
-            'path/to/file.php' => [['.php', 'file'], 'path/to/file'],
-            'path/to/php.php' => ['.php', 'path/to/php'],
-            // Multibyte emoji tests
-            '✋🌊' => ['🌊', '✋'],
-            '✋🌊' => ['✋', '✋🌊'],
-            '🌟💫🚀' => ['🚀', '🌟💫'],
-            '🌟💫🚀' => ['💫🚀', '🌟'],
-            // Multibyte character tests (Japanese, Chinese, Arabic, etc.)
-            '世界こんにちは' => ['こんにちは', '世界'],
-            '世界你好' => ['你好', '世界'],
-            'بك مرحبا' => [' مرحبا', 'بك'],
-            // Mixed multibyte and ASCII
-            'Laravel🎉' => ['🎉', 'Laravel'],
-            'Hello🌍World' => ['World', 'Hello🌍'],
-            // Multiple needle array with multibyte
-            '🎉✋🌊' => [['🚀', '🌊'], '🎉✋'],
-            '世界こんにちは' => [['Hello', 'こんにちは'], '世界'],
-        ] as $subject => $value) {
-            [$needle, $expected] = $value;
+        $this->assertSame($expected, Str::chopStart($subject, $needle));
+    }
 
-            $this->assertSame($expected, Str::chopEnd($subject, $needle));
-        }
+    public static function dataProviderChopEnd(): Generator
+    {
+        yield 'empty string with empty needle' => ['', '', ''];
+        yield 'empty needle leaves subject unchanged' => ['Laravel', '', 'Laravel'];
+        yield 'matching needle selected from array' => ['Ship it', ['', ' it'], 'Ship'];
+        yield 'file extension removed' => ['path/to/file.php', '.php', 'path/to/file'];
+        yield 'suffix removed from repeated extension segment' => ['.php-.php', '.php', '.php-'];
+        yield 'partial non-matching suffix is ignored' => ['path/to/file.php', '.ph', 'path/to/file.php'];
+        yield 'different non-matching suffix is ignored' => ['path/to/file.php', 'foo.php', 'path/to/file.php'];
+        yield 'near-matching suffix is ignored' => ['path/to/file.php', '.php-', 'path/to/file.php'];
+        yield 'matching suffix selected from array' => ['path/to/file.php', ['.html', '.php'], 'path/to/file'];
+        yield 'first matching suffix in ordered array used' => ['path/to/file.php', ['.php', 'file'], 'path/to/file'];
+        yield 'suffix removed from complex path' => ['path/to/php.php', '.php', 'path/to/php'];
+        yield 'emoji suffix removed' => ['✋🌊', '🌊', '✋'];
+        yield 'emoji needle without suffix match is ignored' => ['✋🌊', '✋', '✋🌊'];
+        yield 'last emoji removed from emoji sequence' => ['🌟💫🚀', '🚀', '🌟💫'];
+        yield 'multibyte emoji sequence suffix removed' => ['🌟💫🚀', '💫🚀', '🌟'];
+        yield 'japanese suffix removed' => ['世界こんにちは', 'こんにちは', '世界'];
+        yield 'chinese suffix removed' => ['世界你好', '你好', '世界'];
+        yield 'arabic suffix removed' => ['بك مرحبا', ' مرحبا', 'بك'];
+        yield 'mixed ascii and emoji suffix removed' => ['Laravel🎉', '🎉', 'Laravel'];
+        yield 'mixed emoji and ascii suffix removed' => ['Hello🌍World', 'World', 'Hello🌍'];
+        yield 'multibyte suffix selected from array' => ['🎉✋🌊', ['🚀', '🌊'], '🎉✋'];
+        yield 'multibyte suffix selected from mixed array' => ['世界こんにちは', ['Hello', 'こんにちは'], '世界'];
+    }
+
+    #[DataProvider('dataProviderChopEnd')]
+    public function testChopEnd($subject, $needle, $expected): void
+    {
+        $this->assertSame($expected, Str::chopEnd($subject, $needle));
     }
 
     public function testReplaceMatches()

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
+use Generator;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -36,20 +38,33 @@ class ValidationExcludeIfTest extends TestCase
         $this->assertSame('', (string) $rule);
     }
 
-    public function testItValidatesCallableAndBooleanAreAcceptableArguments()
+    public function testItAcceptsCallableAndBooleanArguments(): void
     {
         new ExcludeIf(false);
         new ExcludeIf(true);
         new ExcludeIf(fn () => true);
 
-        foreach ([1, 1.1, 'phpinfo', new stdClass, null] as $condition) {
-            try {
-                new ExcludeIf($condition);
-                $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));
-            } catch (InvalidArgumentException $exception) {
-                $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
-            }
+        $this->addToAssertionCount(1);
+    }
+
+    #[DataProvider('dataProviderItRejectsNonCallableNonBooleanArguments')]
+    public function testItRejectsNonCallableNonBooleanArguments($condition): void
+    {
+        try {
+            new ExcludeIf($condition);
+            $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
         }
+    }
+
+    public static function dataProviderItRejectsNonCallableNonBooleanArguments(): Generator
+    {
+        yield 'int' => [1];
+        yield 'float' => [1.1];
+        yield 'string' => ['phpinfo'];
+        yield 'object' => [new stdClass];
+        yield 'null' => [null];
     }
 
     public function testItThrowsExceptionIfRuleIsNotSerializable()

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Client\ConnectionException;
@@ -9,21 +10,28 @@ use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
 use Illuminate\Validation\NotPwnedVerifier;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ValidationNotPwnedVerifierTest extends TestCase
 {
-    public function testEmptyValues()
+    #[DataProvider('dataProviderEmptyValues')]
+    public function testEmptyValues($password): void
     {
         $httpFactory = Mockery::mock(HttpFactory::class);
         $verifier = new NotPwnedVerifier($httpFactory);
 
-        foreach (['', false, 0] as $password) {
-            $this->assertFalse($verifier->verify([
-                'value' => $password,
-                'threshold' => 0,
-            ]));
-        }
+        $this->assertFalse($verifier->verify([
+            'value' => $password,
+            'threshold' => 0,
+        ]));
+    }
+
+    public static function dataProviderEmptyValues(): Generator
+    {
+        yield 'empty string' => [''];
+        yield 'false' => [false];
+        yield 'zero' => [0];
     }
 
     public function testApiResponseGoesWrong()

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
+use Generator;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -36,20 +38,32 @@ class ValidationProhibitedIfTest extends TestCase
         $this->assertSame('', (string) $rule);
     }
 
-    public function testItValidatesCallableAndBooleanAreAcceptableArguments()
+    public function testItAcceptsCallableAndBooleanArguments(): void
     {
         new ProhibitedIf(false);
         new ProhibitedIf(true);
         new ProhibitedIf(fn () => true);
 
-        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
-            try {
-                new ProhibitedIf($condition);
-                $this->fail('The ProhibitedIf constructor must not accept '.gettype($condition));
-            } catch (InvalidArgumentException $exception) {
-                $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
-            }
+        $this->addToAssertionCount(1);
+    }
+
+    #[DataProvider('dataProviderItRejectsNonCallableNonBooleanArguments')]
+    public function testItRejectsNonCallableNonBooleanArguments($condition): void
+    {
+        try {
+            new ProhibitedIf($condition);
+            $this->fail('The ProhibitedIf constructor must not accept '.gettype($condition));
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
         }
+    }
+
+    public static function dataProviderItRejectsNonCallableNonBooleanArguments(): Generator
+    {
+        yield 'int' => [1];
+        yield 'float' => [1.1];
+        yield 'string' => ['phpinfo'];
+        yield 'object' => [new stdClass];
     }
 
     public function testItThrowsExceptionIfRuleIsNotSerializable()


### PR DESCRIPTION
A handful of tests looped over a literal array of cases running the same assertion(s) each time. Switched them to `#[DataProvider]`/`Generator` methods so PHPUnit reports which case actually failed.