### PR TITLE
[13.x] Add test coverage proving faked DNS lookups do not bypass RFC validation

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5406,8 +5406,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => 'not-an-email'], ['x' => 'email:dns']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '.invalid@gmail.com'], ['x' => 'email:dns']);
+        $v = new Validator($trans, ['x' => '.invalid@this-domain-does-not-exist.com'], ['x' => 'email:dns']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '.invalid@this-domain-does-not-exist.com'], ['x' => 'email:rfc,dns']);
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:dns']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
`Validator::fakeDnsLookups()` makes `email:dns` and `active_url` resolve without a live DNS lookup. `testValidateEmailWithDnsCheckWithFakedDnsLookups` already covers the happy path, but nothing asserted that faking DNS bypasses *only* the DNS check and leaves the other requested validators intact.

This PR adds that missing regression coverage. The two assertions use the **same** RFC-invalid address on a syntactically valid, nonexistent domain, so the only variable between them is the `rfc` validator:

```php
$v = new Validator($trans, ['x' => '.invalid@this-domain-does-not-exist.com'], ['x' => 'email:dns']);
$this->assertTrue($v->passes());

$v = new Validator($trans, ['x' => '.invalid@this-domain-does-not-exist.com'], ['x' => 'email:rfc,dns']);
$this->assertFalse($v->passes());
```

Together they pin down that:

- DNS validation succeeds for a well-formed domain without a live lookup.
- `email:dns` does not accidentally enforce RFC validation.
- `email:rfc,dns` still rejects an RFC-invalid address while DNS is faked.
- Faking DNS does not disable or weaken the other validators in a `MultipleValidationWithAnd` chain.

The pre-existing `.invalid@gmail.com` case was retargeted to the same nonexistent `.com` domain so the pair reads as a clean A/B — and as a side benefit that assertion no longer depends on a real, externally-owned domain.

Tests only; no production code changed. `vendor/bin/phpunit tests/Validation` passes (1210 tests, 4275 assertions).
