### PR TITLE
[13.x] Add cache:prune-expired command for the database cache store

### DIFF
--- a/src/Illuminate/Cache/Console/PruneExpiredCommand.php
+++ b/src/Illuminate/Cache/Console/PruneExpiredCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Cache\Console;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'cache:prune-expired')]
+class PruneExpiredCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:prune-expired {store? : The name of the store you would like to prune expired items from}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune expired items from caches that do not remove them automatically (database only)';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Cache\CacheManager  $cache
+     * @return int|null
+     */
+    public function handle(CacheManager $cache)
+    {
+        $store = $cache->store($this->argument('store'))->getStore();
+
+        if (! method_exists($store, 'pruneExpired')) {
+            $this->components->error('The cache store does not support pruning expired items.');
+
+            return 1;
+        }
+
+        $count = $store->pruneExpired();
+
+        $this->components->info("Pruned [{$count}] expired cache items.");
+    }
+}

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -453,6 +453,18 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
     }
 
     /**
+     * Remove all expired items from the cache.
+     *
+     * @return int
+     */
+    public function pruneExpired()
+    {
+        return $this->table()
+            ->where('expiration', '<=', $this->getTime())
+            ->delete();
+    }
+
+    /**
      * Remove all locks from the store.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
+use Illuminate\Cache\Console\PruneExpiredCommand;
 use Illuminate\Cache\Console\PruneStaleTagsCommand;
 use Illuminate\Concurrency\Console\InvokeSerializedClosureCommand;
 use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
@@ -151,6 +152,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Optimize' => OptimizeCommand::class,
         'OptimizeClear' => OptimizeClearCommand::class,
         'PackageDiscover' => PackageDiscoverCommand::class,
+        'PruneExpiredCommand' => PruneExpiredCommand::class,
         'PruneStaleTagsCommand' => PruneStaleTagsCommand::class,
         'QueueClear' => QueueClearCommand::class,
         'QueueFailed' => ListFailedQueueCommand::class,

--- a/tests/Cache/PruneExpiredCommandTest.php
+++ b/tests/Cache/PruneExpiredCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Console\PruneExpiredCommand;
+use Illuminate\Cache\DatabaseStore;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Foundation\Application;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class PruneExpiredCommandTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Cache\Console\PruneExpiredCommand
+     */
+    private $command;
+
+    /**
+     * @var \Illuminate\Cache\CacheManager|\Mockery\MockInterface
+     */
+    private $cacheManager;
+
+    /**
+     * @var \Illuminate\Contracts\Cache\Repository|\Mockery\MockInterface
+     */
+    private $cacheRepository;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->cacheManager = Mockery::mock(CacheManager::class);
+        $this->cacheRepository = Mockery::mock(Repository::class);
+        $this->command = new PruneExpiredCommand;
+
+        $app = new Application;
+        $app->instance(CacheManager::class, $this->cacheManager);
+        $this->command->setLaravel($app);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testPruneWithNoStoreArgument()
+    {
+        $store = Mockery::mock(DatabaseStore::class);
+        $store->expects('pruneExpired')->andReturn(3);
+
+        $this->cacheManager->expects('store')->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->expects('getStore')->andReturn($store);
+
+        $this->assertSame(0, $this->runCommand($this->command));
+    }
+
+    public function testPruneWithStoreArgument()
+    {
+        $store = Mockery::mock(DatabaseStore::class);
+        $store->expects('pruneExpired')->andReturn(3);
+
+        $this->cacheManager->expects('store')->with('foo')->andReturn($this->cacheRepository);
+        $this->cacheRepository->expects('getStore')->andReturn($store);
+
+        $this->assertSame(0, $this->runCommand($this->command, ['store' => 'foo']));
+    }
+
+    public function testPruneWillFailWhenNotSupportedByStore()
+    {
+        $store = Mockery::mock(Store::class);
+
+        $this->cacheManager->expects('store')->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->expects('getStore')->andReturn($store);
+
+        $this->assertSame(1, $this->runCommand($this->command));
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}

--- a/tests/Console/Fixtures/command_signatures.php
+++ b/tests/Console/Fixtures/command_signatures.php
@@ -84,6 +84,18 @@ return [
             ],
         ],
     ],
+    \Illuminate\Cache\Console\PruneExpiredCommand::class => [
+        'name' => 'cache:prune-expired',
+        'arguments' => [
+            [
+                'name' => 'store',
+                'mode' => 'optional',
+                'isArray' => false,
+                'default' => null,
+                'description' => 'The name of the store you would like to prune expired items from',
+            ],
+        ],
+    ],
     \Illuminate\Cache\Console\PruneStaleTagsCommand::class => [
         'name' => 'cache:prune-stale-tags',
         'arguments' => [

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -328,6 +328,30 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $store->flushLocks();
     }
 
+    public function testPruneExpiredRemovesOnlyExpiredEntries()
+    {
+        $store = $this->getStore();
+
+        $this->insertToCacheTable('foo', 'bar', 0);
+        $this->insertToCacheTable('baz', 'qux', 0);
+        $this->insertToCacheTable('fresh', 'value', 60);
+
+        $this->assertSame(2, $store->pruneExpired());
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('baz')]);
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('fresh')]);
+    }
+
+    public function testPruneExpiredRemovesNothingWhenNoEntriesAreExpired()
+    {
+        $store = $this->getStore();
+
+        $this->insertToCacheTable('foo', 'bar', 60);
+
+        $this->assertSame(0, $store->pruneExpired());
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
+    }
+
     /**
      * @return \Illuminate\Cache\DatabaseStore
      */


### PR DESCRIPTION
The database cache store only removes an expired row when that same key is read or written again, so keys that never come back are never cleaned up. Redis, Memcached, and DynamoDB expire records natively and sessions and database locks garbage collect via a lottery, but the database cache table has no pruning mechanism.

This adds DatabaseStore::pruneExpired() and a schedulable cache:prune-expired command following the cache:prune-stale-tags pattern, so applications can keep the cache table bounded with $schedule->command('cache:prune-expired')->daily().