### PR TITLE
[13.x] Start a new max wait window after a debounced job runs

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -118,6 +118,17 @@ class DebounceLock
     }
 
     /**
+     * Remove the maximum wait timestamp for the given job.
+     *
+     * @param  mixed  $job
+     * @return void
+     */
+    public function releaseMaxWait($job)
+    {
+        $this->resolveCache($job)->forget(static::getKey($job).':first_dispatched_at');
+    }
+
+    /**
      * Get the debounce delay for the given job.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -80,8 +80,6 @@ class CallQueuedHandler
             return $this->deleteDebouncedJob($job, $command);
         }
 
-        $this->ensureDebounceMaxWaitIsReleased($command);
-
         $this->runningCommand = $command;
 
         try {
@@ -152,6 +150,10 @@ class CallQueuedHandler
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;
+                }
+
+                if (! empty($command->debounceOwner ?? '')) {
+                    (new DebounceLock($this->container->make(Cache::class)))->releaseMaxWait($command);
                 }
 
                 return $this->dispatcher->dispatchNow(
@@ -296,19 +298,6 @@ class CallQueuedHandler
         }
 
         $job->delete();
-    }
-
-    /**
-     * Ensure the maximum wait timestamp for a debounced job is released.
-     *
-     * @param  mixed  $command
-     * @return void
-     */
-    protected function ensureDebounceMaxWaitIsReleased($command)
-    {
-        if (! empty($command->debounceOwner ?? '')) {
-            (new DebounceLock($this->container->make(Cache::class)))->releaseMaxWait($command);
-        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -80,6 +80,8 @@ class CallQueuedHandler
             return $this->deleteDebouncedJob($job, $command);
         }
 
+        $this->ensureDebounceMaxWaitIsReleased($command);
+
         $this->runningCommand = $command;
 
         try {
@@ -294,6 +296,19 @@ class CallQueuedHandler
         }
 
         $job->delete();
+    }
+
+    /**
+     * Ensure the maximum wait timestamp for a debounced job is released.
+     *
+     * @param  mixed  $command
+     * @return void
+     */
+    protected function ensureDebounceMaxWaitIsReleased($command)
+    {
+        if (! empty($command->debounceOwner ?? '')) {
+            (new DebounceLock($this->container->make(Cache::class)))->releaseMaxWait($command);
+        }
     }
 
     /**

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -316,6 +316,24 @@ class DebouncedJobTest extends QueueTestCase
         $this->assertEquals(30, $job->delay);
     }
 
+    public function testMaxDebounceWaitIsNotReleasedWhenMiddlewareReleasesTheJob()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
+
+        dispatch(new DebouncedWithReleasingMiddlewareJob('entity-1'));
+
+        $this->travelTo(Carbon::now()->addSeconds(31));
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->travelTo(Carbon::now()->addSeconds(30));
+
+        $job = new DebouncedWithReleasingMiddlewareJob('entity-1');
+        $pending = dispatch($job);
+        unset($pending);
+
+        $this->assertEquals(0, $job->delay);
+    }
+
     public function testDebounceWithoutMaxWaitAllowsIndefiniteDelay()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
@@ -488,6 +506,38 @@ class DebouncedWithMaxWaitJob implements ShouldQueue
     public function handle()
     {
         static::$handleCount++;
+    }
+}
+
+#[DebounceFor(30, maxWait: 60)]
+class DebouncedWithReleasingMiddlewareJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public function __construct(public string $entityId)
+    {
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function middleware(): array
+    {
+        return [new ReleaseDebouncedJobMiddleware];
+    }
+
+    public function handle()
+    {
+    }
+}
+
+class ReleaseDebouncedJobMiddleware
+{
+    public function handle($job, $next)
+    {
+        $job->release();
     }
 }
 

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -270,7 +270,7 @@ class DebouncedJobTest extends QueueTestCase
 
     public function testMaxDebounceWaitForcesImmediateExecution()
     {
-        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+        $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
 
         DebouncedWithMaxWaitJob::$handleCount = 0;
 
@@ -289,6 +289,31 @@ class DebouncedJobTest extends QueueTestCase
 
         // The job should be queued with delay=0 since max wait was exceeded.
         $this->assertEquals(0, $job->delay);
+    }
+
+    public function testMaxDebounceWaitStartsOverAfterTheDebouncedJobRuns()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+
+        DebouncedWithMaxWaitJob::$handleCount = 0;
+
+        // First dispatch at t=0, which runs once the debounce window closes.
+        dispatch(new DebouncedWithMaxWaitJob('entity-1'));
+
+        $this->travelTo(Carbon::now()->addSeconds(31));
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertEquals(1, DebouncedWithMaxWaitJob::$handleCount);
+
+        // Second dispatch at t=92, long after the first job stopped waiting.
+        $this->travelTo(Carbon::now()->addSeconds(61));
+
+        $job = new DebouncedWithMaxWaitJob('entity-1');
+        $pending = dispatch($job);
+        unset($pending);
+
+        // The job should be debounced again rather than forced to run immediately.
+        $this->assertEquals(30, $job->delay);
     }
 
     public function testDebounceWithoutMaxWaitAllowsIndefiniteDelay()

--- a/tests/Integration/Queue/DebouncedListenerTest.php
+++ b/tests/Integration/Queue/DebouncedListenerTest.php
@@ -36,6 +36,36 @@ class DebouncedListenerTest extends QueueTestCase
 
         $this->assertSame(['second'], DebouncedTestListener::$handledValues);
     }
+
+    public function testMaxDebounceWaitStartsOverAfterTheDebouncedListenerRuns()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
+
+        DebouncedWithMaxWaitListener::$handledValues = [];
+
+        Event::listen(DebouncedTestEvent::class, DebouncedWithMaxWaitListener::class);
+
+        Event::dispatch(new DebouncedTestEvent('entity-1', 'first'));
+
+        $this->travelTo(Carbon::now()->addSeconds(31));
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertSame(['first'], DebouncedWithMaxWaitListener::$handledValues);
+
+        // Dispatch again at t=92, long after the first listener stopped waiting.
+        $this->travelTo(Carbon::now()->addSeconds(61));
+
+        Event::dispatch(new DebouncedTestEvent('entity-1', 'second'));
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertSame(['first'], DebouncedWithMaxWaitListener::$handledValues);
+
+        $this->travelTo(Carbon::now()->addSeconds(31));
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertSame(['first', 'second'], DebouncedWithMaxWaitListener::$handledValues);
+    }
 }
 
 class DebouncedTestEvent
@@ -47,6 +77,22 @@ class DebouncedTestEvent
 
 #[DebounceFor(30)]
 class DebouncedTestListener implements ShouldQueue
+{
+    public static $handledValues = [];
+
+    public function debounceId(DebouncedTestEvent $event): string
+    {
+        return $event->entityId;
+    }
+
+    public function handle(DebouncedTestEvent $event)
+    {
+        static::$handledValues[] = $event->value;
+    }
+}
+
+#[DebounceFor(30, maxWait: 60)]
+class DebouncedWithMaxWaitListener implements ShouldQueue
 {
     public static $handledValues = [];
 


### PR DESCRIPTION
tl;dr a debounced job that already ran can still make the *next* dispatch skip its debounce completely.

`maxWait` on `#[DebounceFor]` keeps a `:first_dispatched_at` cache key, written on the first dispatch of a burst. it gets cleared in exactly two spots: when `maxWait` actually trips, and from `DebounceLock::release()` on a transaction rollback. nothing clears it when the job just runs normally.

so it outlives the burst it belonged to. ttl is `max($debounceFor * 10, 300)`, ie at least 5 minutes, and any dispatch inside that window is measuring elapsed time against a burst thats already finished. if the gap is bigger than `maxWait` the job gets treated as overdue and queued with `delay = 0`:

```php
#[DebounceFor(30, maxWait: 60)]
class SyncSearchIndex implements ShouldQueue { /* ... */ }

dispatch(new SyncSearchIndex('post-1')); // delay 30, so it runs at t=30

// queue goes quiet, nothing else dispatched

dispatch(new SyncSearchIndex('post-1')); // t=92, delay 0, runs immediately
```

so the first event of any burst that starts more than `maxWait` after the last one doesnt get debounced at all. queued listeners with `#[DebounceFor]` do the same thing, both paths go through `CallQueuedHandler`.

fix just clears the max wait timestamp once a job is confirmed not superseded and is about to run. next dispatch then opens a fresh window.

i did think about reusing `DebounceLock::release()` there instead, but that also forgets the owner token and `testTokenPersistsAfterSuccessfulExecution` keeps that on purpose. drop it and a superseded job still sitting on the queue would see an empty cache and run via the fail-open branch. hence the narrower `releaseMaxWait()`.

one test change worth flagging: `testMaxDebounceWaitForcesImmediateExecution` now skips `sync`. it needs three dispatches to pile up while the jobs stay queued, but on `sync` every dispatch runs immediately, so by the second one (t=50, debounce 30) the first job has already run. it was only green because of the stale timestamp. five of the other tests in that file already skip `sync` anyway, and it still runs under `database` and `redis`.
