### PR TITLE
[13.x] Fix failed job providers crashing on corrupted payload

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Failed;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
@@ -55,7 +56,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function log($connection, $queue, $payload, $exception)
     {
         $this->getTable()->insert([
-            'uuid' => $uuid = json_decode($payload, true)['uuid'],
+            'uuid' => $uuid = json_decode($payload, true)['uuid'] ?? (string) Str::uuid(),
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class DynamoDbFailedJobProvider implements FailedJobProviderInterface
 {
@@ -57,7 +58,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        $id = json_decode($payload, true)['uuid'];
+        $id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
 
         $failedAt = Date::now();
 

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
@@ -56,7 +57,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function log($connection, $queue, $payload, $exception)
     {
         return $this->lock(function () use ($connection, $queue, $payload, $exception) {
-            $id = json_decode($payload, true)['uuid'];
+            $id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
 
             $jobs = $this->read();
 

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -84,6 +84,20 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertEmpty($provider->all());
     }
 
+    public function testCanLogFailedJobWithCorruptedPayload()
+    {
+        $provider = $this->getFailedJobProvider();
+
+        $id = $provider->log('connection-1', 'queue-1', 'corrupted-payload', new RuntimeException());
+
+        $this->assertTrue(Str::isUuid($id));
+
+        $failedJob = $provider->find($id);
+
+        $this->assertSame($id, $failedJob->id);
+        $this->assertSame('corrupted-payload', $failedJob->payload);
+    }
+
     public function testPruningFailedJobs()
     {
         $provider = $this->getFailedJobProvider();

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -49,6 +49,43 @@ class DynamoDbFailedJobProviderTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testCanLogFailedJobWithCorruptedPayload()
+    {
+        $uuid = Str::orderedUuid();
+
+        Str::createUuidsUsing(function () use ($uuid) {
+            return $uuid;
+        });
+
+        Carbon::setTestNow($now = CarbonImmutable::now());
+
+        $exception = new Exception('Something went wrong.');
+
+        $dynamoDbClient = Mockery::mock(DynamoDbClient::class);
+
+        $dynamoDbClient->expects('putItem')->with([
+            'TableName' => 'table',
+            'Item' => [
+                'application' => ['S' => 'application'],
+                'uuid' => ['S' => (string) $uuid],
+                'connection' => ['S' => 'connection'],
+                'queue' => ['S' => 'queue'],
+                'payload' => ['S' => 'corrupted-payload'],
+                'exception' => ['S' => (string) $exception],
+                'failed_at' => ['N' => (string) $now->getTimestamp()],
+                'expires_at' => ['N' => (string) $now->addWeek()->getTimestamp()],
+            ],
+        ]);
+
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+
+        $id = $provider->log('connection', 'queue', 'corrupted-payload', $exception);
+
+        $this->assertSame((string) $uuid, $id);
+
+        Str::createUuidsNormally();
+    }
+
     public function testCanRetrieveAllFailedJobs()
     {
         $dynamoDbClient = Mockery::mock(DynamoDbClient::class);

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -96,6 +96,19 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertNull($failedJob);
     }
 
+    public function testCanLogFailedJobWithCorruptedPayload()
+    {
+        $id = $this->provider->log('connection', 'queue', 'corrupted-payload', new Exception('Something went wrong.'));
+
+        $this->assertTrue(Str::isUuid($id));
+
+        $failedJobs = $this->provider->all();
+
+        $this->assertCount(1, $failedJobs);
+        $this->assertSame($id, $failedJobs[0]->id);
+        $this->assertSame('corrupted-payload', $failedJobs[0]->payload);
+    }
+
     public function testCanForgetFailedJobs()
     {
         [$uuid] = $this->logFailedJob();


### PR DESCRIPTION
Fixes #59635

## Problem

The three UUID-based failed job providers extract the job UUID via `json_decode($payload, true)['uuid']` without checking whether decoding succeeded. If the queue backend delivers a corrupted/truncated payload:

1. `json_decode()` returns `null`
2. `null['uuid']` evaluates to `null`
3. **DatabaseUuidFailedJobProvider**: inserts `null` into the UUID column → constraint violation → exception
4. **DynamoDbFailedJobProvider**: same story via `putItem`
5. **FileFailedJobProvider**: stores a `null` id

The provider crashes and the failed job record is permanently lost — the safety net has a hole.

## Fix

Fall back to a freshly generated UUID when the payload cannot be decoded or has no `uuid` key:

```php
$id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
```

The record is still stored with the original (corrupted) payload, so the failure is never lost and can be inspected via `queue:failed`.

## Tests

Added `testCanLogFailedJobWithCorruptedPayload` to all three provider test suites (File, DatabaseUuid, DynamoDb), verifying the record is stored with a valid generated UUID and the original payload preserved. All 44 provider tests + full `tests/Queue/` suite (291 tests) pass; Pint clean.