### PR TITLE
[13.x] Move and copy files that only exist on a read-through disk's fallback

### DIFF
--- a/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
@@ -229,7 +229,7 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
     }
 
     /**
-     * Copy a file on the primary filesystem.
+     * Copy a file on the primary filesystem, reading it from the fallback filesystem when necessary.
      */
     public function copy(string $source, string $destination, Config $config): void
     {

--- a/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
@@ -7,6 +7,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToReadFile;
 
@@ -216,7 +217,7 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
      */
     public function move(string $source, string $destination, Config $config): void
     {
-        $this->primary->move($source, $destination, $config->toArray());
+        $this->moveOnPrimary($source, $destination, $config);
 
         try {
             if ($this->fallback->fileExists($source)) {
@@ -232,7 +233,51 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
      */
     public function copy(string $source, string $destination, Config $config): void
     {
-        $this->primary->copy($source, $destination, $config->toArray());
+        if ($this->primary->fileExists($source)) {
+            $this->primary->copy($source, $destination, $config->toArray());
+
+            return;
+        }
+
+        try {
+            $this->copyFromFallback($source, $destination, $config);
+        } catch (FilesystemException $exception) {
+            throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    /**
+     * Move a file to its destination on the primary filesystem.
+     */
+    protected function moveOnPrimary(string $source, string $destination, Config $config): void
+    {
+        if ($this->primary->fileExists($source)) {
+            $this->primary->move($source, $destination, $config->toArray());
+
+            return;
+        }
+
+        try {
+            $this->copyFromFallback($source, $destination, $config);
+        } catch (FilesystemException $exception) {
+            throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    /**
+     * Copy a file from the fallback filesystem to the primary filesystem.
+     */
+    protected function copyFromFallback(string $source, string $destination, Config $config): void
+    {
+        $stream = $this->fallback->readStream($source);
+
+        try {
+            $this->primary->writeStream($destination, $stream, $config->toArray());
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
     }
 
     /**

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -347,6 +347,86 @@ class FilesystemManagerTest extends TestCase
         $this->assertTrue($readThrough->missing('source.txt'));
     }
 
+    public function testReadThroughDisksMoveFilesThatOnlyExistOnTheFallbackDisk()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('source.txt', 'contents');
+
+        $this->assertTrue($readThrough->move('source.txt', 'destination.txt'));
+        $this->assertSame('contents', $primary->get('destination.txt'));
+        $this->assertTrue($fallback->missing('source.txt'));
+        $this->assertTrue($readThrough->missing('source.txt'));
+    }
+
+    public function testReadThroughDisksCopyFilesThatOnlyExistOnTheFallbackDisk()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('source.txt', 'contents');
+
+        $this->assertTrue($readThrough->copy('source.txt', 'destination.txt'));
+        $this->assertSame('contents', $primary->get('destination.txt'));
+        $this->assertSame('contents', $fallback->get('source.txt'));
+        $this->assertSame('contents', $readThrough->get('source.txt'));
+    }
+
+    public function testReadThroughDisksCopyFromTheFallbackDiskWithoutPromotingTheSourceWhenDisabled()
+    {
+        $filesystem = $this->readThroughFilesystemManager([
+            'copy' => false,
+        ]);
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('source.txt', 'contents');
+
+        $this->assertTrue($readThrough->copy('source.txt', 'destination.txt'));
+        $this->assertSame('contents', $primary->get('destination.txt'));
+        $this->assertTrue($primary->missing('source.txt'));
+        $this->assertSame('contents', $fallback->get('source.txt'));
+
+        $this->assertTrue($readThrough->move('source.txt', 'moved.txt'));
+        $this->assertSame('contents', $primary->get('moved.txt'));
+        $this->assertTrue($primary->missing('source.txt'));
+        $this->assertTrue($fallback->missing('source.txt'));
+    }
+
+    public function testReadThroughDisksFailToMoveOrCopyMissingFiles()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $readThrough = $filesystem->disk('read-through');
+
+        $this->assertFalse($readThrough->move('missing.txt', 'destination.txt'));
+        $this->assertFalse($readThrough->copy('missing.txt', 'destination.txt'));
+    }
+
+    public function testReadThroughDisksFailToMoveOrCopyWhenThePrimaryDiskIsUnwritable()
+    {
+        $filesystem = $this->readThroughFilesystemManager([
+            'primary' => [
+                'driver' => 'local',
+                'root' => $this->temporaryDirectory('primary'),
+                'read-only' => true,
+            ],
+        ]);
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('source.txt', 'contents');
+
+        $this->assertFalse($readThrough->move('source.txt', 'destination.txt'));
+        $this->assertFalse($readThrough->copy('source.txt', 'destination.txt'));
+        $this->assertSame('contents', $fallback->get('source.txt'));
+    }
+
     public function testReadThroughDiskPromotionFailuresAreBestEffortByDefault()
     {
         $filesystem = $this->readThroughFilesystemManager([


### PR DESCRIPTION
On a read-through disk, `move()` and `copy()` only ever look at the primary disk, so they fail for any file that hasn't been promoted yet, even though reads resolve it fine through the fallback.

```php
Storage::disk('fallback')->put('source.txt', 'contents');

Storage::disk('read-through')->exists('source.txt');                  // true
Storage::disk('read-through')->move('source.txt', 'destination.txt'); // false
Storage::disk('read-through')->copy('source.txt', 'destination.txt'); // false
```

The fallback cleanup in `move()` (a833cea6ad) only runs once the primary already has the file, so a fallback-only file never gets that far. With `'copy' => false` it can't work at all, since nothing ever promotes.

Both now stream the source off the fallback disk straight to the destination on the primary when the primary doesn't have it, and `move()` still deletes the fallback source after. Failures are wrapped as `UnableToMoveFile` / `UnableToCopyFile` so a disk that isn't configured to throw keeps returning `false` instead of leaking a raw `UnableToWriteFile` (a read-only primary hits this).

The alternative I skipped: promote the source onto the primary first and let the existing `primary->move()` / `primary->copy()` run. Smaller diff, but `copy()` then leaves a cached copy of the source behind, which quietly breaks `'copy' => false`, since reads of the source would hit a stale primary copy forever instead of going to the fallback. Writing to the destination avoids that, and saves a write on `move()` too.
