### PR TITLE
[13.x] Add `ShouldBroadcastAfterCommit` contract

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -4,6 +4,7 @@ namespace Illuminate\Broadcasting;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastAfterCommit;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Queue\Attributes\Backoff;
@@ -76,7 +77,13 @@ class BroadcastEvent implements ShouldQueue
         $this->tries = $this->getAttributeValue($event, Tries::class, 'tries');
         $this->timeout = $this->getAttributeValue($event, Timeout::class, 'timeout');
         $this->backoff = $this->getAttributeValue($event, Backoff::class, 'backoff');
-        $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
+
+        if ($event instanceof ShouldBroadcastAfterCommit) {
+            $this->afterCommit = true;
+        } else {
+            $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
+        }
+
         $this->maxExceptions = $this->getAttributeValue($event, MaxExceptions::class, 'maxExceptions');
         $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? true;
     }

--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcastAfterCommit.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcastAfterCommit.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Broadcasting;
+
+interface ShouldBroadcastAfterCommit extends ShouldBroadcast
+{
+    //
+}

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -7,6 +7,7 @@ use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastAfterCommit;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -152,6 +153,25 @@ class BroadcastEventTest extends TestCase
         $this->assertFalse($job->deleteWhenMissingModels);
     }
 
+    public function testAfterCommitIsResolvedFromTheEventProperty()
+    {
+        $event = new class
+        {
+            public $afterCommit = true;
+        };
+
+        $job = new BroadcastEvent($event);
+
+        $this->assertTrue($job->afterCommit);
+    }
+
+    public function testAfterCommitIsResolvedFromTheShouldBroadcastAfterCommitContract()
+    {
+        $job = new BroadcastEvent(new TestBroadcastEventAfterCommit);
+
+        $this->assertTrue($job->afterCommit);
+    }
+
     public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent()
     {
         $event = new class
@@ -187,6 +207,11 @@ class TestBroadcastEvent
     {
         return ['test-channel'];
     }
+}
+
+class TestBroadcastEventAfterCommit extends TestBroadcastEvent implements ShouldBroadcastAfterCommit
+{
+    //
 }
 
 class TestBroadcastEventWithStringName extends TestBroadcastEvent

--- a/tests/Integration/Broadcasting/ShouldBroadcastAfterCommitTest.php
+++ b/tests/Integration/Broadcasting/ShouldBroadcastAfterCommitTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Broadcasting;
+
+use Exception;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastAfterCommit;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class ShouldBroadcastAfterCommitTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Broadcast::extend('recording', fn () => new RecordingBroadcaster);
+    }
+
+    protected function tearDown(): void
+    {
+        RecordingBroadcaster::$broadcasts = [];
+
+        parent::tearDown();
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('queue.default', 'sync');
+        $app['config']->set('broadcasting.default', 'recording');
+        $app['config']->set('broadcasting.connections.recording', ['driver' => 'recording']);
+    }
+
+    public function testEventIsBroadcastImmediatelyIfThereIsNoTransaction()
+    {
+        Event::dispatch(new BroadcastAfterCommitTestEvent);
+
+        $this->assertSame([BroadcastAfterCommitTestEvent::class], RecordingBroadcaster::$broadcasts);
+    }
+
+    public function testEventIsOnlyBroadcastAfterTheTransactionCommits()
+    {
+        DB::transaction(function () {
+            Event::dispatch(new BroadcastAfterCommitTestEvent);
+
+            $this->assertSame([], RecordingBroadcaster::$broadcasts);
+        });
+
+        $this->assertSame([BroadcastAfterCommitTestEvent::class], RecordingBroadcaster::$broadcasts);
+    }
+
+    public function testEventIsNotBroadcastIfTheTransactionIsRolledBack()
+    {
+        try {
+            DB::transaction(function () {
+                Event::dispatch(new BroadcastAfterCommitTestEvent);
+
+                throw new Exception;
+            });
+        } catch (Exception) {
+            //
+        }
+
+        $this->assertSame([], RecordingBroadcaster::$broadcasts);
+    }
+
+    public function testEventWithoutTheContractIsBroadcastInsideTheTransaction()
+    {
+        DB::transaction(function () {
+            Event::dispatch(new BroadcastTestEvent);
+
+            $this->assertSame([BroadcastTestEvent::class], RecordingBroadcaster::$broadcasts);
+        });
+    }
+}
+
+class BroadcastTestEvent implements ShouldBroadcast
+{
+    public function broadcastOn()
+    {
+        return ['test-channel'];
+    }
+}
+
+class BroadcastAfterCommitTestEvent implements ShouldBroadcastAfterCommit
+{
+    public function broadcastOn()
+    {
+        return ['test-channel'];
+    }
+}
+
+class RecordingBroadcaster implements Broadcaster
+{
+    public static $broadcasts = [];
+
+    public function auth($request)
+    {
+        //
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+        //
+    }
+
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+        static::$broadcasts[] = $event;
+    }
+}


### PR DESCRIPTION
Adds the ability to defer broadcasting until the current database transaction commits, by implementing `Illuminate\Contracts\Broadcasting\ShouldBroadcastAfterCommit`:

```php
class OrderShipped implements ShouldBroadcastAfterCommit
{
    public function broadcastOn()
    {
        return new PrivateChannel('orders.'.$this->order->id);
    }
}