### PR TITLE
[13.x] Add typed environment value accessors

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -6,6 +6,7 @@ use Closure;
 use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Repository\RepositoryBuilder;
 use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use PhpOption\Option;
 use RuntimeException;
 
@@ -115,6 +116,140 @@ class Env
     public static function getOrFail($key)
     {
         return self::getOption($key)->getOrThrow(new RuntimeException("Environment variable [$key] has no value."));
+    }
+
+    /**
+     * Get the specified string environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(string|null))|string|null  $default
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function string(string $key, $default = null): string
+    {
+        $value = static::get($key, $default);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(int|null))|int|null  $default
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function integer(string $key, $default = null): int
+    {
+        $value = static::get($key, $default);
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) !== false) {
+            return (int) $value;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Environment value for key [%s] must be an integer, %s given.', $key, gettype($value))
+        );
+    }
+
+    /**
+     * Get the specified float environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(float|null))|float|null  $default
+     * @return float
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function float(string $key, $default = null): float
+    {
+        $value = static::get($key, $default);
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_FLOAT) !== false) {
+            return (float) $value;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Environment value for key [%s] must be a float, %s given.', $key, gettype($value))
+        );
+    }
+
+    /**
+     * Get the specified boolean environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(bool|null))|bool|null  $default
+     * @return bool
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function boolean(string $key, $default = null): bool
+    {
+        $value = static::get($key, $default);
+
+        if (! is_bool($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return array<array-key, mixed>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function array(string $key, $default = null): array
+    {
+        $value = static::get($key, $default);
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return trim($value) === '' ? [] : array_map('trim', explode(',', $value));
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Environment value for key [%s] must be an array, %s given.', $key, gettype($value))
+        );
+    }
+
+    /**
+     * Get the specified array environment value as a collection.
+     *
+     * @param  string  $key
+     * @param  (Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return Collection<array-key, mixed>
+     */
+    public function collection(string $key, $default = null): Collection
+    {
+        return new Collection($this->array($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -143,12 +143,16 @@ if (! function_exists('env')) {
     /**
      * Gets the value of an environment variable.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return ($key is null ? \Illuminate\Support\Env : mixed)
      */
-    function env($key, $default = null)
+    function env($key = null, $default = null)
     {
+        if (is_null($key)) {
+            return new Env;
+        }
+
         return Env::get($key, $default);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -11,12 +11,14 @@ use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Stringable;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
+use InvalidArgumentException;
 use IteratorAggregate;
 use LogicException;
 use Mockery;
@@ -1230,6 +1232,72 @@ class SupportHelpersTest extends TestCase
         $_SERVER['foo'] = 'bar';
         $this->assertSame('bar', env('foo'));
         $this->assertSame('bar', Env::get('foo'));
+    }
+
+    public function testEnvWithoutAKeyReturnsAnEnvironmentAccessor()
+    {
+        $this->assertInstanceOf(Env::class, env());
+    }
+
+    public function testEnvTypedValues()
+    {
+        $_SERVER['env_string'] = 'Laravel';
+        $_SERVER['env_integer'] = '42';
+        $_SERVER['env_float'] = '12.5';
+        $_SERVER['env_true'] = 'true';
+        $_SERVER['env_false'] = '(false)';
+        $_SERVER['env_array'] = 'one, two,three';
+        $_SERVER['env_empty_array'] = '';
+
+        $this->assertSame('Laravel', env()->string('env_string'));
+        $this->assertSame('default', env()->string('missing_string', fn () => 'default'));
+        $this->assertSame(42, env()->integer('env_integer'));
+        $this->assertSame(10, env()->integer('missing_integer', fn () => 10));
+        $this->assertSame(12.5, env()->float('env_float'));
+        $this->assertSame(1.5, env()->float('missing_float', fn () => 1.5));
+        $this->assertTrue(env()->boolean('env_true'));
+        $this->assertFalse(env()->boolean('env_false'));
+        $this->assertTrue(env()->boolean('missing_boolean', fn () => true));
+        $this->assertSame(['one', 'two', 'three'], env()->array('env_array'));
+        $this->assertSame([], env()->array('env_empty_array'));
+        $this->assertSame(['default'], env()->array('missing_array', fn () => ['default']));
+
+        $collection = env()->collection('env_array');
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame(['one', 'two', 'three'], $collection->all());
+        $this->assertSame(['default'], env()->collection('missing_collection', fn () => ['default'])->all());
+    }
+
+    #[DataProvider('invalidTypedEnvValues')]
+    public function testEnvTypedValuesRejectInvalidValues($method, $value, $expectedType)
+    {
+        $_SERVER['invalid_typed_env'] = $value;
+
+        try {
+            env()->{$method}('invalid_typed_env');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(
+                sprintf('Environment value for key [invalid_typed_env] must be %s, %s given.', $expectedType, gettype(env('invalid_typed_env'))),
+                $e->getMessage()
+            );
+
+            return;
+        }
+
+        $this->fail('Expected an InvalidArgumentException to be thrown.');
+    }
+
+    public static function invalidTypedEnvValues()
+    {
+        return [
+            'string' => ['string', 'true', 'a string'],
+            'integer' => ['integer', 'not-an-integer', 'an integer'],
+            'float' => ['float', 'not-a-float', 'a float'],
+            'boolean' => ['boolean', 'not-a-boolean', 'a boolean'],
+            'array' => ['array', 'true', 'an array'],
+            'collection' => ['collection', 'true', 'an array'],
+        ];
     }
 
     public function testEnvTrue()

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -2,6 +2,15 @@
 
 use function PHPStan\Testing\assertType;
 
+assertType('Illuminate\Support\Env', env());
+assertType('mixed', env('foo'));
+assertType('string', env()->string('foo'));
+assertType('int', env()->integer('foo'));
+assertType('float', env()->float('foo'));
+assertType('bool', env()->boolean('foo'));
+assertType('array<mixed>', env()->array('foo'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', env()->collection('foo'));
+
 /** @var bool|float|int|string|null $value */
 if (filled($value)) {
     assertType('bool|float|int|non-empty-string', $value);


### PR DESCRIPTION
Allow env() without a key to return an accessor for retrieving string, integer, boolean, float, array, and collection values. Preserve existing keyed helper behavior while providing typed defaults and validation.
