### PR TITLE
[13.x] Add `stop()` and `ensureNotTimedOut()` to `FakeInvokedProcess`

### DIFF
--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -123,21 +123,6 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
-     * Stop the process if it is still running.
-     *
-     * @param  float  $timeout
-     * @param  int|null  $signal
-     * @return int|null
-     */
-    public function stop(float $timeout = 10, ?int $signal = null)
-    {
-        $this->stopped = true;
-        $this->remainingRunIterations = 0;
-
-        return $this->process->exitCode;
-    }
-
-    /**
      * Determine if the process is still running.
      *
      * @return bool
@@ -351,6 +336,21 @@ class FakeInvokedProcess implements InvokedProcessContract
         $this->remainingRunIterations = 0;
 
         return $this->process->toProcessResult($this->command);
+    }
+
+    /**
+     * Stop the process if it is still running.
+     *
+     * @param  float  $timeout
+     * @param  int|null  $signal
+     * @return int|null
+     */
+    public function stop(float $timeout = 10, ?int $signal = null)
+    {
+        $this->stopped = true;
+        $this->remainingRunIterations = 0;
+
+        return $this->process->exitCode;
     }
 
     /**

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -156,7 +156,6 @@ class FakeInvokedProcess implements InvokedProcessContract
 
         if ($this->remainingRunIterations === 0) {
             while (! $this->stopped && $this->invokeOutputHandlerWithNextLineOfOutput()) {
-
             }
 
             return false;

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -35,6 +35,13 @@ class FakeInvokedProcess implements InvokedProcessContract
     protected $remainingRunIterations;
 
     /**
+     * Indicates whether the process has been stopped.
+     *
+     * @var bool
+     */
+    protected $stopped = false;
+
+    /**
      * The general output handler callback.
      *
      * @var callable|null
@@ -116,12 +123,31 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Stop the process if it is still running.
+     *
+     * @param  float  $timeout
+     * @param  int|null  $signal
+     * @return int|null
+     */
+    public function stop(float $timeout = 10, ?int $signal = null)
+    {
+        $this->stopped = true;
+        $this->remainingRunIterations = 0;
+
+        return $this->process->exitCode;
+    }
+
+    /**
      * Determine if the process is still running.
      *
      * @return bool
      */
     public function running()
     {
+        if ($this->stopped) {
+            return false;
+        }
+
         $this->invokeOutputHandlerWithNextLineOfOutput();
 
         $this->remainingRunIterations = is_null($this->remainingRunIterations)
@@ -129,7 +155,8 @@ class FakeInvokedProcess implements InvokedProcessContract
             : $this->remainingRunIterations;
 
         if ($this->remainingRunIterations === 0) {
-            while ($this->invokeOutputHandlerWithNextLineOfOutput()) {
+            while (! $this->stopped && $this->invokeOutputHandlerWithNextLineOfOutput()) {
+
             }
 
             return false;
@@ -259,6 +286,16 @@ class FakeInvokedProcess implements InvokedProcessContract
         }
 
         return $output ?? '';
+    }
+
+    /**
+     * Ensure that the process has not timed out.
+     *
+     * @return void
+     */
+    public function ensureNotTimedOut()
+    {
+        //
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1182,6 +1182,111 @@ class ProcessTest extends TestCase
         $this->assertEmpty($waitUntilCallbacks);
     }
 
+    public function testFakeInvokedProcessCanBeStopped()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()
+                ->output('STARTED')
+                ->exitCode(143)
+                ->runsFor(iterations: 10);
+        });
+
+        $process = $factory->start('sleep 100');
+
+        $this->assertTrue($process->running());
+        $this->assertSame(143, $process->stop());
+        $this->assertFalse($process->running());
+    }
+
+    public function testFakeInvokedProcessStopsInvokingOutputHandlerOnceStopped()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()
+                ->output('FIRST')
+                ->output('SECOND')
+                ->output('THIRD')
+                ->runsFor(iterations: 10);
+        });
+
+        $output = [];
+
+        $process = $factory->start('sleep 100', function ($type, $buffer) use (&$output) {
+            $output[] = $buffer;
+        });
+
+        while ($process->running()) {
+            $process->stop();
+        }
+
+        $this->assertSame(["FIRST\n"], $output);
+    }
+
+    public function testFakeInvokedProcessStopsInvokingOutputHandlerWhenStoppedFromWithinIt()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()
+                ->output('FIRST')
+                ->output('SECOND')
+                ->output('THIRD')
+                ->runsFor(iterations: 10);
+        });
+
+        $output = [];
+
+        $process = $factory->start('sleep 100');
+
+        $process->waitUntil(function ($type, $buffer) use (&$output, &$process) {
+            $output[] = $buffer;
+
+            $process->stop();
+
+            return false;
+        });
+
+        $this->assertSame(["FIRST\n"], $output);
+    }
+
+    public function testFakeInvokedProcessPoolCanBeStopped()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()->runsFor(iterations: 10);
+        });
+
+        $pool = $factory->pool(function ($pool) {
+            return [
+                $pool->command('sleep 100'),
+                $pool->command('sleep 100'),
+            ];
+        })->start();
+
+        $this->assertCount(2, $pool->running());
+
+        $pool->stop();
+
+        $this->assertCount(0, $pool->running());
+    }
+
+    public function testFakeInvokedProcessNeverTimesOut()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()->runsFor(iterations: 10);
+        });
+
+        $process = $factory->timeout(1)->start('sleep 100');
+
+        $this->assertNull($process->ensureNotTimedOut());
+    }
+
     public function testBasicFakeAssertions()
     {
         $factory = new Factory;


### PR DESCRIPTION

`InvokedProcess` has `stop()` and `ensureNotTimedOut()`, but `FakeInvokedProcess` does not, so calling either one under `Process::fake()` fails with `Call to undefined method`, and **there is no way to test code that stops a process**. `InvokedProcessPool::stop()` fails the same way for faked pools.

This PR adds both methods to the fake, so a stopped process returns its exit code and reports that it is no longer running.