### PR TITLE
[13.x] Add insertReturning method query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4297,6 +4297,45 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Insert new records into the database and return the specified columns.
+     *
+     * @param  non-empty-array<non-empty-string>  $returning
+     * @return \Illuminate\Support\Collection
+     */
+    public function insertReturning(array $values, array $returning = ['*'])
+    {
+        if (empty($values)) {
+            return new Collection;
+        }
+
+        if ($returning === []) {
+            throw new InvalidArgumentException('The returning columns must not be empty.');
+        }
+
+        if (! is_array(array_first($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        $sql = $this->grammar->compileInsertReturning($this, $values, $returning);
+
+        $result = new Collection(
+            $this->connection->selectFromWriteConnection($sql, $this->cleanBindings(Arr::flatten($values, 1)))
+        );
+
+        $this->connection->recordsHaveBeenModified($result->isNotEmpty());
+
+        return $result;
+    }
+
+    /**
      * Insert a new record and get the value of the primary key.
      *
      * @param  string|null  $sequence

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1329,6 +1329,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an insert statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileInsertReturning(Builder $query, array $values, array $returning)
+    {
+        throw new RuntimeException('This database engine does not support insert with returning.');
+    }
+
+    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -414,6 +414,19 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an insert statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileInsertReturning(Builder $query, array $values, array $returning)
+    {
+        return $this->compileInsert($query, $values).' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile an insert ignore statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -308,6 +308,19 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an insert statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileInsertReturning(Builder $query, array $values, array $returning)
+    {
+        return $this->compileInsert($query, $values).' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile an insert ignore statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4611,6 +4611,113 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result->isEmpty());
     }
 
+    public function testInsertReturningMethod()
+    {
+        $this->expectExceptionObject(new RuntimeException('does not support'));
+        $builder = $this->getBuilder();
+        $builder->from('users')->insertReturning(['email' => 'foo']);
+    }
+
+    public function testInsertReturningMethodWithEmptyValues()
+    {
+        $builder = $this->getPostgresBuilder();
+        $result = $builder->from('users')->insertReturning([]);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testMySqlInsertReturningMethod()
+    {
+        $this->expectExceptionObject(new RuntimeException('does not support'));
+        $builder = $this->getMySqlBuilder();
+        $builder->from('users')->insertReturning(['email' => 'foo']);
+    }
+
+    public function testPostgresInsertReturningMethod()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->expects('recordsHaveBeenModified');
+        $builder->getConnection()->expects('selectFromWriteConnection')->with(
+            'insert into "users" ("email") values (?) returning "id"',
+            ['foo']
+        )->andReturn([['id' => 1]]);
+        $result = $builder->from('users')->insertReturning(['email' => 'foo'], ['id']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1]], $result->all());
+    }
+
+    public function testPostgresInsertReturningMethodWithMultipleRecords()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->expects('recordsHaveBeenModified');
+        $builder->getConnection()->expects('selectFromWriteConnection')->with(
+            'insert into "users" ("email") values (?), (?) returning "id", "email"',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo'], ['id' => 2, 'email' => 'bar']]);
+        $result = $builder->from('users')->insertReturning(
+            [['email' => 'foo'], ['email' => 'bar']],
+            ['id', 'email']
+        );
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo'], ['id' => 2, 'email' => 'bar']], $result->all());
+    }
+
+    public function testSqliteInsertReturningMethod()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->expects('recordsHaveBeenModified');
+        $builder->getConnection()->expects('selectFromWriteConnection')->with(
+            'insert into "users" ("email") values (?) returning "id"',
+            ['foo']
+        )->andReturn([['id' => 1]]);
+        $result = $builder->from('users')->insertReturning(['email' => 'foo'], ['id']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1]], $result->all());
+    }
+
+    public function testSqliteInsertReturningMethodWithMultipleRecords()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->expects('recordsHaveBeenModified');
+        $builder->getConnection()->expects('selectFromWriteConnection')->with(
+            'insert into "users" ("email") values (?), (?) returning "id", "email"',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo'], ['id' => 2, 'email' => 'bar']]);
+        $result = $builder->from('users')->insertReturning(
+            [['email' => 'foo'], ['email' => 'bar']],
+            ['id', 'email']
+        );
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo'], ['id' => 2, 'email' => 'bar']], $result->all());
+    }
+
+    public function testSqlServerInsertReturningMethod()
+    {
+        $this->expectExceptionObject(new RuntimeException('does not support'));
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('users')->insertReturning(['email' => 'foo']);
+    }
+
+    public function testInsertReturningWithEmptyReturning()
+    {
+        $this->expectExceptionObject(new InvalidArgumentException('The returning columns must not be empty.'));
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->insertReturning(['email' => 'foo'], []);
+    }
+
+    public function testInsertReturningDoesNotMarkRecordsModifiedWhenNoRowsWereInserted()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->expects('selectFromWriteConnection')->with(
+            'insert into "users" ("email") values (?) returning *',
+            ['foo']
+        )->andReturn([]);
+        $builder->getConnection()->expects('recordsHaveBeenModified')->with(false);
+        $result = $builder->from('users')->insertReturning(['email' => 'foo']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
     public function testInsertOrIgnoreUsingMethod()
     {
         $this->expectExceptionObject(new RuntimeException('does not support'));


### PR DESCRIPTION
Adds an _insertReturning()_ method to Illuminate\Database\Query\Builder. Laravel already has _insertOrIgnoreReturning()_ (#59025), which returns inserted rows' columns via native RETURNING — this PR adds the plain counterpart of it: same idea, minus the conflict-ignoring behavior, for cases where you just want a normal batch insert with the results back.

_insertOrIgnoreReturning()_ solved returning IDs for inserts that silently skip conflicting rows. But insertOrIgnore is the wrong tool whenever an application actually wants constraint violations to fail loudly — which is the common case outside of idempotent import/sync jobs. Today, there is no way to batch-insert several rows and get their generated results back in one round trip while **still preserving normal insert failure behavior**:

_insertGetId()_ only supports a single row — looping it per row for a batch defeats the purpose of batching and multiplies query count linearly with row count.
_insert()_ returns only a boolean.
The only current workaround is dropping to _DB::select(DB::raw(...))_ with hand-written SQL.