### PR TITLE
[13.x] Batch JSON:API collection relationship loading

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
@@ -2,11 +2,14 @@
 
 namespace Illuminate\Http\Resources\JsonApi;
 
+use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection as BaseAnonymousResourceCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class AnonymousResourceCollection extends BaseAnonymousResourceCollection
 {
@@ -44,9 +47,65 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
     #[\Override]
     public function toAttributes(Request $request)
     {
+        $this->loadMissingResourceRelationships($request = $this->resolveJsonApiRequestFrom($request));
+
         return $this->collection
             ->map(fn ($resource) => $resource->resolveResourceData($request))
             ->all();
+    }
+
+    /**
+     * Load the requested resource relationships for the collection.
+     */
+    protected function loadMissingResourceRelationships(JsonApiRequest $request): void
+    {
+        if (empty($requestedRelationships = $request->sparseIncluded())) {
+            return;
+        }
+
+        $loadGroups = [];
+
+        foreach ($this->collection as $resource) {
+            if (! $resource instanceof JsonApiResource || ! $resource->resource instanceof Model) {
+                continue;
+            }
+
+            $relationships = [];
+
+            foreach (new Collection($resource->toRelationships($request)) as $key => $value) {
+                $relationship = is_int($key) ? $value : $key;
+
+                if (! is_string($relationship) || ! in_array($relationship, $requestedRelationships, true)) {
+                    continue;
+                }
+
+                $nestedRelationships = $request->sparseIncluded($relationship);
+                $paths = $value instanceof Closure || empty($nestedRelationships)
+                    ? [$relationship]
+                    : array_map(fn ($nestedRelationship) => $relationship.'.'.$nestedRelationship, $nestedRelationships);
+
+                foreach ($paths as $path) {
+                    $relationships[$path] = true;
+                }
+            }
+
+            if (empty($relationships)) {
+                continue;
+            }
+
+            $relationships = array_keys($relationships);
+            sort($relationships);
+
+            $groupKey = $resource->resource::class."\0".implode("\0", $relationships);
+            $loadGroups[$groupKey]['models'][] = $resource->resource;
+            $loadGroups[$groupKey]['relationships'] = $relationships;
+        }
+
+        foreach ($loadGroups as $loadGroup) {
+            $loadGroup['models'][0]
+                ->newCollection($loadGroup['models'])
+                ->loadMissing($loadGroup['relationships']);
+        }
     }
 
     /**

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Http\Resources\JsonApi;
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Comment;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Profile;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Team;
@@ -9,6 +11,59 @@ use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
 
 class JsonApiCollectionTest extends TestCase
 {
+    public function testItLoadsIncludedRelationshipsForCollectionInBatches()
+    {
+        $posts = Post::factory()->times(5)->create();
+
+        $posts->each(fn ($post) => Comment::factory()->create([
+            'post_id' => $post->getKey(),
+        ]));
+
+        DB::enableQueryLog();
+
+        $this->getJson('/posts?'.http_build_query(['include' => 'comments']))
+            ->assertOk()
+            ->assertJsonCount(5, 'data')
+            ->assertJsonCount(5, 'included');
+
+        $this->assertCount(3, DB::getQueryLog());
+    }
+
+    public function testItLoadsNestedIncludedRelationshipsForCollectionInBatches()
+    {
+        $users = User::factory()->times(5)->create();
+
+        $users->each(fn ($user) => Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]));
+
+        DB::enableQueryLog();
+
+        $this->getJson('/users?'.http_build_query(['include' => 'posts.author']))
+            ->assertOk()
+            ->assertJsonCount(5, 'data');
+
+        $this->assertCount(4, DB::getQueryLog());
+    }
+
+    public function testItDoesNotReloadRelationshipsThatWereAlreadyEagerLoaded()
+    {
+        $posts = Post::factory()->times(5)->create();
+
+        $posts->each(fn ($post) => Comment::factory()->create([
+            'post_id' => $post->getKey(),
+        ]));
+
+        DB::enableQueryLog();
+
+        $this->getJson('/posts-with-comments?'.http_build_query(['include' => 'comments']))
+            ->assertOk()
+            ->assertJsonCount(5, 'data')
+            ->assertJsonCount(5, 'included');
+
+        $this->assertCount(3, DB::getQueryLog());
+    }
+
     public function testItCanGenerateJsonApiResponse()
     {
         $users = User::factory()->times(5)->create();

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -45,6 +45,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return Post::paginate(5)->toResourceCollection();
         });
 
+        $router->get('posts-with-comments', function () {
+            return Post::with('comments')->paginate(5)->toResourceCollection();
+        });
+
         $router->get('posts/{postId}', function ($postId) {
             return Post::find($postId)->toResource();
         });


### PR DESCRIPTION
Fixes #61252.

JSON:API collections currently call `loadMissing()` on each model while
serializing requested includes. This can add one relationship query per item,
even though the collection already contains every model needed for one batched
load.

This change groups resources that share a model class and requested relationship
paths, then loads those relationships once per group before individual resource
serialization. It only considers relationships declared by the resource and
requested through `include`. Existing eager loads are reused, while custom
closure resolvers keep their current behavior.

The new regressions cover direct includes, nested includes, and collections that
were already eager loaded. For five paginated records, the direct case drops
from 7 queries to 3 and the nested case drops from 12 queries to 4.

Validated with:

```text
phpunit tests/Integration/Http/Resources tests/Integration/Http/ResourceTest.php tests/Http/Resources/JsonApi tests/Http/JsonResourceTest.php
130 tests, 347 assertions

pint --test
phpstan analyse src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
```
