### PR TITLE
[13.x] Allow queue:retry to prepare the job before it is pushed

### DIFF
--- a/src/Illuminate/Contracts/Queue/PreparesForRetry.php
+++ b/src/Illuminate/Contracts/Queue/PreparesForRetry.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface PreparesForRetry
+{
+    /**
+     * Run preparation logic before the failed job is retried. Return false to leave the job in the failed jobs table.
+     *
+     * @return bool|void
+     */
+    public function prepareForRetry();
+}

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -4,7 +4,9 @@ namespace Illuminate\Queue\Console;
 
 use DateTimeInterface;
 use Illuminate\Console\Command;
+use Illuminate\Console\View\TaskResult;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Contracts\Queue\PreparesForRetry;
 use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -52,9 +54,13 @@ class RetryCommand extends Command
             } else {
                 $this->laravel['events']->dispatch(new JobRetryRequested($job));
 
-                $this->components->task($id, fn () => $this->retryJob($job));
+                $this->components->task($id, function () use ($job, &$retried) {
+                    return ($retried = $this->retryJob($job)) ? TaskResult::Success->value : TaskResult::Skipped->value;
+                });
 
-                $this->laravel['queue.failer']->forget($id);
+                if ($retried) {
+                    $this->laravel['queue.failer']->forget($id);
+                }
             }
         }
 
@@ -136,17 +142,54 @@ class RetryCommand extends Command
      * Retry the queue job.
      *
      * @param  \stdClass  $job
-     * @return void
+     * @return bool
      */
     protected function retryJob($job)
     {
         $queue = $this->laravel['queue']->connection($job->connection);
 
+        if (is_null($payload = $this->prepareForRetry($this->resetAttempts($job->payload)))) {
+            return false;
+        }
+
         $this->laravel['queue']->connection($job->connection)->pushRaw(
-            $this->refreshRetryUntil($this->resetAttempts($job->payload)),
+            $this->refreshRetryUntil($payload),
             $job->queue,
             $this->getQueueableOptions($queue, $job)
         );
+
+        return true;
+    }
+
+    /**
+     * Give the job a chance to prepare itself before it is retried.
+     *
+     * @param  string  $payload
+     * @return string|null
+     */
+    protected function prepareForRetry($payload)
+    {
+        $decoded = json_decode($payload, true);
+
+        if (! isset($decoded['data']['command'])) {
+            return $payload;
+        }
+
+        $instance = $this->getInstanceFromPayload($decoded);
+
+        if (! $instance instanceof PreparesForRetry) {
+            return $payload;
+        }
+
+        if ($instance->prepareForRetry() === false) {
+            return null;
+        }
+
+        $decoded['data']['command'] = str_starts_with($decoded['data']['command'], 'O:')
+            ? serialize($instance)
+            : $this->laravel->make(Encrypter::class)->encrypt(serialize($instance));
+
+        return json_encode($decoded);
     }
 
     /**

--- a/tests/Integration/Queue/PreparesForRetryTest.php
+++ b/tests/Integration/Queue/PreparesForRetryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Illuminate\Contracts\Queue\PreparesForRetry;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+
+class PreparesForRetryTest extends TestCase
+{
+    public function test_job_is_not_retried_when_prepare_returns_false()
+    {
+        $this->app->instance('queue.failer', $failer = Mockery::mock(FailedJobProviderInterface::class));
+        $failer->expects('find')->with('1')->andReturn($this->failedJob(new PreparesForRetryFalseJob));
+        $failer->expects('forget')->never();
+
+        $this->app->instance('queue', $queues = Mockery::mock(QueueFactory::class));
+        $queues->shouldReceive('connection')->with('sync')->andReturn($queue = Mockery::mock(Queue::class));
+        $queue->expects('pushRaw')->never();
+
+        $this->artisan('queue:retry', ['id' => ['1']])->assertSuccessful();
+    }
+
+    public function test_prepared_job_is_retried_with_its_changes()
+    {
+        $this->app->instance('queue.failer', $failer = Mockery::mock(FailedJobProviderInterface::class));
+        $failer->expects('find')->with('1')->andReturn($this->failedJob(new PreparesForRetryCountingJob(2)));
+        $failer->expects('forget')->with('1');
+
+        $this->app->instance('queue', $queues = Mockery::mock(QueueFactory::class));
+        $queues->shouldReceive('connection')->with('sync')->andReturn($queue = Mockery::mock(Queue::class));
+        $queue->expects('pushRaw')->withArgs(function ($payload, $queue) {
+            $job = unserialize(json_decode($payload, true)['data']['command']);
+
+            return $job instanceof PreparesForRetryCountingJob && $job->attempt === 3 && $queue === 'default';
+        });
+
+        $this->artisan('queue:retry', ['id' => ['1']])->assertSuccessful();
+    }
+
+    protected function failedJob($job)
+    {
+        return (object) [
+            'id' => '1',
+            'connection' => 'sync',
+            'queue' => 'default',
+            'payload' => json_encode([
+                'uuid' => 'uuid',
+                'displayName' => $job::class,
+                'job' => 'Illuminate\Queue\CallQueuedHandler@call',
+                'attempts' => 3,
+                'data' => ['commandName' => $job::class, 'command' => serialize($job)],
+            ]),
+        ];
+    }
+}
+
+class PreparesForRetryFalseJob implements PreparesForRetry, ShouldQueue
+{
+    use Queueable;
+
+    public function prepareForRetry(): bool
+    {
+        return false;
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class PreparesForRetryCountingJob implements PreparesForRetry, ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public int $attempt)
+    {
+    }
+
+    public function prepareForRetry(): void
+    {
+        $this->attempt++;
+    }
+
+    public function handle(): void
+    {
+    }
+}


### PR DESCRIPTION
`queue:retry` pushes a failed job back exactly as it was stored: attempts are reset and `retryUntil` is refreshed, but the job's own data is untouched.

That is a problem for jobs whose data is only valid for one attempt. Our Typesense writer jobs, for example, are created with a "run id" — a row in our database that records one attempt at writing a batch of documents. When the job dies, that run is marked failed. If an operator later retries the job from `failed_jobs`, it comes back with the same, already-failed run id, and the only way to retry it properly today is to delete the failed job and dispatch a new one by hand.

With this contract the job can fix itself up on the way back:

```php
class ReconcileProductIndexJob implements ShouldQueue, PreparesForRetry
{
    public function __construct(public array $productIds, public int $runId) {}

    public function prepareForRetry(): bool
    {
        // Don't retry a payload whose products no longer exist.
        if (Product::whereIn('id', $this->productIds)->doesntExist()) {
            return false;
        }

        // Start a fresh run for this attempt; the old one stays marked failed.
        $this->runId = RunTracking::createRun($this->productIds);

        return true;
    }
}
```

`queue:retry` calls `prepareForRetry()` on the unserialized job, re-serializes it with the changes (encrypted payloads stay encrypted) and pushes it. Returning `false` keeps the job in the failed jobs table and shows it as skipped in the command output. Jobs that do not implement the contract behave exactly as before. This mirrors the existing `PreparesForDispatch`, which does the same thing at dispatch time.

**Why not do this in `handle()`?** Inside `handle()` the job cannot tell how it got there: `queue:retry` resets `attempts` and pushes the stored payload unchanged, so a redrive from `failed_jobs` looks exactly like a first run and like the worker's own retries. A run id that must change only on a redrive would then change on every ordinary retry or release as well, which is the opposite of what is needed. Declining from `handle()` is also the expensive path — the job has to fail again, producing a second `failed_jobs` row, a burnt worker slot and a fresh `retryUntil` window — whereas the hook decides before the push and a declined job simply stays where it is. The state involved (run ids, budgets, idempotency tokens) is decided when a job is put on the queue, not every time it executes; `PreparesForDispatch` covers that moment on the dispatch side, this covers it on the retry side.