### PR TITLE
Revert "[13.x] Consolidate tearDown boilerplate into AfterEachTestSubscriber (#61245)"

### DIFF
--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Illuminate\Tests;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Container\Container;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
@@ -34,10 +31,5 @@ final class AfterEachTestSubscriber implements FinishedSubscriber
         Sleep::fake(false);
         Once::flush();
         Lottery::determineResultNormally();
-
-        Container::setInstance(null);
-        Application::setInstance(null);
-        Facade::setFacadeApplication(null);
-        Facade::clearResolvedInstances();
     }
 }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -31,6 +31,11 @@ class AuthenticateMiddlewareTest extends TestCase
         });
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
         $signature = Authenticate::using('foo');

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -46,6 +46,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->container->instance(Registrar::class, $this->router);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
         $signature = Authorize::using('ability');

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -26,6 +26,11 @@ class BroadcasterTest extends TestCase
         $this->broadcaster = new FakeBroadcaster;
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testExtractingParametersWhileCheckingForUserAccess()
     {
         $callback = function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -112,6 +112,12 @@ class BusBatchTest extends TestCase
      */
     protected function tearDown(): void
     {
+        if (Facade::getFacadeApplication()) {
+            Facade::setFacadeApplication(null);
+        }
+
+        Container::setInstance(null);
+
         unset($_SERVER['__finally.batch'], $_SERVER['__progress.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');

--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -28,6 +28,8 @@ class BusBatchableTest extends TestCase
         $container->instance(BatchRepository::class, $repository);
 
         $this->assertSame('test-batch', $class->batch());
+
+        Container::setInstance(null);
     }
 
     public function test_with_fake_batch_sets_and_returns_fake()

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -32,6 +32,8 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(Mockery::mock(ShouldQueue::class));
+
+        Container::setInstance(null);
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
@@ -49,6 +51,8 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherTestCustomQueueCommand);
+
+        Container::setInstance(null);
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
@@ -66,6 +70,8 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherTestSpecificQueueAndDelayCommand);
+
+        Container::setInstance(null);
     }
 
     public function testCommandsAreDispatchedWithQueueRoute()
@@ -84,6 +90,8 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherQueueable);
+
+        Container::setInstance(null);
     }
 
     public function testCommandsAreForwardedToConnectionByQueueName()
@@ -107,6 +115,8 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch((new BusDispatcherQueueable)->onQueue('reports'));
 
         $this->assertSame('cloud', $usedConnection);
+
+        Container::setInstance(null);
     }
 
     public function testExplicitConnectionWinsOverForwardedQueue()
@@ -130,6 +140,8 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch((new BusDispatcherQueueable)->onConnection('redis')->onQueue('reports'));
 
         $this->assertSame('redis', $usedConnection);
+
+        Container::setInstance(null);
     }
 
     public function testDispatchNowShouldNeverQueue()
@@ -187,6 +199,8 @@ class BusDispatcherTest extends TestCase
         $job = (new ShouldNotBeDispatched)->onConnection('null');
 
         $dispatcher->dispatch($job);
+
+        Container::setInstance(null);
     }
 
     public function testDispatchBulk()
@@ -209,6 +223,8 @@ class BusDispatcherTest extends TestCase
             new BusDispatcherQueueable,
             new BusDispatcherTestSpecificQueueCommand,
         ]);
+
+        Container::setInstance(null);
     }
 }
 

--- a/tests/Cache/CacheSpyMemoTest.php
+++ b/tests/Cache/CacheSpyMemoTest.php
@@ -34,6 +34,12 @@ class CacheSpyMemoTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
     public function test_cache_spy_works_with_memoized_cache()
     {
         $cache = Cache::spy();

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -28,6 +28,11 @@ class ContainerTest extends TestCase
         }
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testContainerSingleton()
     {
         $container = Container::setInstance(new Container);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -104,6 +104,8 @@ class DatabaseEloquentFactoryTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->drop('users');
+
+        Container::setInstance(null);
     }
 
     public function test_basic_model_can_be_created()

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -77,6 +77,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
         }
     }
 
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
     public function testBasicMigrationOfSingleFolder()
     {
         $ran = $this->migrator->run([__DIR__.'/migrations/one']);

--- a/tests/Database/DatabaseSQLiteBuilderTest.php
+++ b/tests/Database/DatabaseSQLiteBuilderTest.php
@@ -23,6 +23,12 @@ class DatabaseSQLiteBuilderTest extends TestCase
         Facade::setFacadeApplication($app);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        Facade::setFacadeApplication(null);
+    }
+
     public function testCreateDatabase()
     {
         $connection = Mockery::mock(Connection::class);

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -34,6 +34,12 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
     public function testHasColumnWithTablePrefix()
     {
         $this->db::connection()->setTablePrefix('test_');

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -263,4 +263,9 @@ class PruneCommandTest extends TestCase
 
         return $output;
     }
+
+    protected function tearDown(): void
+    {
+        Application::setInstance(null);
+    }
 }

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -177,6 +177,8 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->connection('event-connection')->assertPushedOn('event-queue', CallQueuedListener::class);
+
+        Container::setInstance(null);
     }
 
     public function testConnectionIsSetUsingForwardedQueue()
@@ -200,6 +202,8 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->connection('cloud')->assertPushedOn('reports', CallQueuedListener::class);
+
+        Container::setInstance(null);
     }
 
     public function testDelayIsSetByWithDelayDynamically()

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -36,6 +36,7 @@ class HandleExceptionsTest extends TestCase
 
     protected function tearDown(): void
     {
+        Application::setInstance(null);
         HandleExceptions::flushState($this);
     }
 

--- a/tests/Foundation/Cloud/JsonFormatterTest.php
+++ b/tests/Foundation/Cloud/JsonFormatterTest.php
@@ -16,6 +16,11 @@ class JsonFormatterTest extends TestCase
         Container::setInstance(new Container);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     protected function createRecord(): LogRecord
     {
         return new LogRecord(

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Foundation\Configuration;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\MaintenanceMode;
@@ -27,6 +28,7 @@ class MiddlewareTest extends TestCase
 {
     protected function tearDown(): void
     {
+        Container::setInstance(null);
         ConvertEmptyStringsToNull::flushState();
         EncryptCookies::flushState();
         PreventRequestForgery::flushState();

--- a/tests/Foundation/Console/DevCommandTest.php
+++ b/tests/Foundation/Console/DevCommandTest.php
@@ -33,6 +33,11 @@ class DevCommandTest extends TestCase
         $app['config'] = new Repository(['app' => ['name' => 'Laravel']]);
     }
 
+    protected function tearDown(): void
+    {
+        Application::setInstance(null);
+    }
+
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testMultiplexCommandDefaultsToTabs()
     {

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -12,6 +12,11 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationAuthorizesRequestsTraitTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testBasicGateCheck()
     {
         unset($_SERVER['_test.authorizes.trait']);

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommandMode;
 use Illuminate\Foundation\DevCommands;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -38,6 +40,14 @@ class FoundationDevCommandsTest extends TestCase
         $app['env'] = 'testing';
 
         File::swap(new Filesystem);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Container::setInstance(null);
+
+        parent::tearDown();
     }
 
     public function testRegisterAddsCommand()

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -77,6 +77,11 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler = new Handler($this->container);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testHandlerReportsExceptionAsContext()
     {
         $logger = Mockery::mock(LoggerInterface::class);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -30,6 +30,8 @@ class FoundationFormRequestTest extends TestCase
     {
         FormRequest::failOnUnknownFields(false);
 
+        Container::setInstance(null);
+
         $this->mocks = [];
     }
 

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -288,5 +288,6 @@ class HtmlDumperTest extends TestCase
     protected function tearDown(): void
     {
         HtmlDumper::resolveDumpSourceUsing(null);
+        Container::setInstance(null);
     }
 }

--- a/tests/Foundation/LaravelCloudJsonFormatterTest.php
+++ b/tests/Foundation/LaravelCloudJsonFormatterTest.php
@@ -16,6 +16,11 @@ class LaravelCloudJsonFormatterTest extends TestCase
         Container::setInstance(new Container);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     protected function createRecord(): LogRecord
     {
         return new LogRecord(

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -13,6 +13,12 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class VitePreloadingTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+        Facade::clearResolvedInstances();
+    }
+
     public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()
     {
         $app = new Container;

--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -184,7 +184,7 @@ class ImagickDriverTest extends TestCase
         try {
             $this->assertSame([137, 73], (new Image($heic))->dimensions());
         } finally {
-            //
+            Container::setInstance(null);
         }
     }
 

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -334,7 +334,7 @@ class ImageTest extends TestCase
             $this->assertSame(123, $image->width());
             $this->assertSame(45, $image->height());
         } finally {
-            //
+            Container::setInstance(null);
         }
     }
 
@@ -377,7 +377,7 @@ class ImageTest extends TestCase
 
             $image->dimensions();
         } finally {
-            //
+            Container::setInstance(null);
         }
     }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -25,6 +25,11 @@ use PHPUnit\Framework\TestCase;
 
 class NotificationChannelManagerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testNotificationCanBeDispatchedToDriver()
     {
         $container = new Container;

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -13,6 +13,11 @@ use stdClass;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testNotificationCanBeDispatched()
     {
         $container = new Container;

--- a/tests/Queue/FailoverQueueTest.php
+++ b/tests/Queue/FailoverQueueTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Queue;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\FailoverQueue;
@@ -11,6 +12,11 @@ use PHPUnit\Framework\TestCase;
 
 class FailoverQueueTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function test_push_fails_over_on_exception()
     {
         $queue = Mockery::mock(QueueManager::class);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -355,6 +355,8 @@ class QueueSqsQueueTest extends TestCase
         ])->andReturn($this->mockedSendMessageResponseModel);
 
         $queue->pushRaw('payload', 'jobs');
+
+        Container::setInstance(null);
     }
 
     public function testGetQueueEnsuresTheQueueIsOnlySuffixedOnce()

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -19,6 +19,11 @@ use PHPUnit\Framework\TestCase;
 
 class QueueSyncQueueTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testPushShouldFireJobInstantly()
     {
         unset($_SERVER['__sync.test']);
@@ -50,6 +55,8 @@ class QueueSyncQueueTest extends TestCase
         } catch (Exception) {
             $this->assertTrue($_SERVER['__sync.failed']);
         }
+
+        Container::setInstance();
     }
 
     public function testFailedJobHasAccessToJobInstance()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -46,6 +46,11 @@ class QueueWorkerTest extends TestCase
         $container->instance(ExceptionHandler::class, $this->exceptionHandler);
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance();
+    }
+
     public function testJobCanBeFired()
     {
         $worker = $this->getWorker('default', ['queue' => [$job = new WorkerFakeJob]]);

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -13,6 +13,7 @@ class SupportFacadeTest extends TestCase
 {
     protected function setUp(): void
     {
+        Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -38,6 +38,12 @@ class SupportFacadesEventTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
     public function testFakeFor()
     {
         Event::fakeFor(function () {

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -583,6 +583,8 @@ class SupportTestingBusFakeTest extends TestCase
             fn (ChainedJobStub $job) => $job->id === 123,
             fn (ChainedJobStub $job) => $job->id === 456,
         ]);
+
+        Container::setInstance(null);
     }
 
     public function testAssertNothingChained()

--- a/tests/Testing/AssertRedirectToActionTest.php
+++ b/tests/Testing/AssertRedirectToActionTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class AssertRedirectToActionTest extends TestCase
@@ -45,6 +46,13 @@ class AssertRedirectToActionTest extends TestCase
     {
         $this->get('redirect-to-show')
             ->assertRedirectToAction([TestActionController::class, 'show'], ['id' => 123]);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
     }
 }
 

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class AssertRedirectToRouteTest extends TestCase
@@ -81,5 +82,12 @@ class AssertRedirectToRouteTest extends TestCase
 
         $this->get('test-route')
             ->assertRedirectToRoute('route-with-empty-uri', ['foo' => 'bar']);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
     }
 }

--- a/tests/Testing/AssertRedirectToSignedRouteTest.php
+++ b/tests/Testing/AssertRedirectToSignedRouteTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class AssertRedirectToSignedRouteTest extends TestCase
@@ -92,5 +93,12 @@ class AssertRedirectToSignedRouteTest extends TestCase
 
         $this->get('test-route')
             ->assertRedirectToSignedRoute('signed-route');
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
     }
 }

--- a/tests/Testing/Concerns/InteractsWithDatabaseTest.php
+++ b/tests/Testing/Concerns/InteractsWithDatabaseTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Facade;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,8 @@ class InteractsWithDatabaseTest extends TestCase
 {
     protected function setUp(): void
     {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
     }
 
     public function testCastToJsonSqlite()

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -35,7 +35,9 @@ class TestCachesTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
         ParallelTestingFacade::clearResolvedInstance();
+        Facade::setFacadeApplication(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
 

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -91,6 +91,7 @@ class TestDatabasesTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
         DB::clearResolvedInstance();
         DB::setFacadeApplication(null);
 

--- a/tests/Testing/Concerns/TestViewsTest.php
+++ b/tests/Testing/Concerns/TestViewsTest.php
@@ -36,7 +36,9 @@ class TestViewsTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
         ParallelTestingFacade::clearResolvedInstance();
+        Facade::setFacadeApplication(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
     }

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -97,6 +97,8 @@ class ParallelTestingTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
+
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
     }
 }

--- a/tests/Validation/ValidationAnyOfRuleTest.php
+++ b/tests/Validation/ValidationAnyOfRuleTest.php
@@ -390,4 +390,11 @@ class ValidationAnyOfRuleTest extends TestCase
 
         $this->setUpRuleSets();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
 }

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -925,4 +925,13 @@ class ValidationEmailRuleTest extends TestCase
 
         (new ValidationServiceProvider($container))->register();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
 }

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -338,4 +338,13 @@ class ValidationEnumRuleTest extends TestCase
 
         (new ValidationServiceProvider($container))->register();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
 }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -496,4 +496,13 @@ class ValidationFileRuleTest extends TestCase
 
         (new ValidationServiceProvider($container))->register();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
 }

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -158,6 +158,15 @@ class ValidationImageFileRuleTest extends TestCase
 
         (new ValidationServiceProvider($container))->register();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
 }
 
 class UploadedFileWithCustomImageSizeMethod extends UploadedFile

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -15,6 +15,11 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationNotPwnedVerifierTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     #[DataProvider('dataProviderEmptyValues')]
     public function testEmptyValues($password): void
     {

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -603,4 +603,15 @@ class ValidationPasswordRuleTest extends TestCase
 
         (new ValidationServiceProvider($container))->register();
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        Password::$defaultCallback = null;
+    }
 }

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -43,6 +43,15 @@ class ValidationRuleCanTest extends TestCase
         (new ValidationServiceProvider($this->container))->register();
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+
     public function testValidationFails()
     {
         $this->gate()->define('update-company', function ($user, $value) {

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Component;
@@ -22,6 +23,7 @@ abstract class AbstractBladeTestCase extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -413,6 +413,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->guessClassName('alert');
 
         $this->assertSame("App\View\Components\Alert", trim($result));
+
+        Container::setInstance(null);
     }
 
     public function testClassNamesCanBeGuessedWithNamespaces()
@@ -426,6 +428,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->guessClassName('base.alert');
 
         $this->assertSame("App\View\Components\Base\Alert", trim($result));
+
+        Container::setInstance(null);
     }
 
     public function testComponentsCanBeCompiledWithHyphenAttributes()

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -41,6 +41,9 @@ class ComponentTest extends TestCase
 
     protected function tearDown(): void
     {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Container::setInstance(null);
         Component::flushCache();
         Component::forgetFactory();
     }


### PR DESCRIPTION
This reverts commit 8cb299dc2c07227f0cb664a2d53d0cde7839eaaf.

CI is failing since the commit

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
