### PR TITLE
[13.x] Fix route name lost when RouteRegistrar action is not callable

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -285,7 +285,7 @@ class RouteRegistrar
 
         if (is_array($action) &&
             array_is_list($action) &&
-            Reflector::isCallable($action)) {
+            Reflector::isCallable($action, true)) {
             if (strncmp($action[0], '\\', 1)) {
                 $action[0] = '\\'.$action[0];
             }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1457,6 +1457,14 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanSetRouteNameWithNonCallableControllerActionArray()
+    {
+        $this->router->name('users.missing')->get('users', [RouteRegistrarControllerStub::class, 'missing']);
+
+        $this->assertSame('users.missing', $this->getRoute()->getName());
+        $this->assertSame(RouteRegistrarControllerStub::class.'@missing', ltrim($this->getRoute()->getAction('uses'), '\\'));
+    }
+
     public function testCanSetRouteNameUsingStringBackedEnum()
     {
         $this->router->name(RouteNameEnum::UserIndex)->get('users', fn () => 'all-users');


### PR DESCRIPTION
Fixes #61282.

`Route::name('x')->post()` lost the route name for non-callable `[Controller, 'method']` actions because `RouteRegistrar::compileAction()` used a strict callable check while `RouteAction::parse()` uses a syntax-only one. The parse step then rewrote the whole action array, dropping `as`.

Fix: use the syntax-only check in `compileAction()` too, so both paths normalize the action the same way. Includes a regression test.