### PR TITLE
Fix zero JSON API relationship depth

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -78,7 +78,10 @@ class JsonApiRequest extends Request
                         return null;
                     }
 
-                    $item = implode('.', Arr::take(explode('.', $item), JsonApiResource::$maxRelationshipDepth - 1));
+                    $item = implode('.', Arr::take(
+                        explode('.', $item),
+                        max(0, JsonApiResource::$maxRelationshipDepth - 1)
+                    ));
 
                     return ! empty($item) ? $item : null;
                 })->filter()->all();

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
@@ -80,6 +80,20 @@ class JsonApiRequestTest extends TestCase
         $this->assertSame(['user'], $request->sparseIncluded('profile'));
     }
 
+    public function testItCanResolveSparseIncludedWithZeroMaxRelationshipNesting()
+    {
+        JsonApiResource::maxRelationshipDepth(0);
+
+        $request = JsonApiRequest::create(uri: '/?'.http_build_query([
+            'include' => 'teams,posts.author,profile.user.profile',
+        ]));
+
+        $this->assertSame(['teams', 'posts', 'profile'], $request->sparseIncluded());
+        $this->assertSame([], $request->sparseIncluded('teams'));
+        $this->assertSame([], $request->sparseIncluded('posts'));
+        $this->assertSame([], $request->sparseIncluded('profile'));
+    }
+
     public function testItCanResolveEmptySparseIncluded()
     {
         $request = JsonApiRequest::create(uri: '/');


### PR DESCRIPTION
Fixes #61280

`JsonApiResource::maxRelationshipDepth(0)` currently causes `JsonApiRequest::sparseIncluded()` to pass `-1` to `Arr::take()`. A negative limit retains the tail of the relationship path instead of removing nested includes, which can allow nested relationships through or trigger a `RelationNotFoundException`.

This change clamps the remaining nested relationship depth to zero while preserving `0` as a valid configured value.

This prevents unexpected nested relationship loading at zero depth and avoids exceptions for valid include paths. Existing behavior for positive relationship depths is unchanged.

A regression test has been added for zero relationship depth.

Tests:
- `vendor/bin/phpunit tests/Integration/Http/Resources/JsonApi`