### PR TITLE
Fix URI query decoding and numeric JSON Schema properties

### DIFF
--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -119,7 +119,39 @@ abstract class Type extends JsonSchema
      */
     public function toString(): string
     {
-        return json_encode($this->toArray(), JSON_PRETTY_PRINT) ?: '';
+        return json_encode(static::normalizeSchemaForJson($this->toArray()), JSON_PRETTY_PRINT) ?: '';
+    }
+
+    /**
+     * Normalize schema objects that PHP cannot represent with an array.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected static function normalizeSchemaForJson(array $schema): array
+    {
+        if (isset($schema['properties'])) {
+            $properties = new \stdClass;
+
+            foreach ($schema['properties'] as $name => $property) {
+                $properties->{(string) $name} = static::normalizeSchemaForJson($property);
+            }
+
+            $schema['properties'] = $properties;
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            $schema['items'] = static::normalizeSchemaForJson($schema['items']);
+        }
+
+        if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
+            $schema['anyOf'] = array_map(
+                static fn (array $schema): array => static::normalizeSchemaForJson($schema),
+                $schema['anyOf'],
+            );
+        }
+
+        return $schema;
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -387,11 +387,13 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      */
     public function decode(): string
     {
-        if (empty($this->query()->toArray())) {
+        $query = $this->query();
+
+        if (empty($query->toArray())) {
             return $this->value();
         }
 
-        return Str::replace($this->query()->value(), $this->query()->decode(), $this->value());
+        return Str::replaceFirst('?'.$query->value(), '?'.$query->decode(), $this->value());
     }
 
     /**

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -62,6 +62,19 @@ class TypeTest extends TestCase
         JSON, $type->toString());
     }
 
+    public function test_numeric_property_names_are_encoded_as_json_object_properties(): void
+    {
+        $schema = JsonSchema::object([
+            '0' => JsonSchema::string()->required(),
+        ]);
+
+        $encoded = json_decode($schema->toString(), false, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertIsObject($encoded->properties);
+        $this->assertSame('string', $encoded->properties->{'0'}->type);
+        $this->assertValidOnJsonSchema($schema, (object) ['0' => 'value']);
+    }
+
     public function test_does_have_a_stringable_representation(): void
     {
         $type = JsonSchema::object([

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -197,6 +197,13 @@ class SupportUriTest extends TestCase
         $this->assertSame('https://laravel.com/docs/11.x/routing?q=laravel docs#route-model-binding', $uri->decode());
     }
 
+    public function test_decoding_the_query_does_not_modify_the_path_or_fragment()
+    {
+        $uri = Uri::of('https://example.com/x=a%20b?x=a%20b#x=a%20b');
+
+        $this->assertSame('https://example.com/x=a%20b?x=a b#x=a%20b', $uri->decode());
+    }
+
     public function test_with_query_if_missing()
     {
         // Test adding new parameters while preserving existing ones


### PR DESCRIPTION
Coverage-guided fuzzing found both regressions.

## Summary

- Scope URI decoding to the query component.
- Preserve numeric JSON Schema property names during JSON encoding.
- Add regression tests for both reproductions.

This prevents altered path/fragment data and malformed schemas without changing normal query decoding, `toArray()`, or array-valued schema keywords.

## Reproduction

```php
$uri = Uri::of('https://example.com/x=a%20b?x=a%20b#x=a%20b');
$uri->decode();
// Before:   https://example.com/x=a b?x=a b#x=a b
// Expected: https://example.com/x=a%20b?x=a b#x=a%20b
```

```php
$schema = JsonSchema::object([
    '0' => JsonSchema::string()->required(),
]);
$schema->toString();
// Before:   "properties": [{"type":"string"}]
// Expected: "properties": {"0":{"type":"string"}}
```

## Testing

Ran the targeted PHPUnit tests, Pint, PHPStan, and capped coverage-guided fuzzing for URI, JSON Schema, and configuration URL parsing; all passed.
