### PR TITLE
[13.x] Add queue concurrency driver

### DIFF
--- a/config/concurrency.php
+++ b/config/concurrency.php
@@ -11,10 +11,45 @@ return [
     | by Laravel's concurrency functions. By default, concurrent work will
     | be sent to isolated PHP processes which will return their results.
     |
-    | Supported: "process", "fork", "sync"
+    | Supported: "process", "fork", "sync", "queue"
     |
     */
 
     'default' => env('CONCURRENCY_DRIVER', 'process'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Concurrency Drivers
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure each of the concurrency drivers utilized by your
+    | application. The queue driver will distribute your tasks to the queue
+    | workers, which return their results through the given cache store.
+    |
+    */
+
+    'drivers' => [
+
+        'process' => [
+            'driver' => 'process',
+        ],
+
+        'fork' => [
+            'driver' => 'fork',
+        ],
+
+        'sync' => [
+            'driver' => 'sync',
+        ],
+
+        'queue' => [
+            'driver' => 'queue',
+            'connection' => env('CONCURRENCY_QUEUE_CONNECTION'),
+            'queue' => env('CONCURRENCY_QUEUE'),
+            'store' => env('CONCURRENCY_CACHE_STORE'),
+            'timeout' => (int) env('CONCURRENCY_TIMEOUT', 60),
+        ],
+
+    ],
 
 ];

--- a/src/Illuminate/Concurrency/CapturedTaskException.php
+++ b/src/Illuminate/Concurrency/CapturedTaskException.php
@@ -5,15 +5,13 @@ namespace Illuminate\Concurrency;
 use RuntimeException;
 use Throwable;
 
+/**
+ * The original task exception has already been captured in the task's
+ * result envelope for the caller. This wrapper is rethrown so that the
+ * failure remains visible to the queue's failed job machinery.
+ */
 class CapturedTaskException extends RuntimeException
 {
-    /**
-     * Create a new captured task exception instance.
-     *
-     * The original task exception has already been captured in the task's
-     * result envelope for the caller. This wrapper is rethrown so that the
-     * failure remains visible to the queue's failed job machinery.
-     */
     public function __construct(Throwable $previous)
     {
         parent::__construct($previous->getMessage(), 0, $previous);

--- a/src/Illuminate/Concurrency/CapturedTaskException.php
+++ b/src/Illuminate/Concurrency/CapturedTaskException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use RuntimeException;
+use Throwable;
+
+class CapturedTaskException extends RuntimeException
+{
+    /**
+     * Create a new captured task exception instance.
+     *
+     * The original task exception has already been captured in the task's
+     * result envelope for the caller. This wrapper is rethrown so that the
+     * failure remains visible to the queue's failed job machinery.
+     */
+    public function __construct(Throwable $previous)
+    {
+        parent::__construct($previous->getMessage(), 0, $previous);
+    }
+}

--- a/src/Illuminate/Concurrency/ConcurrencyManager.php
+++ b/src/Illuminate/Concurrency/ConcurrencyManager.php
@@ -2,7 +2,13 @@
 
 namespace Illuminate\Concurrency;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Process\Factory as ProcessFactory;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Arr;
 use Illuminate\Support\MultipleInstanceManager;
 use RuntimeException;
 use Spatie\Fork\Fork;
@@ -28,9 +34,10 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the process concurrency driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Concurrency\ProcessDriver
      */
-    public function createProcessDriver()
+    public function createProcessDriver(array $config = [])
     {
         return new ProcessDriver($this->app->make(ProcessFactory::class));
     }
@@ -38,11 +45,12 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the fork concurrency driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Concurrency\ForkDriver
      *
      * @throws \RuntimeException
      */
-    public function createForkDriver()
+    public function createForkDriver(array $config = [])
     {
         if (! $this->app->runningInConsole()) {
             throw new RuntimeException('Due to PHP limitations, the fork driver may not be used within web requests.');
@@ -58,11 +66,36 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the sync concurrency driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Concurrency\SyncDriver
      */
-    public function createSyncDriver()
+    public function createSyncDriver(array $config = [])
     {
         return new SyncDriver;
+    }
+
+    /**
+     * Create an instance of the queue concurrency driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Concurrency\QueueDriver
+     *
+     * @throws \RuntimeException
+     */
+    public function createQueueDriver(array $config = [])
+    {
+        if (! trait_exists(Queueable::class) ||
+            ! class_exists(QueueManager::class) ||
+            ! class_exists(CacheManager::class)) {
+            throw new RuntimeException('Please install the "illuminate/bus", "illuminate/cache", and "illuminate/queue" Composer packages in order to utilize the "queue" driver.');
+        }
+
+        return new QueueDriver(
+            $this->app->make(Dispatcher::class),
+            $this->app->make(CacheFactory::class),
+            $this->app->make('config'),
+            Arr::except($config, ['driver']),
+        );
     }
 
     /**
@@ -97,6 +130,12 @@ class ConcurrencyManager extends MultipleInstanceManager
      */
     public function getInstanceConfig($name)
     {
+        $config = $this->app['config']->get('concurrency.drivers.'.$name);
+
+        if (is_array($config)) {
+            return array_merge(['driver' => $name], $config);
+        }
+
         return $this->app['config']->get(
             'concurrency.driver.'.$name, ['driver' => $name],
         );

--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Concurrency\Console;
 
+use Illuminate\Concurrency\TaskResult;
 use Illuminate\Console\Command;
-use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
@@ -41,41 +41,17 @@ class InvokeSerializedClosureCommand extends Command
     public function handle()
     {
         try {
-            $this->output->write(json_encode([
-                'successful' => true,
-                'result' => serialize($this->laravel->call(match (true) {
-                    ! is_null($this->argument('code')) => unserialize($this->argument('code')),
-                    isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize(
-                        base64_decode($_SERVER['LARAVEL_INVOKABLE_CLOSURE'])
-                    ),
-                    default => fn () => null,
-                })),
-            ]));
+            $this->output->write(json_encode(TaskResult::success($this->laravel->call(match (true) {
+                ! is_null($this->argument('code')) => unserialize($this->argument('code')),
+                isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize(
+                    base64_decode($_SERVER['LARAVEL_INVOKABLE_CLOSURE'])
+                ),
+                default => fn () => null,
+            }))));
         } catch (Throwable $e) {
             report($e);
 
-            $reflection = new ReflectionClass($e);
-            $constructor = $reflection->getConstructor();
-            $parameters = [];
-
-            if ($constructor) {
-                $declaringClass = $constructor->getDeclaringClass()->getName();
-
-                if ($declaringClass === $reflection->getName()) {
-                    foreach ($constructor->getParameters() as $parameter) {
-                        $parameters[$parameter->name] = $e->{$parameter->name} ?? null;
-                    }
-                }
-            }
-
-            $this->output->write(json_encode([
-                'successful' => false,
-                'exception' => get_class($e),
-                'message' => $e->getMessage(),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'parameters' => $parameters,
-            ]));
+            $this->output->write(json_encode(TaskResult::failure($e)));
         }
     }
 }

--- a/src/Illuminate/Concurrency/InvokeDeferredClosure.php
+++ b/src/Illuminate/Concurrency/InvokeDeferredClosure.php
@@ -2,28 +2,38 @@
 
 namespace Illuminate\Concurrency;
 
+use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\SyncJob;
+use Laravel\SerializableClosure\SerializableClosure;
 use Throwable;
 
 /**
- * The job QueueDriver::defer() dispatches.
- *
- * It is a CallQueuedClosure, so everything a deferred closure could observe
- * about the job it used to receive still holds: the type it may be hinted
- * on, the batch API, failure callbacks, the worker deciding retries, and a
- * closure whose models are gone being discarded. It differs in one place: on
- * a synchronous queue link a rethrown failure is not a recorded failure, it
- * is what makes a failover queue treat the link as dead and run the task
- * again on the next one, so there it reports the failure and returns.
+ * A CallQueuedClosure that reports a failure on a synchronous queue link
+ * instead of rethrowing it, so a failover queue does not read the task's
+ * failure as a dead link and run the task again on the next one.
  */
 class InvokeDeferredClosure extends CallQueuedClosure
 {
     /**
-     * Execute the job.
+     * Create a new job instance.
+     *
+     * @param  \Closure  $job
+     * @return static
      */
-    public function handle(Container $container): void
+    public static function create(Closure $job)
+    {
+        return new static(new SerializableClosure($job));
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function handle(Container $container)
     {
         try {
             parent::handle($container);

--- a/src/Illuminate/Concurrency/InvokeDeferredClosure.php
+++ b/src/Illuminate/Concurrency/InvokeDeferredClosure.php
@@ -10,9 +10,9 @@ use Laravel\SerializableClosure\SerializableClosure;
 use Throwable;
 
 /**
- * A CallQueuedClosure that reports a failure on a synchronous queue link
- * instead of rethrowing it, so a failover queue does not read the task's
- * failure as a dead link and run the task again on the next one.
+ * A queued closure that reports a failure on a sync connection instead of
+ * rethrowing it, so a failover connection does not treat the failure as the
+ * connection being down and run the task again.
  */
 class InvokeDeferredClosure extends CallQueuedClosure
 {

--- a/src/Illuminate/Concurrency/InvokeDeferredClosure.php
+++ b/src/Illuminate/Concurrency/InvokeDeferredClosure.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\Jobs\SyncJob;
+use Throwable;
+
+/**
+ * The job QueueDriver::defer() dispatches.
+ *
+ * It is a CallQueuedClosure, so everything a deferred closure could observe
+ * about the job it used to receive still holds: the type it may be hinted
+ * on, the batch API, failure callbacks, the worker deciding retries, and a
+ * closure whose models are gone being discarded. It differs in one place: on
+ * a synchronous queue link a rethrown failure is not a recorded failure, it
+ * is what makes a failover queue treat the link as dead and run the task
+ * again on the next one, so there it reports the failure and returns.
+ */
+class InvokeDeferredClosure extends CallQueuedClosure
+{
+    /**
+     * Execute the job.
+     */
+    public function handle(Container $container): void
+    {
+        try {
+            parent::handle($container);
+        } catch (Throwable $e) {
+            if ($this->job instanceof SyncJob) {
+                report($e);
+
+                return;
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Illuminate/Concurrency/InvokeQueuedClosure.php
+++ b/src/Illuminate/Concurrency/InvokeQueuedClosure.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
+use Laravel\SerializableClosure\SerializableClosure;
+use ReflectionFunction;
+use RuntimeException;
+use Throwable;
+
+class InvokeQueuedClosure implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
+     * Indicates if the job should fail when its timeout is exceeded.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
+
+    /**
+     * The number of seconds the job may run before timing out.
+     *
+     * @var int|null
+     */
+    public $timeout;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public string $runId,
+        public string $resultKey,
+        public string $cancellationKey,
+        public ?string $store,
+        public int $ttl,
+        public int $deadline,
+        public bool $rethrowFailures,
+        public SerializableClosure $task,
+    ) {
+        $this->afterCommit = false;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(ContainerContract $container, CacheFactory $cache): void
+    {
+        $repository = $cache->store($this->store);
+
+        if ($repository->get($this->cancellationKey) ||
+            Carbon::now()->getTimestamp() > $this->deadline) {
+            return;
+        }
+
+        $failure = null;
+
+        try {
+            $result = TaskResult::success($container->call($this->task->getClosure()));
+        } catch (Throwable $failure) {
+            if (! $this->rethrowFailures) {
+                report($failure);
+            }
+
+            $result = TaskResult::failure($failure);
+        }
+
+        $this->storeResult($repository, $result);
+
+        if ($failure && $this->rethrowFailures) {
+            throw new CapturedTaskException($failure);
+        }
+    }
+
+    /**
+     * Handle a failure of the queued task itself.
+     */
+    public function failed(?Throwable $e): void
+    {
+        if ($e instanceof CapturedTaskException) {
+            return;
+        }
+
+        $this->storeResult(
+            Container::getInstance()->make(CacheFactory::class)->store($this->store),
+            TaskResult::failure($e ?? new RuntimeException('The concurrency task failed without an exception.')),
+        );
+    }
+
+    /**
+     * Store the given result envelope, discarding exception parameters that cannot be serialized.
+     */
+    protected function storeResult($repository, array $result): void
+    {
+        try {
+            $repository->add($this->resultKey, $result, $this->ttl);
+        } catch (Throwable) {
+            $repository->add($this->resultKey, array_merge($result, ['parameters' => []]), $this->ttl);
+        }
+    }
+
+    /**
+     * Get the display name for the queued job.
+     *
+     * @return string
+     */
+    public function displayName()
+    {
+        $reflection = new ReflectionFunction($this->task->getClosure());
+
+        return 'Concurrency task ('.basename($reflection->getFileName()).':'.$reflection->getStartLine().')';
+    }
+}

--- a/src/Illuminate/Concurrency/InvokeQueuedClosure.php
+++ b/src/Illuminate/Concurrency/InvokeQueuedClosure.php
@@ -40,7 +40,6 @@ class InvokeQueuedClosure implements ShouldQueue
     public $timeout;
 
     public function __construct(
-        public string $runId,
         public string $resultKey,
         public string $cancellationKey,
         public ?string $store,

--- a/src/Illuminate/Concurrency/InvokeQueuedClosure.php
+++ b/src/Illuminate/Concurrency/InvokeQueuedClosure.php
@@ -39,9 +39,6 @@ class InvokeQueuedClosure implements ShouldQueue
      */
     public $timeout;
 
-    /**
-     * Create a new job instance.
-     */
     public function __construct(
         public string $runId,
         public string $resultKey,

--- a/src/Illuminate/Concurrency/InvokeQueuedClosure.php
+++ b/src/Illuminate/Concurrency/InvokeQueuedClosure.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Carbon;
 use Laravel\SerializableClosure\SerializableClosure;
 use ReflectionFunction;
@@ -58,17 +59,26 @@ class InvokeQueuedClosure implements ShouldQueue
     {
         $repository = $cache->store($this->store);
 
+        // An envelope that already exists means this task has run: the job
+        // was redelivered, or a failover queue pushed it onto a second link.
         if ($repository->get($this->cancellationKey) ||
-            Carbon::now()->getTimestamp() > $this->deadline) {
+            Carbon::now()->getTimestamp() > $this->deadline ||
+            $repository->has($this->resultKey)) {
             return;
         }
+
+        // A job that finds itself on a synchronous link has no worker to
+        // record a failure for. Rethrowing there would only make a failover
+        // queue read the task's failure as a dead link and run the task again
+        // on the next one, so it reports and returns the way plain sync does.
+        $rethrow = $this->rethrowFailures && ! ($this->job instanceof SyncJob);
 
         $failure = null;
 
         try {
             $result = TaskResult::success($container->call($this->task->getClosure()));
         } catch (Throwable $failure) {
-            if (! $this->rethrowFailures) {
+            if (! $rethrow) {
                 report($failure);
             }
 
@@ -77,7 +87,7 @@ class InvokeQueuedClosure implements ShouldQueue
 
         $this->storeResult($repository, $result);
 
-        if ($failure && $this->rethrowFailures) {
+        if ($failure && $rethrow) {
             throw new CapturedTaskException($failure);
         }
     }

--- a/src/Illuminate/Concurrency/InvokeQueuedClosure.php
+++ b/src/Illuminate/Concurrency/InvokeQueuedClosure.php
@@ -59,18 +59,17 @@ class InvokeQueuedClosure implements ShouldQueue
     {
         $repository = $cache->store($this->store);
 
-        // An envelope that already exists means this task has run: the job
-        // was redelivered, or a failover queue pushed it onto a second link.
+        // Skip the task if the run was cancelled, its deadline has passed, or
+        // its result has already been stored by an earlier run of this job.
         if ($repository->get($this->cancellationKey) ||
             Carbon::now()->getTimestamp() > $this->deadline ||
             $repository->has($this->resultKey)) {
             return;
         }
 
-        // A job that finds itself on a synchronous link has no worker to
-        // record a failure for. Rethrowing there would only make a failover
-        // queue read the task's failure as a dead link and run the task again
-        // on the next one, so it reports and returns the way plain sync does.
+        // On a sync connection there is no worker to record a failure, and
+        // rethrowing would make a failover connection treat it as down and run
+        // the task again, so the failure is reported instead of rethrown.
         $rethrow = $this->rethrowFailures && ! ($this->job instanceof SyncJob);
 
         $failure = null;

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -59,17 +59,7 @@ class ProcessDriver implements Driver
                 $output = substr($output, 0, $pos);
             }
 
-            $result = json_decode($output, true);
-
-            if (! $result['successful']) {
-                throw new $result['exception'](
-                    ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
-                        ? $result['parameters']
-                        : [$result['message']])
-                );
-            }
-
-            return [$key => unserialize($result['result'])];
+            return [$key => TaskResult::unwrap(json_decode($output, true))];
         })->all();
     }
 

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -60,11 +60,41 @@ class QueueDriver implements Driver
         $ttl = max((int) ($this->options['ttl'] ?? 0), $timeout + 60);
 
         $startedAt = Carbon::now();
-        $deadline = $startedAt->getTimestamp() + $timeout;
-
         $runId = (string) Str::ulid();
         $cancellationKey = $this->cancellationKey($runId);
         $repository = $this->cache->store($store);
+
+        [$keys, $inlineEnvelopes] = $this->dispatchTasks(
+            $repository, $tasks, $runId, $cancellationKey, $connection, $store, $inline, $timeout, $ttl, $startedAt,
+        );
+
+        $envelopes = $inline
+            ? $this->ensureInlineEnvelopes($repository, $keys, $inlineEnvelopes)
+            : $this->wait(
+                $repository, $keys, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
+            );
+
+        return $this->resolveResults($repository, $tasks, $keys, $cancellationKey, $envelopes);
+    }
+
+    /**
+     * Dispatch one queued job per task, collecting inline results as they run.
+     *
+     * @throws \Throwable
+     */
+    protected function dispatchTasks(
+        CacheRepository $repository,
+        array $tasks,
+        string $runId,
+        string $cancellationKey,
+        ?string $connection,
+        ?string $store,
+        bool $inline,
+        int $timeout,
+        int $ttl,
+        Carbon $startedAt,
+    ): array {
+        $deadline = $startedAt->getTimestamp() + $timeout;
 
         $keys = [];
         $inlineEnvelopes = [];
@@ -109,12 +139,21 @@ class QueueDriver implements Driver
             throw $e;
         }
 
-        $envelopes = $inline
-            ? $this->ensureInlineEnvelopes($repository, $keys, $inlineEnvelopes)
-            : $this->wait(
-                $repository, $keys, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
-            );
+        return [$keys, $inlineEnvelopes];
+    }
 
+    /**
+     * Unwrap the collected envelopes in their original task order, then clean up.
+     *
+     * @throws \Throwable
+     */
+    protected function resolveResults(
+        CacheRepository $repository,
+        array $tasks,
+        array $keys,
+        string $cancellationKey,
+        array $envelopes,
+    ): array {
         try {
             $results = [];
 

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -69,7 +69,9 @@ class QueueDriver implements Driver
         );
 
         $envelopes = $inline
-            ? $this->ensureInlineEnvelopes($repository, $keys, $inlineEnvelopes)
+            ? $this->ensureInlineEnvelopes(
+                $repository, $keys, $inlineEnvelopes, $startedAt, $timeout, $connection, $store,
+            )
             : $this->wait(
                 $repository, $keys, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
             );
@@ -233,24 +235,38 @@ class QueueDriver implements Driver
     /**
      * Ensure every inline task reported a result envelope during dispatch.
      *
+     * @throws \Illuminate\Concurrency\TaskTimedOutException
      * @throws \RuntimeException
      */
-    protected function ensureInlineEnvelopes(CacheRepository $repository, array $keys, array $envelopes): array
-    {
-        if (in_array(null, $envelopes, true)) {
-            $missing = count(array_keys($envelopes, null, true));
+    protected function ensureInlineEnvelopes(
+        CacheRepository $repository,
+        array $keys,
+        array $envelopes,
+        Carbon $startedAt,
+        int $timeout,
+        ?string $connection,
+        ?string $store,
+    ): array {
+        if (! in_array(null, $envelopes, true)) {
+            return $envelopes;
+        }
 
-            $repository->deleteMultiple(array_values($keys));
+        $missing = count(array_keys($envelopes, null, true));
 
-            throw new RuntimeException(
-                sprintf(
-                    '[%d] of [%d] concurrency tasks did not report a result. Ensure the queue connection and cache store are configured correctly.',
-                    $missing, count($keys),
-                )
+        $repository->deleteMultiple(array_values($keys));
+
+        if (Carbon::now()->getTimestamp() > $startedAt->getTimestamp() + $timeout) {
+            throw new TaskTimedOutException(
+                count($keys) - $missing, count($keys), $timeout, $connection, $this->queue(), $store,
             );
         }
 
-        return $envelopes;
+        throw new RuntimeException(
+            sprintf(
+                '[%d] of [%d] concurrency tasks did not report a result. Ensure the queue connection and cache store are configured correctly.',
+                $missing, count($keys),
+            )
+        );
     }
 
     /**

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -104,7 +104,6 @@ class QueueDriver implements Driver
                 $keys[$index] = $this->resultKey($runId, $index);
 
                 $job = new InvokeQueuedClosure(
-                    $runId,
                     $keys[$index],
                     $cancellationKey,
                     $store,

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use Carbon\CarbonInterval;
+use Closure;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Concurrency\Driver;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Defer\DeferredCallback;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
+use RuntimeException;
+use Throwable;
+
+use function Illuminate\Support\defer;
+use function Illuminate\Support\enum_value;
+
+class QueueDriver implements Driver
+{
+    /**
+     * Create a new queue based concurrency driver.
+     */
+    public function __construct(
+        protected Dispatcher $bus,
+        protected CacheFactory $cache,
+        protected ConfigRepository $config,
+        protected array $options = [],
+    ) {
+        //
+    }
+
+    /**
+     * Run the given tasks concurrently and return an array containing the results.
+     *
+     * @throws \Throwable
+     */
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
+    {
+        $tasks = Arr::wrap($tasks);
+
+        if ($tasks === []) {
+            return [];
+        }
+
+        $connection = $this->connection();
+        $store = $this->resolveStore();
+        $inline = $this->queueConnectionDriver($connection) === 'sync';
+
+        $this->ensureQueueConnectionIsSupported($connection);
+        $this->ensureStoreIsSupported($store, $inline);
+
+        $timeout = $this->normalizeTimeout($timeout);
+        $ttl = max((int) ($this->options['ttl'] ?? 0), $timeout + 60);
+
+        $startedAt = Carbon::now();
+        $deadline = $startedAt->getTimestamp() + $timeout;
+
+        $runId = (string) Str::ulid();
+        $cancellationKey = $this->cancellationKey($runId);
+        $repository = $this->cache->store($store);
+
+        $keys = [];
+        $inlineEnvelopes = [];
+
+        try {
+            foreach (array_values($tasks) as $index => $task) {
+                $keys[$index] = $this->resultKey($runId, $index);
+
+                $job = new InvokeQueuedClosure(
+                    $runId,
+                    $keys[$index],
+                    $cancellationKey,
+                    $store,
+                    $ttl,
+                    $deadline,
+                    ! $inline,
+                    new SerializableClosure($task),
+                );
+
+                $job->timeout = $timeout;
+
+                $job->onConnection($connection);
+
+                if (! is_null($queue = $this->queue())) {
+                    $job->onQueue($queue);
+                }
+
+                $this->bus->dispatch($job);
+
+                // Inline execution is not bounded by the timeout, so each
+                // envelope is collected right away instead of relying on
+                // its expiry outliving the remaining tasks.
+                if ($inline) {
+                    $inlineEnvelopes[$keys[$index]] = $repository->get($keys[$index]);
+                }
+            }
+        } catch (Throwable $e) {
+            $repository->put($cancellationKey, true, $ttl);
+
+            $repository->deleteMultiple(array_values($keys));
+
+            throw $e;
+        }
+
+        $envelopes = $inline
+            ? $this->ensureInlineEnvelopes($repository, $keys, $inlineEnvelopes)
+            : $this->wait(
+                $repository, $keys, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
+            );
+
+        try {
+            $results = [];
+
+            foreach (array_keys($tasks) as $index => $key) {
+                $results[$key] = TaskResult::unwrap($envelopes[$keys[$index]]);
+            }
+
+            return $results;
+        } finally {
+            $repository->deleteMultiple([...array_values($keys), $cancellationKey]);
+        }
+    }
+
+    /**
+     * Start the given tasks in the background after the current task has finished.
+     */
+    public function defer(Closure|array $tasks): DeferredCallback
+    {
+        $connection = $this->connection();
+
+        $this->ensureQueueConnectionIsSupported($connection);
+
+        return defer(function () use ($tasks, $connection) {
+            foreach (Arr::wrap($tasks) as $task) {
+                $job = CallQueuedClosure::create($task)->onConnection($connection);
+
+                if (! is_null($queue = $this->queue())) {
+                    $job->onQueue($queue);
+                }
+
+                $this->bus->dispatch($job);
+            }
+        });
+    }
+
+    /**
+     * Specify the queue connection that tasks should be dispatched to.
+     *
+     * @param  \UnitEnum|string|null  $connection
+     */
+    public function onConnection($connection): static
+    {
+        $driver = clone $this;
+
+        $driver->options['connection'] = enum_value($connection);
+
+        return $driver;
+    }
+
+    /**
+     * Specify the queue that tasks should be dispatched to.
+     *
+     * @param  \UnitEnum|string|null  $queue
+     */
+    public function onQueue($queue): static
+    {
+        $driver = clone $this;
+
+        $driver->options['queue'] = enum_value($queue);
+
+        return $driver;
+    }
+
+    /**
+     * Specify the cache store that should transport task results.
+     *
+     * @param  \UnitEnum|string|null  $store
+     */
+    public function store($store): static
+    {
+        $driver = clone $this;
+
+        $driver->options['store'] = enum_value($store);
+
+        return $driver;
+    }
+
+    /**
+     * Ensure every inline task reported a result envelope during dispatch.
+     *
+     * @throws \RuntimeException
+     */
+    protected function ensureInlineEnvelopes(CacheRepository $repository, array $keys, array $envelopes): array
+    {
+        if (in_array(null, $envelopes, true)) {
+            $missing = count(array_keys($envelopes, null, true));
+
+            $repository->deleteMultiple(array_values($keys));
+
+            throw new RuntimeException(
+                sprintf(
+                    '[%d] of [%d] concurrency tasks did not report a result. Ensure the queue connection and cache store are configured correctly.',
+                    $missing, count($keys),
+                )
+            );
+        }
+
+        return $envelopes;
+    }
+
+    /**
+     * Wait until every task has written a result envelope or the timeout has elapsed.
+     *
+     * @throws \Illuminate\Concurrency\TaskTimedOutException
+     */
+    protected function wait(
+        CacheRepository $repository,
+        array $keys,
+        string $cancellationKey,
+        Carbon $startedAt,
+        int $timeout,
+        int $ttl,
+        ?string $connection,
+        ?string $store,
+    ): array {
+        $envelopes = $repository->many(array_values($keys));
+
+        if (! in_array(null, $envelopes, true)) {
+            return $envelopes;
+        }
+
+        $starting = ((int) $startedAt->format('Uu')) / 1000;
+
+        $deadline = $starting + $timeout * 1000;
+
+        $poll = max((int) ($this->options['poll'] ?? 100), 1);
+
+        while (true) {
+            $now = ((int) Carbon::now()->format('Uu')) / 1000;
+
+            if ($now >= $deadline) {
+                $repository->put($cancellationKey, true, $ttl);
+
+                $received = count($keys) - count(array_keys($envelopes, null, true));
+
+                $repository->deleteMultiple(array_values($keys));
+
+                throw new TaskTimedOutException(
+                    $received, count($keys), $timeout, $connection, $this->queue(), $store,
+                );
+            }
+
+            Sleep::usleep((int) (max(min($poll, $deadline - $now), 1) * 1000));
+
+            foreach ($repository->many(array_keys($envelopes, null, true)) as $key => $envelope) {
+                $envelopes[$key] = $envelope;
+            }
+
+            if (! in_array(null, $envelopes, true)) {
+                return $envelopes;
+            }
+        }
+    }
+
+    /**
+     * Ensure the resolved queue connection is able to process tasks.
+     *
+     * @throws \RuntimeException
+     */
+    protected function ensureQueueConnectionIsSupported(?string $connection): void
+    {
+        if (in_array($this->queueConnectionDriver($connection), ['deferred', 'null', 'background'], true)) {
+            throw new RuntimeException(
+                "The [{$connection}] queue connection may not be used with the queue concurrency driver, as its jobs would never run while waiting for results."
+            );
+        }
+    }
+
+    /**
+     * Ensure the resolved cache store is able to transport task results.
+     *
+     * @throws \RuntimeException
+     */
+    protected function ensureStoreIsSupported(?string $store, bool $inline): void
+    {
+        $cacheDriver = $this->config->get('cache.stores.'.$store.'.driver');
+
+        if (! $inline && in_array($cacheDriver, ['array', 'null', 'session', 'octane', 'apc'], true)) {
+            throw new RuntimeException(
+                "The [{$store}] cache store is not shared across processes and may not transport concurrency results. Configure the queue concurrency driver to use a shared store such as \"redis\", \"memcached\", or \"database\"."
+            );
+        }
+    }
+
+    /**
+     * Get the queue connection name that tasks should be dispatched to.
+     */
+    protected function connection(): ?string
+    {
+        return $this->options['connection'] ?? $this->config->get('queue.default');
+    }
+
+    /**
+     * Get the queue name that tasks should be dispatched to.
+     */
+    protected function queue(): ?string
+    {
+        return $this->options['queue'] ?? null;
+    }
+
+    /**
+     * Get the cache store name that should transport task results.
+     */
+    protected function resolveStore(): ?string
+    {
+        return $this->options['store'] ?? $this->config->get('cache.default');
+    }
+
+    /**
+     * Get the driver of the given queue connection.
+     */
+    protected function queueConnectionDriver(?string $connection): ?string
+    {
+        return $this->config->get('queue.connections.'.$connection.'.driver');
+    }
+
+    /**
+     * Normalize the given timeout into a positive number of seconds.
+     */
+    protected function normalizeTimeout(CarbonInterval|int|null $timeout): int
+    {
+        $timeout ??= $this->options['timeout'] ?? 60;
+
+        if ($timeout instanceof CarbonInterval) {
+            $timeout = (int) $timeout->totalSeconds;
+        }
+
+        return max((int) $timeout, 1);
+    }
+
+    /**
+     * Get the cache key for the given task's result envelope.
+     */
+    protected function resultKey(string $runId, int $index): string
+    {
+        return "illuminate:concurrency:{$runId}:{$index}";
+    }
+
+    /**
+     * Get the cache key for the given run's cancellation flag.
+     */
+    protected function cancellationKey(string $runId): string
+    {
+        return "illuminate:concurrency:{$runId}:cancelled";
+    }
+}

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -49,7 +49,7 @@ class QueueDriver implements Driver
             return [];
         }
 
-        $connection = $this->connection();
+        $connection = $this->resolveConnection();
         $store = $this->resolveStore();
         $inline = $this->queueConnectionDriver($connection) === 'sync';
 
@@ -119,7 +119,7 @@ class QueueDriver implements Driver
 
                 $job->onConnection($connection);
 
-                if (! is_null($queue = $this->queue())) {
+                if (! is_null($queue = $this->resolveQueue())) {
                     $job->onQueue($queue);
                 }
 
@@ -173,7 +173,7 @@ class QueueDriver implements Driver
      */
     public function defer(Closure|array $tasks): DeferredCallback
     {
-        $connection = $this->connection();
+        $connection = $this->resolveConnection();
 
         $this->ensureQueueConnectionIsSupported($connection);
 
@@ -181,7 +181,7 @@ class QueueDriver implements Driver
             foreach (Arr::wrap($tasks) as $task) {
                 $job = CallQueuedClosure::create($task)->onConnection($connection);
 
-                if (! is_null($queue = $this->queue())) {
+                if (! is_null($queue = $this->resolveQueue())) {
                     $job->onQueue($queue);
                 }
 
@@ -257,7 +257,7 @@ class QueueDriver implements Driver
 
         if (Carbon::now()->getTimestamp() > $startedAt->getTimestamp() + $timeout) {
             throw new TaskTimedOutException(
-                count($keys) - $missing, count($keys), $timeout, $connection, $this->queue(), $store,
+                count($keys) - $missing, count($keys), $timeout, $connection, $this->resolveQueue(), $store,
             );
         }
 
@@ -307,7 +307,7 @@ class QueueDriver implements Driver
                 $repository->deleteMultiple(array_values($keys));
 
                 throw new TaskTimedOutException(
-                    $received, count($keys), $timeout, $connection, $this->queue(), $store,
+                    $received, count($keys), $timeout, $connection, $this->resolveQueue(), $store,
                 );
             }
 
@@ -356,7 +356,7 @@ class QueueDriver implements Driver
     /**
      * Get the queue connection name that tasks should be dispatched to.
      */
-    protected function connection(): ?string
+    protected function resolveConnection(): ?string
     {
         return $this->options['connection'] ?? $this->config->get('queue.default');
     }
@@ -364,7 +364,7 @@ class QueueDriver implements Driver
     /**
      * Get the queue name that tasks should be dispatched to.
      */
-    protected function queue(): ?string
+    protected function resolveQueue(): ?string
     {
         return $this->options['queue'] ?? null;
     }

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Concurrency\Driver;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Defer\DeferredCallback;
@@ -51,9 +50,11 @@ class QueueDriver implements Driver
 
         $connection = $this->resolveConnection();
         $store = $this->resolveStore();
-        $inline = $this->queueConnectionDriver($connection) === 'sync';
 
         $this->ensureQueueConnectionIsSupported($connection);
+
+        $inline = $this->resolvesInline($connection);
+
         $this->ensureStoreIsSupported($store, $inline);
 
         $timeout = $this->normalizeTimeout($timeout);
@@ -64,19 +65,19 @@ class QueueDriver implements Driver
         $cancellationKey = $this->cancellationKey($runId);
         $repository = $this->cache->store($store);
 
-        [$keys, $inlineEnvelopes] = $this->dispatchTasks(
+        [$keys, $collected] = $this->dispatchTasks(
             $repository, $tasks, $runId, $cancellationKey, $connection, $store, $inline, $timeout, $ttl, $startedAt,
         );
 
         $envelopes = $inline
             ? $this->ensureInlineEnvelopes(
-                $repository, $keys, $inlineEnvelopes, $startedAt, $timeout, $connection, $store,
+                $repository, $keys, $collected, $startedAt, $timeout, $connection, $store,
             )
             : $this->wait(
-                $repository, $keys, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
+                $repository, $keys, $collected, $cancellationKey, $startedAt, $timeout, $ttl, $connection, $store,
             );
 
-        return $this->resolveResults($repository, $tasks, $keys, $cancellationKey, $envelopes);
+        return $this->resolveResults($repository, $tasks, $keys, $cancellationKey, $envelopes, $ttl);
     }
 
     /**
@@ -99,7 +100,7 @@ class QueueDriver implements Driver
         $deadline = $startedAt->getTimestamp() + $timeout;
 
         $keys = [];
-        $inlineEnvelopes = [];
+        $collected = [];
 
         try {
             foreach (array_values($tasks) as $index => $task) {
@@ -125,12 +126,11 @@ class QueueDriver implements Driver
 
                 $this->bus->dispatch($job);
 
-                // Inline execution is not bounded by the timeout, so each
-                // envelope is collected right away instead of relying on
-                // its expiry outliving the remaining tasks.
-                if ($inline) {
-                    $inlineEnvelopes[$keys[$index]] = $repository->get($keys[$index]);
-                }
+                // Whatever ran during dispatch, inline or a failover chain that
+                // fell through to a synchronous link, is not bounded by the
+                // timeout, so its envelope is collected right away rather than
+                // relying on its expiry outliving the remaining tasks.
+                $collected[$keys[$index]] = $repository->get($keys[$index]);
             }
         } catch (Throwable $e) {
             $repository->put($cancellationKey, true, $ttl);
@@ -140,7 +140,7 @@ class QueueDriver implements Driver
             throw $e;
         }
 
-        return [$keys, $inlineEnvelopes];
+        return [$keys, $collected];
     }
 
     /**
@@ -154,6 +154,7 @@ class QueueDriver implements Driver
         array $keys,
         string $cancellationKey,
         array $envelopes,
+        int $ttl,
     ): array {
         try {
             $results = [];
@@ -164,7 +165,12 @@ class QueueDriver implements Driver
 
             return $results;
         } finally {
-            $repository->deleteMultiple([...array_values($keys), $cancellationKey]);
+            // The cancellation flag stays behind as a tombstone, written before
+            // the envelopes go, so a job redelivered after the caller has been
+            // answered always finds one or the other and refuses to run.
+            $repository->put($cancellationKey, true, $ttl);
+
+            $repository->deleteMultiple(array_values($keys));
         }
     }
 
@@ -179,7 +185,7 @@ class QueueDriver implements Driver
 
         return defer(function () use ($tasks, $connection) {
             foreach (Arr::wrap($tasks) as $task) {
-                $job = CallQueuedClosure::create($task)->onConnection($connection);
+                $job = (new InvokeDeferredClosure(new SerializableClosure($task)))->onConnection($connection);
 
                 if (! is_null($queue = $this->resolveQueue())) {
                     $job->onQueue($queue);
@@ -277,6 +283,7 @@ class QueueDriver implements Driver
     protected function wait(
         CacheRepository $repository,
         array $keys,
+        array $collected,
         string $cancellationKey,
         Carbon $startedAt,
         int $timeout,
@@ -285,6 +292,14 @@ class QueueDriver implements Driver
         ?string $store,
     ): array {
         $envelopes = $repository->many(array_values($keys));
+
+        // An envelope read back at dispatch time wins over a later miss: the
+        // task ran synchronously and its envelope may since have expired.
+        foreach ($collected as $key => $envelope) {
+            if (! is_null($envelope) && is_null($envelopes[$key] ?? null)) {
+                $envelopes[$key] = $envelope;
+            }
+        }
 
         if (! in_array(null, $envelopes, true)) {
             return $envelopes;
@@ -328,13 +343,74 @@ class QueueDriver implements Driver
      *
      * @throws \RuntimeException
      */
-    protected function ensureQueueConnectionIsSupported(?string $connection): void
+    protected function ensureQueueConnectionIsSupported(?string $connection, array $seen = []): void
     {
-        if (in_array($this->queueConnectionDriver($connection), ['deferred', 'null', 'background'], true)) {
+        if (in_array($connection, $seen, true)) {
+            throw new RuntimeException(
+                "The [{$connection}] failover queue connection refers back to itself, so its jobs could never be dispatched."
+            );
+        }
+
+        $driver = $this->queueConnectionDriver($connection);
+
+        if (in_array($driver, ['deferred', 'null', 'background'], true)) {
             throw new RuntimeException(
                 "The [{$connection}] queue connection may not be used with the queue concurrency driver, as its jobs would never run while waiting for results."
             );
         }
+
+        // A failover chain is only as usable as its weakest link, and a chain
+        // with no links at all would only fail later, inside the dispatch.
+        if ($driver === 'failover') {
+            $links = $this->failoverLinks($connection);
+
+            if ($links === []) {
+                throw new RuntimeException(
+                    "The [{$connection}] failover queue connection has no connections to fall through, so its jobs could never be dispatched."
+                );
+            }
+
+            foreach ($links as $link) {
+                $this->ensureQueueConnectionIsSupported($link, [...$seen, $connection]);
+            }
+        }
+    }
+
+    /**
+     * Determine whether tasks dispatched to the given connection run inside the dispatch call.
+     *
+     * A failover chain runs inline only if every link does; a chain that can
+     * reach a real queue needs the asynchronous path and a shared store.
+     */
+    protected function resolvesInline(?string $connection, array $seen = []): bool
+    {
+        $driver = $this->queueConnectionDriver($connection);
+
+        if ($driver !== 'failover') {
+            return $driver === 'sync';
+        }
+
+        $links = $this->failoverLinks($connection);
+
+        if ($links === [] || in_array($connection, $seen, true)) {
+            return false;
+        }
+
+        foreach ($links as $link) {
+            if (! $this->resolvesInline($link, [...$seen, $connection])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the connections a failover queue connection falls through.
+     */
+    protected function failoverLinks(?string $connection): array
+    {
+        return array_values((array) $this->config->get('queue.connections.'.$connection.'.connections', []));
     }
 
     /**
@@ -342,9 +418,25 @@ class QueueDriver implements Driver
      *
      * @throws \RuntimeException
      */
-    protected function ensureStoreIsSupported(?string $store, bool $inline): void
+    protected function ensureStoreIsSupported(?string $store, bool $inline, array $seen = []): void
     {
         $cacheDriver = $this->config->get('cache.stores.'.$store.'.driver');
+
+        // A failover store is only as shared as the store it may fall back to,
+        // and one that falls back to itself would recurse on the first read.
+        if ($cacheDriver === 'failover') {
+            foreach ((array) $this->config->get('cache.stores.'.$store.'.stores', []) as $fallback) {
+                if (in_array($fallback, [...$seen, $store], true)) {
+                    throw new RuntimeException(
+                        "The [{$fallback}] failover cache store refers back to itself, so results could never be read."
+                    );
+                }
+
+                $this->ensureStoreIsSupported($fallback, $inline, [...$seen, $store]);
+            }
+
+            return;
+        }
 
         if (! $inline && in_array($cacheDriver, ['array', 'null', 'session', 'octane', 'apc'], true)) {
             throw new RuntimeException(

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -126,10 +126,9 @@ class QueueDriver implements Driver
 
                 $this->bus->dispatch($job);
 
-                // Whatever ran during dispatch, inline or a failover chain that
-                // fell through to a synchronous link, is not bounded by the
-                // timeout, so its envelope is collected right away rather than
-                // relying on its expiry outliving the remaining tasks.
+                // Collect any result written while the job was dispatched,
+                // since a sync connection runs the job right away and its
+                // result is not bound by the timeout.
                 $collected[$keys[$index]] = $repository->get($keys[$index]);
             }
         } catch (Throwable $e) {
@@ -165,9 +164,8 @@ class QueueDriver implements Driver
 
             return $results;
         } finally {
-            // The cancellation flag stays behind as a tombstone, written before
-            // the envelopes go, so a job redelivered after the caller has been
-            // answered always finds one or the other and refuses to run.
+            // Keep the cancellation flag so a job delivered again after this
+            // run finishes will skip itself instead of running the task.
             $repository->put($cancellationKey, true, $ttl);
 
             $repository->deleteMultiple(array_values($keys));
@@ -362,8 +360,8 @@ class QueueDriver implements Driver
             );
         }
 
-        // A failover chain is only as usable as its weakest link, and a chain
-        // with no links at all would only fail later, inside the dispatch.
+        // A failover connection is only usable if each of its connections is,
+        // and one with no connections would only fail once a job is sent.
         if ($driver === 'failover') {
             $links = $this->failoverLinks($connection);
 
@@ -380,10 +378,9 @@ class QueueDriver implements Driver
     }
 
     /**
-     * Determine whether tasks dispatched to the given connection run inside the dispatch call.
+     * Determine if tasks sent to the given connection run during the dispatch call.
      *
-     * A failover chain runs inline only if every link does; a chain that can
-     * reach a real queue needs the asynchronous path and a shared store.
+     * A failover connection runs inline only when every one of its connections does.
      */
     protected function resolvesInline(?string $connection, array $seen = []): bool
     {
@@ -425,8 +422,8 @@ class QueueDriver implements Driver
     {
         $cacheDriver = $this->config->get('cache.stores.'.$store.'.driver');
 
-        // A failover store is only as shared as the store it may fall back to,
-        // and one that falls back to itself would recurse on the first read.
+        // A failover store is only as shared as the stores it falls back to,
+        // and one that falls back to itself would loop on the first read.
         if ($cacheDriver === 'failover') {
             foreach ((array) $this->config->get('cache.stores.'.$store.'.stores', []) as $fallback) {
                 if (in_array($fallback, [...$seen, $store], true)) {

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -185,7 +185,7 @@ class QueueDriver implements Driver
 
         return defer(function () use ($tasks, $connection) {
             foreach (Arr::wrap($tasks) as $task) {
-                $job = (new InvokeDeferredClosure(new SerializableClosure($task)))->onConnection($connection);
+                $job = InvokeDeferredClosure::create($task)->onConnection($connection);
 
                 if (! is_null($queue = $this->resolveQueue())) {
                     $job->onQueue($queue);

--- a/src/Illuminate/Concurrency/QueueDriver.php
+++ b/src/Illuminate/Concurrency/QueueDriver.php
@@ -291,7 +291,10 @@ class QueueDriver implements Driver
         ?string $connection,
         ?string $store,
     ): array {
-        $envelopes = $repository->many(array_values($keys));
+        // getMultiple() rather than many(): the former is on the cache contract
+        // this method is typed against, the latter only on Laravel's concrete
+        // repository. PSR-16 promises an iterable, so it is materialised once.
+        $envelopes = iterator_to_array($repository->getMultiple(array_values($keys)));
 
         // An envelope read back at dispatch time wins over a later miss: the
         // task ran synchronously and its envelope may since have expired.
@@ -328,7 +331,7 @@ class QueueDriver implements Driver
 
             Sleep::usleep((int) (max(min($poll, $deadline - $now), 1) * 1000));
 
-            foreach ($repository->many(array_keys($envelopes, null, true)) as $key => $envelope) {
+            foreach ($repository->getMultiple(array_keys($envelopes, null, true)) as $key => $envelope) {
                 $envelopes[$key] = $envelope;
             }
 

--- a/src/Illuminate/Concurrency/TaskResult.php
+++ b/src/Illuminate/Concurrency/TaskResult.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use ReflectionClass;
+use RuntimeException;
+use Throwable;
+
+class TaskResult
+{
+    /**
+     * Create a result envelope for a task that completed successfully.
+     */
+    public static function success(mixed $value): array
+    {
+        return [
+            'version' => 1,
+            'successful' => true,
+            'result' => serialize($value),
+        ];
+    }
+
+    /**
+     * Create a result envelope for a task that threw the given exception.
+     */
+    public static function failure(Throwable $e): array
+    {
+        $reflection = new ReflectionClass($e);
+        $constructor = $reflection->getConstructor();
+        $parameters = [];
+
+        if ($constructor && $constructor->getDeclaringClass()->getName() === $reflection->getName()) {
+            foreach ($constructor->getParameters() as $parameter) {
+                $parameters[$parameter->name] = $e->{$parameter->name} ?? null;
+            }
+        }
+
+        return [
+            'version' => 1,
+            'successful' => false,
+            'exception' => get_class($e),
+            'message' => $e->getMessage(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+            'parameters' => $parameters,
+        ];
+    }
+
+    /**
+     * Unwrap the given result envelope, returning the task's value or throwing its exception.
+     *
+     * @throws \Throwable
+     */
+    public static function unwrap(array $result): mixed
+    {
+        if (! $result['successful']) {
+            throw static::toException($result);
+        }
+
+        return unserialize($result['result']);
+    }
+
+    /**
+     * Reconstruct the failed envelope's exception, degrading gracefully when its constructor cannot be satisfied.
+     */
+    protected static function toException(array $result): Throwable
+    {
+        $parameters = $result['parameters'] ?? [];
+
+        try {
+            return new $result['exception'](
+                ...(! empty(array_filter($parameters, fn ($parameter) => ! is_null($parameter)))
+                    ? $parameters
+                    : [$result['message']])
+            );
+        } catch (Throwable) {
+            //
+        }
+
+        try {
+            return new $result['exception']($result['message']);
+        } catch (Throwable) {
+            return new RuntimeException($result['exception'].': '.$result['message']);
+        }
+    }
+}

--- a/src/Illuminate/Concurrency/TaskResult.php
+++ b/src/Illuminate/Concurrency/TaskResult.php
@@ -14,7 +14,6 @@ class TaskResult
     public static function success(mixed $value): array
     {
         return [
-            'version' => 1,
             'successful' => true,
             'result' => serialize($value),
         ];
@@ -36,7 +35,6 @@ class TaskResult
         }
 
         return [
-            'version' => 1,
             'successful' => false,
             'exception' => get_class($e),
             'message' => $e->getMessage(),

--- a/src/Illuminate/Concurrency/TaskTimedOutException.php
+++ b/src/Illuminate/Concurrency/TaskTimedOutException.php
@@ -15,7 +15,7 @@ class TaskTimedOutException extends RuntimeException
         public ?string $store = null,
     ) {
         parent::__construct(sprintf(
-            'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d seconds with [%d/%d] results received. Ensure queue workers are running and share the [%s] cache store with this process.',
+            'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d seconds with [%d/%d] results received. Ensure queue workers are running and writing results to the [%s] cache store.',
             $connection,
             is_null($queue) ? '' : sprintf(' on the [%s] queue', $queue),
             $seconds,

--- a/src/Illuminate/Concurrency/TaskTimedOutException.php
+++ b/src/Illuminate/Concurrency/TaskTimedOutException.php
@@ -15,11 +15,10 @@ class TaskTimedOutException extends RuntimeException
         public ?string $store = null,
     ) {
         parent::__construct(sprintf(
-            'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d %s with [%d/%d] results received. Ensure queue workers are running and share the [%s] cache store with this process.',
+            'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d seconds with [%d/%d] results received. Ensure queue workers are running and share the [%s] cache store with this process.',
             $connection,
             is_null($queue) ? '' : sprintf(' on the [%s] queue', $queue),
             $seconds,
-            $seconds === 1 ? 'second' : 'seconds',
             $received,
             $total,
             $store,

--- a/src/Illuminate/Concurrency/TaskTimedOutException.php
+++ b/src/Illuminate/Concurrency/TaskTimedOutException.php
@@ -16,13 +16,13 @@ class TaskTimedOutException extends RuntimeException
     ) {
         parent::__construct(sprintf(
             'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d %s with [%d/%d] results received. Ensure queue workers are running and share the [%s] cache store with this process.',
-            $connection ?? 'default',
+            $connection,
             is_null($queue) ? '' : sprintf(' on the [%s] queue', $queue),
             $seconds,
             $seconds === 1 ? 'second' : 'seconds',
             $received,
             $total,
-            $store ?? 'default',
+            $store,
         ));
     }
 }

--- a/src/Illuminate/Concurrency/TaskTimedOutException.php
+++ b/src/Illuminate/Concurrency/TaskTimedOutException.php
@@ -6,9 +6,6 @@ use RuntimeException;
 
 class TaskTimedOutException extends RuntimeException
 {
-    /**
-     * Create a new task timeout exception instance.
-     */
     public function __construct(
         public int $received,
         public int $total,

--- a/src/Illuminate/Concurrency/TaskTimedOutException.php
+++ b/src/Illuminate/Concurrency/TaskTimedOutException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Concurrency;
+
+use RuntimeException;
+
+class TaskTimedOutException extends RuntimeException
+{
+    /**
+     * Create a new task timeout exception instance.
+     */
+    public function __construct(
+        public int $received,
+        public int $total,
+        public int $seconds,
+        public ?string $connection = null,
+        public ?string $queue = null,
+        public ?string $store = null,
+    ) {
+        parent::__construct(sprintf(
+            'Concurrency tasks dispatched to the [%s] queue connection%s timed out after %d %s with [%d/%d] results received. Ensure queue workers are running and share the [%s] cache store with this process.',
+            $connection ?? 'default',
+            is_null($queue) ? '' : sprintf(' on the [%s] queue', $queue),
+            $seconds,
+            $seconds === 1 ? 'second' : 'seconds',
+            $received,
+            $total,
+            $store ?? 'default',
+        ));
+    }
+}

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -22,6 +22,9 @@
         "laravel/serializable-closure": "^2.0.10"
     },
     "suggest": {
+        "illuminate/bus": "Required to use the 'queue' concurrency driver (^13.0).",
+        "illuminate/cache": "Required to use the 'queue' concurrency driver (^13.0).",
+        "illuminate/queue": "Required to use the 'queue' concurrency driver (^13.0).",
         "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2)."
     },
     "minimum-stability": "dev",

--- a/src/Illuminate/Support/Facades/Concurrency.php
+++ b/src/Illuminate/Support/Facades/Concurrency.php
@@ -6,9 +6,10 @@ use Illuminate\Concurrency\ConcurrencyManager;
 
 /**
  * @method static mixed driver(\UnitEnum|string|null $name = null)
- * @method static \Illuminate\Concurrency\ProcessDriver createProcessDriver()
- * @method static \Illuminate\Concurrency\ForkDriver createForkDriver()
- * @method static \Illuminate\Concurrency\SyncDriver createSyncDriver()
+ * @method static \Illuminate\Concurrency\ProcessDriver createProcessDriver(array $config = [])
+ * @method static \Illuminate\Concurrency\ForkDriver createForkDriver(array $config = [])
+ * @method static \Illuminate\Concurrency\SyncDriver createSyncDriver(array $config = [])
+ * @method static \Illuminate\Concurrency\QueueDriver createQueueDriver(array $config = [])
  * @method static string getDefaultInstance()
  * @method static void setDefaultInstance(string $name)
  * @method static array getInstanceConfig(string $name)

--- a/tests/Concurrency/TaskResultTest.php
+++ b/tests/Concurrency/TaskResultTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Illuminate\Tests\Concurrency;
+
+use Exception;
+use Illuminate\Concurrency\TaskResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class TaskResultTest extends TestCase
+{
+    #[DataProvider('resultValues')]
+    public function testSuccessEnvelopesRoundTripValues(mixed $value)
+    {
+        $envelope = TaskResult::success($value);
+
+        $this->assertSame(1, $envelope['version']);
+        $this->assertTrue($envelope['successful']);
+        $this->assertEquals($value, TaskResult::unwrap($envelope));
+    }
+
+    public static function resultValues(): array
+    {
+        return [
+            'string' => ['value'],
+            'integer' => [42],
+            'zero' => [0],
+            'false' => [false],
+            'null' => [null],
+            'empty string' => [''],
+            'array' => [['a' => 1, 'b' => [2, 3]]],
+            'object' => [(object) ['name' => 'Taylor']],
+        ];
+    }
+
+    public function testFailureEnvelopeCapturesExceptionMetadata()
+    {
+        $envelope = TaskResult::failure(new RuntimeException('Something broke'));
+
+        $this->assertSame(1, $envelope['version']);
+        $this->assertFalse($envelope['successful']);
+        $this->assertSame(RuntimeException::class, $envelope['exception']);
+        $this->assertSame('Something broke', $envelope['message']);
+        $this->assertSame(__FILE__, $envelope['file']);
+        $this->assertIsInt($envelope['line']);
+        $this->assertSame([], $envelope['parameters']);
+    }
+
+    public function testUnwrapRethrowsFailuresUsingTheMessage()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Something broke');
+
+        TaskResult::unwrap(TaskResult::failure(new RuntimeException('Something broke')));
+    }
+
+    public function testUnwrapReconstructsExceptionsWithConstructorParameters()
+    {
+        $envelope = TaskResult::failure(new TaskResultTestExceptionWithParam(
+            'https://api.example.com', 400, 'Bad Request', 'Invalid payload',
+        ));
+
+        try {
+            TaskResult::unwrap($envelope);
+        } catch (TaskResultTestExceptionWithParam $e) {
+            $this->assertSame('https://api.example.com', $e->uri);
+            $this->assertSame(400, $e->statusCode);
+            $this->assertSame('Bad Request', $e->reason);
+            $this->assertSame('Invalid payload', $e->responseBody);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    #[DataProvider('falseyParameters')]
+    public function testUnwrapPreservesFalseyConstructorParameters(int|bool|string $value)
+    {
+        $envelope = TaskResult::failure(new TaskResultTestExceptionWithFalseyParam($value));
+
+        try {
+            TaskResult::unwrap($envelope);
+        } catch (TaskResultTestExceptionWithFalseyParam $e) {
+            $this->assertSame($value, $e->value);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public static function falseyParameters(): array
+    {
+        return [
+            'zero' => [0],
+            'false' => [false],
+            'empty string' => [''],
+        ];
+    }
+
+    public function testUnwrapFallsBackWhenTheConstructorCannotBeSatisfied()
+    {
+        $envelope = TaskResult::failure(new TaskResultTestExceptionWithRequiredThrowable(
+            'Query failed', new RuntimeException('The underlying failure'),
+        ));
+
+        try {
+            TaskResult::unwrap($envelope);
+        } catch (RuntimeException $e) {
+            $this->assertSame(
+                TaskResultTestExceptionWithRequiredThrowable::class.': Query failed',
+                $e->getMessage(),
+            );
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public function testUnwrapFallsBackWhenTheExceptionClassDoesNotExist()
+    {
+        $envelope = TaskResult::failure(new RuntimeException('Original message'));
+
+        $envelope['exception'] = 'App\\Exceptions\\DoesNotExist';
+
+        try {
+            TaskResult::unwrap($envelope);
+        } catch (RuntimeException $e) {
+            $this->assertSame('App\\Exceptions\\DoesNotExist: Original message', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public function testFailureEnvelopeIgnoresInheritedConstructors()
+    {
+        $envelope = TaskResult::failure(new TaskResultTestExceptionWithoutConstructor('Inherited'));
+
+        $this->assertSame([], $envelope['parameters']);
+
+        $this->expectException(TaskResultTestExceptionWithoutConstructor::class);
+        $this->expectExceptionMessage('Inherited');
+
+        TaskResult::unwrap($envelope);
+    }
+}
+
+class TaskResultTestExceptionWithParam extends Exception
+{
+    public function __construct(
+        public string $uri,
+        public int $statusCode,
+        public string $reason,
+        public string|array $responseBody = '',
+    ) {
+        parent::__construct("API request to {$uri} failed with status $statusCode $reason");
+    }
+}
+
+class TaskResultTestExceptionWithFalseyParam extends Exception
+{
+    public function __construct(public int|bool|string $value)
+    {
+        parent::__construct('Exception with falsey parameter');
+    }
+}
+
+class TaskResultTestExceptionWithoutConstructor extends Exception
+{
+}
+
+class TaskResultTestExceptionWithRequiredThrowable extends Exception
+{
+    public function __construct(string $message, \Throwable $previous)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/tests/Concurrency/TaskResultTest.php
+++ b/tests/Concurrency/TaskResultTest.php
@@ -135,6 +135,23 @@ class TaskResultTest extends TestCase
         $this->fail('The expected exception was not thrown.');
     }
 
+    public function testUnwrapToleratesEnvelopesWithoutParameters()
+    {
+        $envelope = TaskResult::failure(new RuntimeException('Original message'));
+
+        unset($envelope['parameters']);
+
+        try {
+            TaskResult::unwrap($envelope);
+        } catch (RuntimeException $e) {
+            $this->assertSame('Original message', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
     public function testFailureEnvelopeIgnoresInheritedConstructors()
     {
         $envelope = TaskResult::failure(new TaskResultTestExceptionWithoutConstructor('Inherited'));

--- a/tests/Concurrency/TaskResultTest.php
+++ b/tests/Concurrency/TaskResultTest.php
@@ -15,7 +15,6 @@ class TaskResultTest extends TestCase
     {
         $envelope = TaskResult::success($value);
 
-        $this->assertSame(1, $envelope['version']);
         $this->assertTrue($envelope['successful']);
         $this->assertEquals($value, TaskResult::unwrap($envelope));
     }
@@ -38,7 +37,6 @@ class TaskResultTest extends TestCase
     {
         $envelope = TaskResult::failure(new RuntimeException('Something broke'));
 
-        $this->assertSame(1, $envelope['version']);
         $this->assertFalse($envelope['successful']);
         $this->assertSame(RuntimeException::class, $envelope['exception']);
         $this->assertSame('Something broke', $envelope['message']);

--- a/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
@@ -1,0 +1,436 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Concurrency;
+
+use DomainException;
+use Illuminate\Concurrency\InvokeDeferredClosure;
+use Illuminate\Concurrency\InvokeQueuedClosure;
+use Illuminate\Concurrency\TaskResult;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\Events\QueueFailedOver;
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionProperty;
+use RuntimeException;
+
+class QueueConcurrencyFailoverTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('cache.default', 'file');
+
+        // A link the failover queue hops off exactly as it would a dead redis,
+        // without needing a redis client: the connector for its driver does
+        // not exist.
+        $app['config']->set('queue.connections.dead', ['driver' => 'no-such-driver']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+
+        Cache::store('file')->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::store('file')->flush();
+
+        parent::tearDown();
+    }
+
+    public function testDeliversTheOriginalExceptionWhenTheChainFallsThroughToSync()
+    {
+        $this->useChain(['dead', 'sync']);
+
+        try {
+            Concurrency::driver('queue')->run([
+                'only' => function () {
+                    Cache::store('file')->increment('runs');
+
+                    throw new DomainException('task failed');
+                },
+            ], timeout: 3);
+        } catch (DomainException $e) {
+            $this->assertSame('task failed', $e->getMessage());
+            $this->assertSame(1, $this->runsSoFar());
+
+            return;
+        }
+
+        $this->fail('The original exception was not delivered.');
+    }
+
+    public function testRunsAFailingTaskOnceEvenWithAnotherSyncLinkAfterIt()
+    {
+        $this->useChain(['dead', 'sync', 'sync']);
+
+        $hops = [];
+
+        Event::listen(QueueFailedOver::class, function (QueueFailedOver $event) use (&$hops) {
+            $hops[] = $event->connectionName;
+        });
+
+        try {
+            Concurrency::driver('queue')->run([
+                'only' => function () {
+                    Cache::store('file')->increment('runs');
+
+                    throw new DomainException('task failed');
+                },
+            ], timeout: 3);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (DomainException) {
+            //
+        }
+
+        // The task's failure must not read as a dead link: the only hop is off "dead".
+        $this->assertSame(1, $this->runsSoFar());
+        $this->assertSame(['dead'], $hops);
+    }
+
+    public function testLeavesNoDuplicateOnARealQueueAfterASyncLinkRanTheTask()
+    {
+        $this->useChain(['dead', 'sync', 'database']);
+
+        try {
+            Concurrency::driver('queue')->run([
+                'only' => function () {
+                    Cache::store('file')->increment('runs');
+
+                    throw new DomainException('task failed');
+                },
+            ], timeout: 3);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (DomainException) {
+            //
+        }
+
+        $this->assertSame(1, $this->runsSoFar());
+        $this->assertSame(0, DB::table('jobs')->count());
+    }
+
+    public function testDoesNotLetADeadLinkAfterSyncMaskTheTaskException()
+    {
+        $this->useChain(['dead', 'sync', 'dead']);
+
+        $this->expectException(DomainException::class);
+
+        Concurrency::driver('queue')->run([
+            'only' => fn () => throw new DomainException('task failed'),
+        ], timeout: 3);
+    }
+
+    public function testReturnsResultsWhenTheChainFallsThroughToSync()
+    {
+        $this->useChain(['dead', 'sync']);
+
+        $this->assertSame(['a' => 2, 'b' => 'two'], Concurrency::driver('queue')->run([
+            'a' => fn () => 1 + 1,
+            'b' => fn () => 'two',
+        ], timeout: 3));
+    }
+
+    public function testReportsASyncFallThroughFailureTheWayPlainSyncDoes()
+    {
+        $this->useChain(['dead', 'sync']);
+
+        Exceptions::fake();
+
+        try {
+            Concurrency::driver('queue')->run([
+                'only' => fn () => throw new DomainException('task failed'),
+            ], timeout: 3);
+        } catch (DomainException) {
+            //
+        }
+
+        Exceptions::assertReported(DomainException::class);
+    }
+
+    public function testKeepsAnEnvelopeALaterFallThroughTaskOutlived()
+    {
+        // Work that ran during dispatch is not bounded by the timeout, so a
+        // slow later task can outlive an earlier envelope's TTL. The envelope
+        // read back right after dispatch is what survives that.
+        $this->useChain(['dead', 'sync']);
+
+        try {
+            $results = Concurrency::driver('queue')->run([
+                'first' => fn () => 'kept',
+                'second' => function () {
+                    Carbon::setTestNow(Carbon::now()->addSeconds(120));
+
+                    return 'slow';
+                },
+            ], timeout: 3);
+        } finally {
+            Carbon::setTestNow();
+        }
+
+        $this->assertSame(['first' => 'kept', 'second' => 'slow'], $results);
+    }
+
+    public function testTreatsAChainMadeOnlyOfSyncLinksAsInline()
+    {
+        $this->useChain(['sync']);
+        config()->set('cache.default', 'array');
+
+        $this->assertSame([7], Concurrency::driver('queue')->run([fn () => 7]));
+    }
+
+    #[DataProvider('connectionsThatNeverRunTasks')]
+    public function testRefusesAChainContainingAConnectionThatWouldNeverRunTheTasks(string $driver)
+    {
+        config()->set('queue.connections.never', ['driver' => $driver]);
+        $this->useChain(['dead', 'never']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not be used with the queue concurrency driver');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public static function connectionsThatNeverRunTasks(): array
+    {
+        return [
+            'null' => ['null'],
+            'deferred' => ['deferred'],
+            'background' => ['background'],
+        ];
+    }
+
+    public function testRefusesACyclicFailoverChain()
+    {
+        config()->set('queue.connections.a', ['driver' => 'failover', 'connections' => ['b']]);
+        config()->set('queue.connections.b', ['driver' => 'failover', 'connections' => ['a']]);
+        config()->set('queue.default', 'a');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('refers back to itself');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testRefusesAFailoverChainWithNoConnections()
+    {
+        $this->useChain([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has no connections');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testRefusesAFailoverChainWithNoConnectionsWhenDeferringBeforeTheCallbackRuns()
+    {
+        $this->useChain([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has no connections');
+
+        Concurrency::driver('queue')->defer([fn () => 1]);
+    }
+
+    public function testRefusesACyclicFailoverCacheStore()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.stores.loop_a', ['driver' => 'failover', 'stores' => ['loop_b']]);
+        config()->set('cache.stores.loop_b', ['driver' => 'failover', 'stores' => ['loop_a']]);
+        config()->set('cache.default', 'loop_a');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('refers back to itself');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testRefusesAFailoverCacheStoreWhoseFallbackIsNotSharedForAnAsyncRun()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.stores.fallback', ['driver' => 'failover', 'stores' => ['file', 'array']]);
+        config()->set('cache.default', 'fallback');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not shared across processes');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testLeavesATombstoneSoAStragglerRefusesToRunAfterTheCallerWasAnswered()
+    {
+        config()->set('queue.default', 'sync');
+        $invoked = false;
+
+        $ulid = Str::freezeUlids(function () {
+            return Concurrency::driver('queue')->run([fn () => 'done']);
+        });
+
+        $this->assertTrue(Cache::store('file')->get("illuminate:concurrency:{$ulid}:cancelled"));
+
+        // The same job, redelivered after the run finished and its envelope
+        // was deleted, with the deadline still in the future.
+        $straggler = new InvokeQueuedClosure(
+            "illuminate:concurrency:{$ulid}:0",
+            "illuminate:concurrency:{$ulid}:cancelled",
+            'file',
+            60,
+            time() + 60,
+            true,
+            new SerializableClosure(function () use (&$invoked) {
+                $invoked = true;
+            }),
+        );
+
+        $straggler->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $this->assertFalse($invoked);
+    }
+
+    public function testSkipsAJobWhoseEnvelopeAlreadyExists()
+    {
+        $invoked = false;
+
+        Cache::store('file')->put('dup:0', TaskResult::success('first'), 60);
+
+        $job = new InvokeQueuedClosure('dup:0', 'dup:cancelled', 'file', 60, time() + 60, true, new SerializableClosure(function () use (&$invoked) {
+            $invoked = true;
+        }));
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $this->assertFalse($invoked);
+        $this->assertSame('first', TaskResult::unwrap(Cache::store('file')->get('dup:0')));
+    }
+
+    public function testRunsAFailingDeferredTaskOnceWhenTheChainFallsThroughToSync()
+    {
+        $this->useChain(['dead', 'sync', 'sync']);
+
+        Exceptions::fake();
+
+        Concurrency::driver('queue')->defer([
+            function () {
+                Cache::store('file')->increment('runs');
+
+                throw new DomainException('deferred failed');
+            },
+        ])();
+
+        $this->assertSame(1, $this->runsSoFar());
+
+        Exceptions::assertReported(DomainException::class);
+    }
+
+    public function testLetsTheWorkerRetryADeferredTaskThatFailsOnce()
+    {
+        $this->prepareFailedJobs();
+        config()->set('queue.default', 'database');
+
+        Concurrency::driver('queue')->defer([
+            function () {
+                if (Cache::store('file')->increment('attempts') === 1) {
+                    throw new RuntimeException('first attempt fails');
+                }
+
+                Cache::store('file')->put('outcome', 'succeeded on retry', 60);
+            },
+        ])();
+
+        // Two attempts allowed by the worker, so the second one completes the task.
+        $this->artisan('queue:work', ['connection' => 'database', '--once' => true, '--tries' => 2, '--sleep' => 0])->run();
+        $this->artisan('queue:work', ['connection' => 'database', '--once' => true, '--tries' => 2, '--sleep' => 0])->run();
+
+        $this->assertSame(2, Cache::store('file')->get('attempts'));
+        $this->assertSame('succeeded on retry', Cache::store('file')->get('outcome'));
+        $this->assertSame(0, DB::table('failed_jobs')->count());
+        $this->assertSame(0, DB::table('jobs')->count());
+    }
+
+    public function testInjectsTheJobIntoADeferredClosureThatAsksForIt()
+    {
+        config()->set('queue.default', 'sync');
+
+        // CallQueuedClosure hands the closure the queued command itself as
+        // $job, which in turn carries the queue's job wrapper; keep exactly that.
+        Concurrency::driver('queue')->defer([
+            function ($job) {
+                Cache::store('file')->put('job class', $job::class, 60);
+                Cache::store('file')->put('wrapper class', $job->job::class, 60);
+            },
+        ])();
+
+        $this->assertSame(InvokeDeferredClosure::class, Cache::store('file')->get('job class'));
+        $this->assertSame(SyncJob::class, Cache::store('file')->get('wrapper class'));
+    }
+
+    public function testTheDeferredJobIsACallQueuedClosure()
+    {
+        config()->set('queue.default', 'sync');
+
+        Concurrency::driver('queue')->defer([
+            function (CallQueuedClosure $job) {
+                Cache::store('file')->put('typed', 'ran', 60);
+                Cache::store('file')->put('batch', $job->batch() === null ? 'none' : 'some', 60);
+            },
+        ])();
+
+        $this->assertSame('ran', Cache::store('file')->get('typed'));
+        $this->assertSame('none', Cache::store('file')->get('batch'));
+        $this->assertTrue(is_subclass_of(InvokeDeferredClosure::class, CallQueuedClosure::class));
+        $this->assertTrue((new ReflectionProperty(InvokeDeferredClosure::class, 'deleteWhenMissingModels'))->getDefaultValue());
+        $this->assertFalse(property_exists(InvokeDeferredClosure::class, 'tries'));
+    }
+
+    protected function useChain(array $links): void
+    {
+        config()->set('queue.connections.chain', ['driver' => 'failover', 'connections' => $links]);
+        config()->set('queue.default', 'chain');
+    }
+
+    protected function runsSoFar(): int
+    {
+        return (int) Cache::store('file')->get('runs', 0);
+    }
+
+    protected function prepareFailedJobs(): void
+    {
+        config()->set('queue.failed.driver', 'database-uuids');
+        config()->set('queue.failed.database', 'testing');
+        config()->set('queue.failed.table', 'failed_jobs');
+
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+}

--- a/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
@@ -494,6 +494,32 @@ class QueueConcurrencyFailoverTest extends TestCase
         Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
     }
 
+    public function testRefusesAProcessLocalStoreWhenASyncLinkComesLast()
+    {
+        // The mirror image: a sync link last does not make [database, sync]
+        // inline either, since the job may well land on the database queue.
+        $this->useChain(['database', 'sync']);
+        config()->set('cache.default', 'array');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not shared across processes');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testRefusesAProcessLocalStoreWhenANestedChainCanReachARealQueue()
+    {
+        // A nested failover link is only inline if its own links are.
+        config()->set('queue.connections.inner', ['driver' => 'failover', 'connections' => ['database']]);
+        $this->useChain(['inner']);
+        config()->set('cache.default', 'array');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not shared across processes');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
     public function testCreateReturnsTheDeferredJobClass()
     {
         $this->assertInstanceOf(InvokeDeferredClosure::class, InvokeDeferredClosure::create(fn () => 1));

--- a/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Concurrency;
 
 use Closure;
-use DateInterval;
 use DomainException;
 use Illuminate\Concurrency\InvokeDeferredClosure;
 use Illuminate\Concurrency\InvokeQueuedClosure;
@@ -500,6 +499,11 @@ class QueueConcurrencyFailoverTest extends TestCase
  * A repository that implements exactly the cache contract by delegation and
  * nothing else: no many(), no __call(). A tracing or metrics decorator is the
  * realistic shape of this, and it is legal for Cache::store() to return one.
+ *
+ * The PSR-16 methods take untyped parameters and typed returns, the way
+ * Illuminate\Cache\Repository does, so the class loads against psr/simple-cache
+ * 1, 2 and 3 alike; typed parameters are a fatal against the untyped 1.x
+ * interface.
  */
 class QueueContractOnlyCacheRepository implements Repository
 {
@@ -567,17 +571,17 @@ class QueueContractOnlyCacheRepository implements Repository
         return $this->inner->getStore();
     }
 
-    public function get(string $key, mixed $default = null): mixed
+    public function get($key, $default = null): mixed
     {
         return $this->inner->get($key, $default);
     }
 
-    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    public function set($key, $value, $ttl = null): bool
     {
         return $this->inner->set($key, $value, $ttl);
     }
 
-    public function delete(string $key): bool
+    public function delete($key): bool
     {
         return $this->inner->delete($key);
     }
@@ -587,7 +591,7 @@ class QueueContractOnlyCacheRepository implements Repository
         return $this->inner->clear();
     }
 
-    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    public function getMultiple($keys, $default = null): iterable
     {
         $values = $this->inner->getMultiple($keys, $default);
 
@@ -598,17 +602,17 @@ class QueueContractOnlyCacheRepository implements Repository
         })() : $values;
     }
 
-    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    public function setMultiple($values, $ttl = null): bool
     {
         return $this->inner->setMultiple($values, $ttl);
     }
 
-    public function deleteMultiple(iterable $keys): bool
+    public function deleteMultiple($keys): bool
     {
         return $this->inner->deleteMultiple($keys);
     }
 
-    public function has(string $key): bool
+    public function has($key): bool
     {
         return $this->inner->has($key);
     }

--- a/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
@@ -2,11 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Concurrency;
 
+use Closure;
+use DateInterval;
 use DomainException;
 use Illuminate\Concurrency\InvokeDeferredClosure;
 use Illuminate\Concurrency\InvokeQueuedClosure;
 use Illuminate\Concurrency\TaskResult;
+use Illuminate\Concurrency\TaskTimedOutException;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Events\QueueFailedOver;
@@ -17,7 +21,9 @@ use Illuminate\Support\Facades\Concurrency;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Laravel\SerializableClosure\SerializableClosure;
 use Orchestra\Testbench\TestCase;
@@ -406,6 +412,52 @@ class QueueConcurrencyFailoverTest extends TestCase
         $this->assertFalse(property_exists(InvokeDeferredClosure::class, 'tries'));
     }
 
+    #[DataProvider('contractOnlyRepositories')]
+    public function testCollectsResultsThroughARepositoryThatOnlyImplementsTheContract(bool $generators)
+    {
+        $this->bindContractOnlyStore($generators);
+
+        Queue::fake();
+        Sleep::fake();
+
+        $results = null;
+
+        Str::freezeUlids(function ($ulid) use (&$results) {
+            Cache::store('file')->put("illuminate:concurrency:{$ulid}:0", TaskResult::success('one'), 60);
+            Cache::store('file')->put("illuminate:concurrency:{$ulid}:1", TaskResult::success('two'), 60);
+
+            $results = Concurrency::driver('queue')->run([
+                'a' => fn () => null,
+                'b' => fn () => null,
+            ]);
+        });
+
+        $this->assertSame(['a' => 'one', 'b' => 'two'], $results);
+
+        Sleep::assertNeverSlept();
+    }
+
+    #[DataProvider('contractOnlyRepositories')]
+    public function testPollsThroughARepositoryThatOnlyImplementsTheContract(bool $generators)
+    {
+        $this->bindContractOnlyStore($generators);
+
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        $this->expectException(TaskTimedOutException::class);
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public static function contractOnlyRepositories(): array
+    {
+        return [
+            'array results' => [false],
+            'generator results' => [true],
+        ];
+    }
+
     protected function useChain(array $links): void
     {
         config()->set('queue.connections.chain', ['driver' => 'failover', 'connections' => $links]);
@@ -432,5 +484,132 @@ class QueueConcurrencyFailoverTest extends TestCase
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
         });
+    }
+
+    protected function bindContractOnlyStore(bool $generators): void
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.stores.contract', ['driver' => 'contract']);
+        config()->set('cache.default', 'contract');
+
+        Cache::extend('contract', fn ($app) => new QueueContractOnlyCacheRepository(Cache::store('file'), $generators));
+    }
+}
+
+/**
+ * A repository that implements exactly the cache contract by delegation and
+ * nothing else: no many(), no __call(). A tracing or metrics decorator is the
+ * realistic shape of this, and it is legal for Cache::store() to return one.
+ */
+class QueueContractOnlyCacheRepository implements Repository
+{
+    public function __construct(protected Repository $inner, protected bool $generators = false)
+    {
+    }
+
+    public function pull($key, $default = null)
+    {
+        return $this->inner->pull($key, $default);
+    }
+
+    public function put($key, $value, $ttl = null)
+    {
+        return $this->inner->put($key, $value, $ttl);
+    }
+
+    public function add($key, $value, $ttl = null)
+    {
+        return $this->inner->add($key, $value, $ttl);
+    }
+
+    public function increment($key, $value = 1)
+    {
+        return $this->inner->increment($key, $value);
+    }
+
+    public function decrement($key, $value = 1)
+    {
+        return $this->inner->decrement($key, $value);
+    }
+
+    public function forever($key, $value)
+    {
+        return $this->inner->forever($key, $value);
+    }
+
+    public function remember($key, $ttl, Closure $callback)
+    {
+        return $this->inner->remember($key, $ttl, $callback);
+    }
+
+    public function sear($key, Closure $callback)
+    {
+        return $this->inner->sear($key, $callback);
+    }
+
+    public function rememberForever($key, Closure $callback)
+    {
+        return $this->inner->rememberForever($key, $callback);
+    }
+
+    public function touch($key, $ttl)
+    {
+        return $this->inner->touch($key, $ttl);
+    }
+
+    public function forget($key)
+    {
+        return $this->inner->forget($key);
+    }
+
+    public function getStore()
+    {
+        return $this->inner->getStore();
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->inner->get($key, $default);
+    }
+
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    {
+        return $this->inner->set($key, $value, $ttl);
+    }
+
+    public function delete(string $key): bool
+    {
+        return $this->inner->delete($key);
+    }
+
+    public function clear(): bool
+    {
+        return $this->inner->clear();
+    }
+
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $values = $this->inner->getMultiple($keys, $default);
+
+        // PSR-16 only promises an iterable, so a strict implementation may
+        // hand back a generator.
+        return $this->generators ? (function () use ($values) {
+            yield from $values;
+        })() : $values;
+    }
+
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        return $this->inner->setMultiple($values, $ttl);
+    }
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        return $this->inner->deleteMultiple($keys);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->inner->has($key);
     }
 }

--- a/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyFailoverTest.php
@@ -357,7 +357,11 @@ class QueueConcurrencyFailoverTest extends TestCase
         config()->set('queue.default', 'database');
 
         Concurrency::driver('queue')->defer([
-            function () {
+            function ($job) {
+                // The queue's own attempt counter, so a retry of the same job
+                // cannot be confused with a fresh dispatch that also ran twice.
+                Cache::store('file')->put('attempts seen', $job->job->attempts(), 60);
+
                 if (Cache::store('file')->increment('attempts') === 1) {
                     throw new RuntimeException('first attempt fails');
                 }
@@ -371,6 +375,7 @@ class QueueConcurrencyFailoverTest extends TestCase
         $this->artisan('queue:work', ['connection' => 'database', '--once' => true, '--tries' => 2, '--sleep' => 0])->run();
 
         $this->assertSame(2, Cache::store('file')->get('attempts'));
+        $this->assertSame(2, Cache::store('file')->get('attempts seen'));
         $this->assertSame('succeeded on retry', Cache::store('file')->get('outcome'));
         $this->assertSame(0, DB::table('failed_jobs')->count());
         $this->assertSame(0, DB::table('jobs')->count());
@@ -455,6 +460,43 @@ class QueueConcurrencyFailoverTest extends TestCase
             'array results' => [false],
             'generator results' => [true],
         ];
+    }
+
+    public function testAFailingDeferredTaskOnSyncIsReportedAndDoesNotStopLaterTasks()
+    {
+        config()->set('queue.default', 'sync');
+
+        Exceptions::fake();
+
+        // On a real queue one task's failure never stops the others, and the
+        // synchronous connection now behaves the same way instead of letting
+        // the first failure escape the callback.
+        Concurrency::driver('queue')->defer([
+            fn () => throw new DomainException('first deferred task failed'),
+            fn () => Cache::store('file')->put('second', 'ran', 60),
+        ])();
+
+        $this->assertSame('ran', Cache::store('file')->get('second'));
+
+        Exceptions::assertReported(DomainException::class);
+    }
+
+    public function testRefusesAProcessLocalStoreWhenAMixedChainCanReachARealQueue()
+    {
+        // A chain is inline only if every link is: a sync link first does not
+        // make [sync, database] safe for a store the database worker cannot see.
+        $this->useChain(['sync', 'database']);
+        config()->set('cache.default', 'array');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not shared across processes');
+
+        Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+    }
+
+    public function testCreateReturnsTheDeferredJobClass()
+    {
+        $this->assertInstanceOf(InvokeDeferredClosure::class, InvokeDeferredClosure::create(fn () => 1));
     }
 
     protected function useChain(array $links): void

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -554,8 +554,7 @@ class QueueConcurrencyTest extends TestCase
 
     public function testDispatchFailureWritesCancellationFlagAndCleansUp()
     {
-        $context = new class
-        {
+        $context = new class {
         };
 
         $thrown = null;

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -682,7 +682,6 @@ class QueueConcurrencyTest extends TestCase
     public function testFailureEnvelopesDropUnserializableExceptionParameters()
     {
         $job = new InvokeQueuedClosure(
-            'run',
             'illuminate:concurrency:test:0',
             'illuminate:concurrency:test:cancelled',
             'file',
@@ -784,7 +783,6 @@ class QueueConcurrencyTest extends TestCase
     protected function makeJob(callable $task, bool $rethrowFailures = false, ?int $deadline = null): InvokeQueuedClosure
     {
         return new InvokeQueuedClosure(
-            'run',
             'task:0',
             'task:cancelled',
             null,

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -128,6 +128,27 @@ class QueueConcurrencyTest extends TestCase
         $this->fail('The expected exception was not thrown.');
     }
 
+    public function testCacheIsCleanedUpWhenATaskFails()
+    {
+        $thrown = false;
+
+        $ulid = Str::freezeUlids(function () use (&$thrown) {
+            try {
+                Concurrency::driver('queue')->run([
+                    'ok' => fn () => 'this task succeeds',
+                    'boom' => fn () => throw new RuntimeException('Task failure'),
+                ]);
+            } catch (RuntimeException) {
+                $thrown = true;
+            }
+        });
+
+        $this->assertTrue($thrown);
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:1"));
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
+    }
+
     public function testResultKeysAreRemovedFromCacheAfterRun()
     {
         $ulid = Str::freezeUlids(function () {
@@ -515,13 +536,19 @@ class QueueConcurrencyTest extends TestCase
         Bus::fake();
         Sleep::fake();
 
-        try {
-            Concurrency::driver('queue')->run([fn () => 1]);
+        Str::freezeUlids(function ($ulid) {
+            Cache::put("illuminate:concurrency:{$ulid}:0", TaskResult::success('collected'), 60);
 
-            $this->fail('The expected exception was not thrown.');
-        } catch (RuntimeException $e) {
-            $this->assertStringContainsString('did not report a result', $e->getMessage());
-        }
+            try {
+                Concurrency::driver('queue')->run([fn () => 1, fn () => 2]);
+
+                $this->fail('The expected exception was not thrown.');
+            } catch (RuntimeException $e) {
+                $this->assertStringContainsString('did not report a result', $e->getMessage());
+            }
+
+            $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
+        });
 
         Sleep::assertNeverSlept();
     }

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -146,7 +146,6 @@ class QueueConcurrencyTest extends TestCase
         $this->assertTrue($thrown);
         $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
         $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:1"));
-        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
     }
 
     public function testResultKeysAreRemovedFromCacheAfterRun()
@@ -553,7 +552,7 @@ class QueueConcurrencyTest extends TestCase
         Sleep::assertNeverSlept();
     }
 
-    public function testDispatchFailureWritesCancellationFlag()
+    public function testDispatchFailureWritesCancellationFlagAndCleansUp()
     {
         $context = new class
         {
@@ -563,7 +562,12 @@ class QueueConcurrencyTest extends TestCase
 
         $ulid = Str::freezeUlids(function () use ($context, &$thrown) {
             try {
-                Concurrency::driver('queue')->run([fn () => $context]);
+                Concurrency::driver('queue')->run([
+                    // The first task runs inline and caches its envelope
+                    // before the second task's dispatch fails to serialize.
+                    'ok' => fn () => 'collected',
+                    'boom' => fn () => $context,
+                ]);
             } catch (Throwable $thrown) {
                 //
             }

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -227,6 +227,33 @@ class QueueConcurrencyTest extends TestCase
             $this->assertSame(2, $e->seconds);
             $this->assertSame('database', $e->connection);
             $this->assertSame('file', $e->store);
+            $this->assertSame(
+                'Concurrency tasks dispatched to the [database] queue connection timed out after 2 seconds with [0/2] results received. Ensure queue workers are running and writing results to the [file] cache store.',
+                $e->getMessage(),
+            );
+        } finally {
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testTimeoutMessageIncludesTheQueueWhenOneIsSpecified()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        try {
+            Concurrency::driver('queue')->onQueue('reports')->run([fn () => 1], timeout: 1);
+
+            $this->fail('The expected timeout exception was not thrown.');
+        } catch (TaskTimedOutException $e) {
+            $this->assertSame('reports', $e->queue);
+            $this->assertSame(
+                'Concurrency tasks dispatched to the [database] queue connection on the [reports] queue timed out after 1 seconds with [0/1] results received. Ensure queue workers are running and writing results to the [file] cache store.',
+                $e->getMessage(),
+            );
         } finally {
             Cache::store('file')->flush();
         }

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -256,6 +256,30 @@ class QueueConcurrencyTest extends TestCase
         }
     }
 
+    public function testInlineRunsThatExceedTheTimeoutFailAsTimeouts()
+    {
+        try {
+            Concurrency::driver('queue')->run([
+                'slow' => function () {
+                    Carbon::setTestNow(Carbon::now()->addSeconds(5));
+
+                    return 'finished';
+                },
+                'skipped' => fn () => 'never',
+            ], timeout: 1);
+
+            $this->fail('The expected timeout exception was not thrown.');
+        } catch (TaskTimedOutException $e) {
+            $this->assertSame(1, $e->received);
+            $this->assertSame(2, $e->total);
+            $this->assertSame(1, $e->seconds);
+            $this->assertSame('sync', $e->connection);
+            $this->assertSame('array', $e->store);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     public function testDeferDispatchesCallQueuedClosureJobs()
     {
         Bus::fake();

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -1,0 +1,795 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Concurrency;
+
+use Carbon\CarbonInterval;
+use Closure;
+use Exception;
+use Illuminate\Concurrency\CapturedTaskException;
+use Illuminate\Concurrency\InvokeQueuedClosure;
+use Illuminate\Concurrency\QueueDriver;
+use Illuminate\Concurrency\TaskResult;
+use Illuminate\Concurrency\TaskTimedOutException;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Throwable;
+
+class QueueConcurrencyTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('queue.default', 'sync');
+        $app['config']->set('cache.default', 'array');
+    }
+
+    public function testRunReturnsResultsInOrder()
+    {
+        $results = Concurrency::driver('queue')->run([
+            fn () => 1 + 1,
+            fn () => 2 + 2,
+        ]);
+
+        $this->assertSame([2, 4], $results);
+    }
+
+    public function testRunPreservesStringKeys()
+    {
+        $results = Concurrency::driver('queue')->run([
+            'first' => fn () => 1 + 1,
+            'second' => fn () => 2 + 2,
+        ]);
+
+        $this->assertSame(['first' => 2, 'second' => 4], $results);
+    }
+
+    public function testRunWrapsSingleClosure()
+    {
+        $this->assertSame(['value'], Concurrency::driver('queue')->run(fn () => 'value'));
+    }
+
+    public function testRunReturnsEmptyArrayForNoTasks()
+    {
+        $this->assertSame([], Concurrency::driver('queue')->run([]));
+    }
+
+    public function testTaskExceptionIsRethrownInCaller()
+    {
+        $this->expectExceptionObject(new Exception('This is a different exception'));
+
+        Concurrency::driver('queue')->run([
+            fn () => throw new Exception('This is a different exception'),
+        ]);
+    }
+
+    public function testTaskExceptionWithParametersIsReconstructed()
+    {
+        $this->expectException(QueueExceptionWithParam::class);
+        $this->expectExceptionMessage('API request to https://api.example.com failed with status 400 Bad Request');
+
+        Concurrency::driver('queue')->run([
+            fn () => throw new QueueExceptionWithParam(
+                'https://api.example.com', 400, 'Bad Request', 'Invalid payload',
+            ),
+        ]);
+    }
+
+    #[DataProvider('falseyExceptionParameters')]
+    public function testTaskExceptionWithFalseyParametersIsReconstructed(int|bool|string $value)
+    {
+        try {
+            Concurrency::driver('queue')->run([
+                fn () => throw new QueueExceptionWithFalseyParam($value),
+            ]);
+        } catch (QueueExceptionWithFalseyParam $e) {
+            $this->assertSame($value, $e->value);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public static function falseyExceptionParameters(): array
+    {
+        return [
+            'zero' => [0],
+            'false' => [false],
+            'empty string' => [''],
+        ];
+    }
+
+    public function testFirstFailureInKeyOrderWins()
+    {
+        try {
+            Concurrency::driver('queue')->run([
+                'first' => fn () => throw new Exception('First failure'),
+                'second' => fn () => throw new Exception('Second failure'),
+            ]);
+        } catch (Exception $e) {
+            $this->assertSame('First failure', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public function testResultKeysAreRemovedFromCacheAfterRun()
+    {
+        $ulid = Str::freezeUlids(function () {
+            return Concurrency::driver('queue')->run([fn () => 1, fn () => 2]);
+        });
+
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:1"));
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
+    }
+
+    #[DataProvider('processLocalCacheStores')]
+    public function testRunRejectsProcessLocalCacheStoresForAsyncQueues(string $driver)
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.stores.local', ['driver' => $driver]);
+        config()->set('cache.default', 'local');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not shared across processes');
+
+        Concurrency::driver('queue')->run([fn () => 1]);
+    }
+
+    public static function processLocalCacheStores(): array
+    {
+        return [
+            'array' => ['array'],
+            'null' => ['null'],
+            'session' => ['session'],
+            'octane' => ['octane'],
+            'apc' => ['apc'],
+        ];
+    }
+
+    public function testRunRejectsDeferredQueueConnections()
+    {
+        config()->set('queue.connections.deferred', ['driver' => 'deferred']);
+        config()->set('queue.default', 'deferred');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not be used with the queue concurrency driver');
+
+        Concurrency::driver('queue')->run([fn () => 1]);
+    }
+
+    public function testRunRejectsNullQueueConnections()
+    {
+        config()->set('queue.connections.discard', ['driver' => 'null']);
+        config()->set('queue.default', 'discard');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not be used with the queue concurrency driver');
+
+        Concurrency::driver('queue')->run([fn () => 1]);
+    }
+
+    public function testRunTimesOutWhenNoWorkerProcessesTheTasks()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Queue::fake();
+
+        // Without Carbon-synced fake sleeps advancing the clock, the poll
+        // loop could never reach its deadline, so catching the timeout
+        // exception below also proves that the loop polled and slept.
+        Sleep::fake(syncWithCarbon: true);
+
+        try {
+            Concurrency::driver('queue')->run([fn () => 1, fn () => 2], timeout: 2);
+
+            $this->fail('The expected timeout exception was not thrown.');
+        } catch (TaskTimedOutException $e) {
+            $this->assertSame(0, $e->received);
+            $this->assertSame(2, $e->total);
+            $this->assertSame(2, $e->seconds);
+            $this->assertSame('database', $e->connection);
+            $this->assertSame('file', $e->store);
+        } finally {
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testTimeoutWritesCancellationFlagThatOutlivesTheRun()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        $ulid = Str::freezeUlids(function () {
+            try {
+                Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+            } catch (TaskTimedOutException) {
+                //
+            }
+        });
+
+        try {
+            $this->assertTrue(Cache::store('file')->get("illuminate:concurrency:{$ulid}:cancelled"));
+            $this->assertNull(Cache::store('file')->get("illuminate:concurrency:{$ulid}:0"));
+        } finally {
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testDeferDispatchesCallQueuedClosureJobs()
+    {
+        Bus::fake();
+
+        $callback = Concurrency::driver('queue')->defer([fn () => 1, fn () => 2]);
+
+        Bus::assertNothingDispatched();
+
+        $callback();
+
+        Bus::assertDispatchedTimes(CallQueuedClosure::class, 2);
+    }
+
+    public function testManagerResolvesQueueDriver()
+    {
+        $this->assertInstanceOf(QueueDriver::class, Concurrency::driver('queue'));
+    }
+
+    public function testNamedInstancesUseTheirConfiguredQueue()
+    {
+        config()->set('concurrency.drivers.reports', ['driver' => 'queue', 'queue' => 'reports']);
+
+        Bus::fake();
+
+        $driver = Concurrency::driver('reports');
+
+        $this->assertInstanceOf(QueueDriver::class, $driver);
+
+        try {
+            $driver->run([fn () => 1]);
+        } catch (RuntimeException) {
+            // The faked bus never executes the job, so no result is reported.
+        }
+
+        Bus::assertDispatched(InvokeQueuedClosure::class, fn ($job) => $job->queue === 'reports');
+    }
+
+    public function testJobWritesSuccessEnvelope()
+    {
+        $job = $this->makeJob(fn () => 'value');
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $envelope = Cache::get('task:0');
+
+        $this->assertTrue($envelope['successful']);
+        $this->assertSame('value', TaskResult::unwrap($envelope));
+    }
+
+    public function testJobSwallowsFailuresWhenNotRethrowing()
+    {
+        $job = $this->makeJob(fn () => throw new Exception('Task failure'));
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $envelope = Cache::get('task:0');
+
+        $this->assertFalse($envelope['successful']);
+        $this->assertSame(Exception::class, $envelope['exception']);
+    }
+
+    public function testJobRethrowsCapturedTaskExceptionsWhenRethrowing()
+    {
+        $job = $this->makeJob(fn () => throw new Exception('Task failure'), rethrowFailures: true);
+
+        try {
+            $job->handle($this->app, $this->app->make(CacheFactory::class));
+        } catch (CapturedTaskException $e) {
+            $this->assertSame('Task failure', $e->getMessage());
+            $this->assertSame('Task failure', $e->getPrevious()->getMessage());
+            $this->assertFalse(Cache::get('task:0')['successful']);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public function testJobHonorsCancellationFlag()
+    {
+        $invoked = false;
+
+        Cache::forever('task:cancelled', true);
+
+        $job = $this->makeJob(function () use (&$invoked) {
+            $invoked = true;
+        });
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $this->assertFalse($invoked);
+        $this->assertNull(Cache::get('task:0'));
+    }
+
+    public function testJobHonorsExpiredDeadline()
+    {
+        $invoked = false;
+
+        $job = $this->makeJob(function () use (&$invoked) {
+            $invoked = true;
+        }, deadline: time() - 10);
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $this->assertFalse($invoked);
+        $this->assertNull(Cache::get('task:0'));
+    }
+
+    public function testFailedWritesInfrastructureFailureEnvelope()
+    {
+        $job = $this->makeJob(fn () => 'value');
+
+        $job->failed(new RuntimeException('The worker died'));
+
+        $envelope = Cache::get('task:0');
+
+        $this->assertFalse($envelope['successful']);
+        $this->assertSame(RuntimeException::class, $envelope['exception']);
+        $this->assertSame('The worker died', $envelope['message']);
+    }
+
+    public function testFailedIgnoresCapturedTaskExceptions()
+    {
+        $job = $this->makeJob(fn () => 'value');
+
+        $job->failed(new CapturedTaskException(new Exception('Already enveloped')));
+
+        $this->assertNull(Cache::get('task:0'));
+    }
+
+    public function testFailedDoesNotOverwriteExistingEnvelopes()
+    {
+        Cache::put('task:0', TaskResult::success('kept'), 60);
+
+        $job = $this->makeJob(fn () => 'value');
+
+        $job->failed(new RuntimeException('Late failure'));
+
+        $this->assertSame('kept', TaskResult::unwrap(Cache::get('task:0')));
+    }
+
+    public function testJobDefaults()
+    {
+        $job = $this->makeJob(fn () => 'value');
+
+        $this->assertSame(1, $job->tries);
+        $this->assertTrue($job->failOnTimeout);
+        $this->assertFalse($job->afterCommit);
+    }
+
+    public function testMixedKeysArePreservedInOrder()
+    {
+        $results = Concurrency::driver('queue')->run([
+            5 => fn () => 'five',
+            'a' => fn () => 'letter',
+            0 => fn () => 'zero',
+        ]);
+
+        $this->assertSame([5 => 'five', 'a' => 'letter', 0 => 'zero'], $results);
+    }
+
+    public function testTimeoutAcceptsCarbonInterval()
+    {
+        $results = Concurrency::driver('queue')->run([fn () => 'value'], CarbonInterval::seconds(5));
+
+        $this->assertSame(['value'], $results);
+    }
+
+    public function testAsyncRunReturnsOnceAllEnvelopesArePresent()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Queue::fake();
+        Sleep::fake();
+
+        $results = null;
+
+        try {
+            Str::freezeUlids(function ($ulid) use (&$results) {
+                Cache::store('file')->put("illuminate:concurrency:{$ulid}:0", TaskResult::success('one'), 60);
+                Cache::store('file')->put("illuminate:concurrency:{$ulid}:1", TaskResult::success('two'), 60);
+
+                $results = Concurrency::driver('queue')->run([
+                    'a' => fn () => null,
+                    'b' => fn () => null,
+                ]);
+            });
+        } finally {
+            Cache::store('file')->flush();
+        }
+
+        $this->assertSame(['a' => 'one', 'b' => 'two'], $results);
+
+        Sleep::assertNeverSlept();
+    }
+
+    public function testPartialTimeoutReportsReceivedResultsAndCleansUp()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Carbon::setTestNow(Carbon::now());
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        try {
+            Str::freezeUlids(function ($ulid) {
+                Cache::store('file')->put("illuminate:concurrency:{$ulid}:0", TaskResult::success('one'), 60);
+
+                try {
+                    Concurrency::driver('queue')->run(['a' => fn () => null, 'b' => fn () => null], timeout: 1);
+
+                    $this->fail('The expected timeout exception was not thrown.');
+                } catch (TaskTimedOutException $e) {
+                    $this->assertSame(1, $e->received);
+                    $this->assertSame(2, $e->total);
+                }
+
+                $this->assertNull(Cache::store('file')->get("illuminate:concurrency:{$ulid}:0"));
+                $this->assertTrue(Cache::store('file')->get("illuminate:concurrency:{$ulid}:cancelled"));
+            });
+        } finally {
+            Carbon::setTestNow();
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testJobDeadlineIsDerivedFromRunStart()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Carbon::setTestNow($now = Carbon::now());
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        try {
+            Concurrency::driver('queue')->run([fn () => 1], timeout: 30);
+
+            $this->fail('The expected timeout exception was not thrown.');
+        } catch (TaskTimedOutException) {
+            //
+        } finally {
+            Carbon::setTestNow();
+            Cache::store('file')->flush();
+        }
+
+        Queue::assertPushed(InvokeQueuedClosure::class, fn ($job) => $job->deadline === $now->getTimestamp() + 30);
+    }
+
+    public function testPollLoopUsesTheFullTimeoutBudget()
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+
+        Carbon::setTestNow(Carbon::now());
+        Queue::fake();
+        Sleep::fake(syncWithCarbon: true);
+
+        try {
+            Concurrency::driver('queue')->run([fn () => 1], timeout: 1);
+
+            $this->fail('The expected timeout exception was not thrown.');
+        } catch (TaskTimedOutException) {
+            //
+        } finally {
+            Carbon::setTestNow();
+            Cache::store('file')->flush();
+        }
+
+        Sleep::assertSleptTimes(10);
+    }
+
+    public function testSyncMissingEnvelopeFailsWithoutSleeping()
+    {
+        Bus::fake();
+        Sleep::fake();
+
+        try {
+            Concurrency::driver('queue')->run([fn () => 1]);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('did not report a result', $e->getMessage());
+        }
+
+        Sleep::assertNeverSlept();
+    }
+
+    public function testDispatchFailureWritesCancellationFlag()
+    {
+        $context = new class
+        {
+        };
+
+        $thrown = null;
+
+        $ulid = Str::freezeUlids(function () use ($context, &$thrown) {
+            try {
+                Concurrency::driver('queue')->run([fn () => $context]);
+            } catch (Throwable $thrown) {
+                //
+            }
+        });
+
+        $this->assertNotNull($thrown);
+        $this->assertTrue(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
+        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
+    }
+
+    public function testRunRejectsBackgroundQueueConnections()
+    {
+        config()->set('queue.connections.later', ['driver' => 'background']);
+        config()->set('queue.default', 'later');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not be used with the queue concurrency driver');
+
+        Concurrency::driver('queue')->run([fn () => 1]);
+    }
+
+    public function testDeferRejectsNullQueueConnections()
+    {
+        config()->set('queue.connections.discard', ['driver' => 'null']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not be used with the queue concurrency driver');
+
+        Concurrency::driver('queue')->onConnection('discard')->defer([fn () => 1]);
+    }
+
+    public function testLegacyDriverConfigFallbackResolvesQueueDriver()
+    {
+        config()->set('concurrency.driver', ['legacy' => ['driver' => 'queue', 'queue' => 'legacy-queue']]);
+
+        Bus::fake();
+
+        $driver = Concurrency::driver('legacy');
+
+        $this->assertInstanceOf(QueueDriver::class, $driver);
+
+        try {
+            $driver->run([fn () => 1]);
+        } catch (RuntimeException) {
+            // The faked bus never executes the job, so no result is reported.
+        }
+
+        Bus::assertDispatched(InvokeQueuedClosure::class, fn ($job) => $job->queue === 'legacy-queue');
+    }
+
+    public function testRuntimeTargetingReturnsNewDriverInstances()
+    {
+        Bus::fake();
+
+        $base = Concurrency::driver('queue');
+
+        $configured = $base->onConnection('sync')->onQueue('images')->store('array');
+
+        $this->assertInstanceOf(QueueDriver::class, $configured);
+        $this->assertNotSame($base, $configured);
+
+        try {
+            $configured->run([fn () => 1]);
+        } catch (RuntimeException) {
+            //
+        }
+
+        Bus::assertDispatched(InvokeQueuedClosure::class, function ($job) {
+            return $job->connection === 'sync' && $job->queue === 'images' && $job->store === 'array';
+        });
+
+        try {
+            $base->run([fn () => 1]);
+        } catch (RuntimeException) {
+            //
+        }
+
+        Bus::assertDispatched(InvokeQueuedClosure::class, fn ($job) => is_null($job->queue));
+    }
+
+    public function testInlineEnvelopesAreCollectedBeforeLaterTasksRun()
+    {
+        $results = null;
+
+        Str::freezeUlids(function ($ulid) use (&$results) {
+            $results = Concurrency::driver('queue')->run([
+                'first' => fn () => 'kept',
+                'second' => function () use ($ulid) {
+                    // Simulates the first envelope expiring while a later
+                    // inline task is still running, since inline execution
+                    // is not bounded by the run timeout.
+                    Cache::forget("illuminate:concurrency:{$ulid}:0");
+
+                    return 'second';
+                },
+            ]);
+        });
+
+        $this->assertSame(['first' => 'kept', 'second' => 'second'], $results);
+    }
+
+    public function testHandleDoesNotOverwriteExistingEnvelope()
+    {
+        Cache::put('task:0', TaskResult::success('first'), 60);
+
+        $job = $this->makeJob(fn () => 'second');
+
+        $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+        $this->assertSame('first', TaskResult::unwrap(Cache::get('task:0')));
+    }
+
+    public function testFailureEnvelopesDropUnserializableExceptionParameters()
+    {
+        $job = new InvokeQueuedClosure(
+            'run',
+            'illuminate:concurrency:test:0',
+            'illuminate:concurrency:test:cancelled',
+            'file',
+            60,
+            time() + 60,
+            false,
+            new SerializableClosure(fn () => throw new QueueExceptionWithClosureParam(fn () => 'context')),
+        );
+
+        try {
+            $job->handle($this->app, $this->app->make(CacheFactory::class));
+
+            $envelope = Cache::store('file')->get('illuminate:concurrency:test:0');
+
+            $this->assertFalse($envelope['successful']);
+            $this->assertSame(QueueExceptionWithClosureParam::class, $envelope['exception']);
+            $this->assertSame([], $envelope['parameters']);
+        } finally {
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testResultsRoundTripThroughARealDatabaseWorker()
+    {
+        $this->prepareDatabaseQueue();
+
+        Sleep::fake(syncWithCarbon: true);
+
+        Sleep::whenFakingSleep(function () {
+            $this->artisan('queue:work', ['connection' => 'database', '--once' => true, '--sleep' => 0])->run();
+        });
+
+        try {
+            $results = Concurrency::driver('queue')->run([
+                'first' => fn () => 1 + 1,
+                'second' => fn () => 'two',
+            ], timeout: 30);
+
+            $this->assertSame(['first' => 2, 'second' => 'two'], $results);
+            $this->assertSame(0, DB::table('jobs')->count());
+        } finally {
+            Cache::store('file')->flush();
+        }
+    }
+
+    public function testTaskFailuresRoundTripThroughARealDatabaseWorker()
+    {
+        $this->prepareDatabaseQueue();
+
+        Sleep::fake(syncWithCarbon: true);
+
+        Sleep::whenFakingSleep(function () {
+            $this->artisan('queue:work', ['connection' => 'database', '--once' => true, '--sleep' => 0])->run();
+        });
+
+        try {
+            Concurrency::driver('queue')->run([fn () => throw new Exception('Worker failure')], timeout: 30);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::class, get_class($e));
+            $this->assertSame('Worker failure', $e->getMessage());
+        } finally {
+            Cache::store('file')->flush();
+        }
+
+        $this->assertSame(1, DB::table('failed_jobs')->count());
+    }
+
+    protected function prepareDatabaseQueue(): void
+    {
+        config()->set('queue.default', 'database');
+        config()->set('cache.default', 'file');
+        config()->set('queue.failed.driver', 'database-uuids');
+        config()->set('queue.failed.database', 'testing');
+        config()->set('queue.failed.table', 'failed_jobs');
+
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    protected function makeJob(callable $task, bool $rethrowFailures = false, ?int $deadline = null): InvokeQueuedClosure
+    {
+        return new InvokeQueuedClosure(
+            'run',
+            'task:0',
+            'task:cancelled',
+            null,
+            60,
+            $deadline ?? time() + 60,
+            $rethrowFailures,
+            new SerializableClosure($task),
+        );
+    }
+}
+
+class QueueExceptionWithParam extends Exception
+{
+    public function __construct(
+        public string $uri,
+        public int $statusCode,
+        public string $reason,
+        public string|array $responseBody = '',
+    ) {
+        parent::__construct("API request to {$uri} failed with status $statusCode $reason");
+    }
+}
+
+class QueueExceptionWithFalseyParam extends Exception
+{
+    public function __construct(public int|bool|string $value)
+    {
+        parent::__construct('Exception with falsey parameter');
+    }
+}
+
+class QueueExceptionWithClosureParam extends Exception
+{
+    public function __construct(public Closure $callback)
+    {
+        parent::__construct('Exception with closure parameter');
+    }
+}

--- a/tests/Integration/Concurrency/QueueConcurrencyTest.php
+++ b/tests/Integration/Concurrency/QueueConcurrencyTest.php
@@ -6,13 +6,13 @@ use Carbon\CarbonInterval;
 use Closure;
 use Exception;
 use Illuminate\Concurrency\CapturedTaskException;
+use Illuminate\Concurrency\InvokeDeferredClosure;
 use Illuminate\Concurrency\InvokeQueuedClosure;
 use Illuminate\Concurrency\QueueDriver;
 use Illuminate\Concurrency\TaskResult;
 use Illuminate\Concurrency\TaskTimedOutException;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
@@ -154,9 +154,11 @@ class QueueConcurrencyTest extends TestCase
             return Concurrency::driver('queue')->run([fn () => 1, fn () => 2]);
         });
 
+        // The result keys go; the cancellation key stays as a tombstone so a
+        // redelivered job refuses to run after the caller has been answered.
         $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:0"));
         $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:1"));
-        $this->assertNull(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
+        $this->assertTrue(Cache::get("illuminate:concurrency:{$ulid}:cancelled"));
     }
 
     #[DataProvider('processLocalCacheStores')]
@@ -307,7 +309,7 @@ class QueueConcurrencyTest extends TestCase
         }
     }
 
-    public function testDeferDispatchesCallQueuedClosureJobs()
+    public function testDeferDispatchesOneDeferredJobPerTask()
     {
         Bus::fake();
 
@@ -317,7 +319,7 @@ class QueueConcurrencyTest extends TestCase
 
         $callback();
 
-        Bus::assertDispatchedTimes(CallQueuedClosure::class, 2);
+        Bus::assertDispatchedTimes(InvokeDeferredClosure::class, 2);
     }
 
     public function testManagerResolvesQueueDriver()


### PR DESCRIPTION
This PR adds a `queue` driver to the Concurrency component. It uses the same `Concurrency::run()` API, but runs the closures on queue workers and waits for their results through a shared cache store.

```php
$results = Concurrency::driver('queue')->run([
    'thumbnail' => fn () => ProcessImage::thumbnail($path),
    'preview' => fn () => ProcessImage::preview($path),
    'optimized' => fn () => ProcessImage::optimize($path),
]);
```

This lets a small web instance use workers for heavier tasks while still returning the results in the same request. It uses existing queue connections and cache stores, without additional tables or services.

The results keep their original keys and order. You can also choose the connection, queue, and cache store:

```php
$results = Concurrency::driver('queue')
    ->onConnection('redis')
    ->onQueue('images')
    ->store('redis')
    ->run([...], timeout: 30);
```

The new `concurrency.drivers` configuration supports named drivers, such as `Concurrency::driver('reports')`. The default remains `process`, and the existing `concurrency.driver` configuration keeps working.

A demo application is available at https://github.com/mathiasgrimm/concurrency-demo.

### Behavior

- The caller waits up to 60 seconds by default, including time spent waiting in the queue. A timeout throws `TaskTimedOutException` and stops waiting for results; it does not guarantee that tasks already running have stopped.
- Tasks that fail on a queue worker remain visible in failed jobs. With a `sync` fallback, the exception is still thrown to the caller, but the failover connection does not treat the task failure as a connection failure. For example, a failing task on `[redis, sync, sync]` is not sent to the second `sync` connection because of that task error.
- Checks for completed or cancelled tasks reduce duplicate execution, but cannot guarantee that a task runs only once.
- A `sync` fallback runs tasks sequentially in the calling process and may exceed the timeout.
- Use a shared cache store that both the caller and workers can access. A failover cache can make results unavailable when the primary store recovers.
- When calling `run()` from a queued job, other workers must be available to process its tasks. Tasks are dispatched immediately, even inside a database transaction, so they may not see changes that have not been committed.
- `defer()` dispatches queued closures after the response without collecting their results. Normal queue retry settings apply to these deferred tasks.

The shared exception handling also improves the existing `process` driver. If Laravel cannot recreate a task's exception using its original arguments, it tries again using just the message. If that also fails, the caller receives a `RuntimeException` containing the original exception class and message instead of an error from calling the exception constructor.

Tests cover result ordering, failures, timeouts, configuration, deferred tasks, queue and cache failover, and a real database queue worker round trip.

Companion documentation: https://github.com/laravel/docs/pull/11365. Both PRs remain in draft.
