### PR TITLE
[13.x] Guard against `false` returns in `PhpRedisConnection::mget()` and `hmget()`

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -131,6 +131,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function mget(array $keys)
     {
         $result = $this->command('mget', [$keys]);
+
         if ($result === false) {
             return array_fill(0, count($keys), null);
         }
@@ -185,6 +186,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         }
 
         $result = $this->command('hmget', [$key, $dictionary]);
+
         if ($result === false) {
             return array_fill(0, count((array) $dictionary), null);
         }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -184,7 +184,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             $dictionary = $dictionary[0];
         }
 
-        return array_values($this->command('hmget', [$key, $dictionary]));
+        $result = $this->command('hmget', [$key, $dictionary]);
+
+        return $result !== false ? array_values($result) : [];
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -130,9 +130,14 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function mget(array $keys)
     {
+        $result = $this->command('mget', [$keys]);
+        if ($result === false) {
+            return array_fill(0, count($keys), null);
+        }
+
         return array_map(function ($value) {
             return $value !== false ? $value : null;
-        }, $this->command('mget', [$keys]));
+        }, $result);
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -185,8 +185,11 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         }
 
         $result = $this->command('hmget', [$key, $dictionary]);
+        if ($result === false) {
+            return array_fill(0, count((array) $dictionary), null);
+        }
 
-        return $result !== false ? array_values($result) : [];
+        return array_values($result);
     }
 
     /**


### PR DESCRIPTION
phpredis returns `false` when the server rejects a command.

These `false` return types are handled already on single-key commands, but there is no type type on multi key commands: `mget` and `hmget`.

CROSSSLOT error can occur when the keys land in different hash slots and phpredis signals that by returning false - in that case `PhpRedisConnection.php(133)` throws `(TypeError) - 'array_map(): Argument #2 ($array) must be of type array, false given'`