### PR TITLE
[13.x] Introduce `InteractsWithTestCaseLifecycle::flushState()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -178,6 +178,18 @@ trait InteractsWithTestCaseLifecycle
             $this->originalDeprecationHandler = null;
         }
 
+        $this->flushState();
+
+        if ($this->callbackException) {
+            throw $this->callbackException;
+        }
+    }
+
+    /**
+     * Reset static state between test executions.
+     */
+    protected function flushState(): void
+    {
         AboutCommand::flushState();
         Artisan::forgetBootstrappers();
         Component::flushCache();
@@ -208,10 +220,6 @@ trait InteractsWithTestCaseLifecycle
         PreventRequestForgery::flushState();
         Validator::flushState();
         WorkCommand::flushState();
-
-        if ($this->callbackException) {
-            throw $this->callbackException;
-        }
     }
 
     /**


### PR DESCRIPTION
We have added a few static-memo sort of classes into our codebase. Flushing them usually looks like this:

```php
class MyBaseTestCase extends TestCase
{
    protected function tearDownTheTestEnvironment()
    {
        parent::tearDownTheTestEnvironment();
        CredentialCache::flushState();
    }
}
```

That's fine and it works, but the method is declared as "internal" and therefore hints it shouldn't be overridden. It's also unclear if the parent method should be called before or after I flush my own app's static state.

This introduces an easier way to hook into it.

```php
class MyBaseTestCase extends TestCase
{
    protected function flushState()
    {
        parent::flushState();
        CredentialCache::flushState();
    }
}
```