### PR TITLE
[13.x] Simplify testImageBmp

### DIFF
--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -94,13 +94,7 @@ class HttpTestingFileFactoryTest extends TestCase
     {
         $image = (new FileFactory)->image('test.bmp');
 
-        $imagePath = $image->getRealPath();
-
-        if (version_compare(PHP_VERSION, '8.3.0-dev', '>=')) {
-            $this->assertSame('image/bmp', mime_content_type($imagePath));
-        } else {
-            $this->assertSame('image/x-ms-bmp', mime_content_type($imagePath));
-        }
+        $this->assertSame('image/bmp', mime_content_type($image->getRealPath()));
     }
 
     public function testCreateWithMimeType()


### PR DESCRIPTION
Framework's minimum PHP version is 8.3, so the `version_compare(PHP_VERSION, '8.3.0-dev', '>=')` check was always true and the else branch was dead code.