### PR TITLE
[13.x] Respect queue forwarding for routed jobs

### DIFF
--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -37,7 +37,13 @@ class QueueRoutes
         $route = $this->getRoute($queueable);
 
         if (! is_null($route)) {
-            return is_string($route) ? null : $route[0];
+            if (! is_string($route) && ! is_null($route[0])) {
+                return $route[0];
+            }
+
+            return $this->forwardedConnection(
+                is_string($route) ? $route : $route[1]
+            );
         }
 
         if (empty($this->forwards)) {

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -122,6 +122,74 @@ class QueueRoutesTest extends TestCase
         $this->assertNull($defaults->getConnection(new SomeJob));
     }
 
+    public function testStringRouteResolvesForwardedConnection()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set([SomeJob::class => 'payments']);
+        $defaults->forward('payments', 'settlements', 'cloud');
+
+        $job = new SomeJob;
+        $connection = $defaults->getConnection($job);
+
+        $this->assertSame('cloud', $connection);
+        $this->assertSame('settlements', $defaults->forwardedQueue(
+            $defaults->getQueue($job),
+            $connection,
+        ));
+    }
+
+    public function testRouteWithoutConnectionResolvesForwardedConnection()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set(SomeJob::class, 'payments');
+        $defaults->forward('payments', 'settlements', 'cloud');
+
+        $job = new SomeJob;
+        $connection = $defaults->getConnection($job);
+
+        $this->assertSame('cloud', $connection);
+        $this->assertSame('settlements', $defaults->forwardedQueue(
+            $defaults->getQueue($job),
+            $connection,
+        ));
+    }
+
+    public function testRouteWithExplicitConnectionRetainsItsConnection()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set(SomeJob::class, 'payments', 'redis');
+        $defaults->forward('payments', 'settlements', 'cloud');
+
+        $job = new SomeJob;
+        $connection = $defaults->getConnection($job);
+
+        $this->assertSame('redis', $connection);
+        $this->assertSame('payments', $defaults->forwardedQueue(
+            $defaults->getQueue($job),
+            $connection,
+        ));
+    }
+
+    public function testUnrelatedRouteIsNotForwarded()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set([SomeJob::class => 'other']);
+        $defaults->forward('payments', 'settlements', 'cloud');
+
+        $job = new SomeJob;
+        $connection = $defaults->getConnection($job);
+
+        $this->assertNull($connection);
+        $this->assertSame('other', $defaults->forwardedQueue(
+            $defaults->getQueue($job),
+            $connection,
+        ));
+    }
+
     public function testForwardMatchesQueueAttribute()
     {
         $defaults = new QueueRoutes();


### PR DESCRIPTION
`Queue::route()` and `Queue::forward()` do not compose when a class route specifies a queue name without an explicit connection.

For example:

```php
  Queue::route(GeneratePayment::class, 'payments');
  Queue::forward('payments', 'settlements', 'cloud');
```
QueueRoutes::getConnection() returns null for the class route without considering queue forwarding. Since forwarded queue resolution is connection-scoped, the queue name is not rewritten either. The job remains on the default payments queue instead of being dispatched to cloud:settlements.

This PR resolves the forwarded connection when a class route provides only a queue name. Routes with an explicit connection retain their existing precedence.