### PR TITLE
[13.x] Add clearWhen to ThrottlesExceptions

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -59,6 +59,13 @@ class ThrottlesExceptions
     protected $whenCallback;
 
     /**
+     * The callback that determines if the limiter should be cleared after the job is processed.
+     *
+     * @var callable|null
+     */
+    protected $clearWhenCallback;
+
+    /**
      * The callbacks that determine if the job should be deleted.
      *
      * @var callable[]
@@ -118,7 +125,9 @@ class ThrottlesExceptions
         try {
             $next($job);
 
-            $this->limiter->clear($jobKey);
+            if ($this->shouldClear($job)) {
+                $this->limiter->clear($jobKey);
+            }
         } catch (Throwable $throwable) {
             if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
                 throw $throwable;
@@ -153,6 +162,30 @@ class ThrottlesExceptions
         $this->whenCallback = $callback;
 
         return $this;
+    }
+
+    /**
+     * Specify a callback that should determine if the limiter should be cleared after the job is processed.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function clearWhen(callable $callback)
+    {
+        $this->clearWhenCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the limiter should be cleared after the job was processed.
+     *
+     * @param  mixed  $job
+     * @return bool
+     */
+    protected function shouldClear($job)
+    {
+        return $this->clearWhenCallback === null || call_user_func($this->clearWhenCallback, $job);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -60,7 +60,9 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
         try {
             $next($job);
 
-            $this->limiter->clear();
+            if ($this->shouldClear($job)) {
+                $this->limiter->clear();
+            }
         } catch (Throwable $throwable) {
             if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
                 throw $throwable;

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -41,6 +41,14 @@ class ThrottlesExceptionsTest extends TestCase
         $this->assertJobWasReleasedWithDelay(CircuitBreakerTestJob::class);
     }
 
+    public function testCircuitIsNotResetWhenClearWhenCallbackReturnsFalse()
+    {
+        $this->assertJobWasReleasedImmediately(CircuitBreakerTestJob::class);
+        $this->assertJobWasReleasedByItself(CircuitBreakerReleasedJob::class);
+        $this->assertJobWasReleasedImmediately(CircuitBreakerTestJob::class);
+        $this->assertJobWasReleasedWithDelay(CircuitBreakerTestJob::class);
+    }
+
     public function testCircuitCanSkipJob()
     {
         $this->assertJobWasDeleted(CircuitBreakerSkipJob::class);
@@ -91,6 +99,26 @@ class ThrottlesExceptionsTest extends TestCase
         ]);
 
         $this->assertFalse($class::$handled);
+    }
+
+    protected function assertJobWasReleasedByItself($class)
+    {
+        $class::$handled = false;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = Mockery::mock(Job::class);
+
+        $job->expects('hasFailed')->andReturn(false);
+        $job->expects('release')->with(5);
+        $job->expects('isReleased')->times(3)->andReturn(true);
+        $job->expects('isDeletedOrReleased')->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertTrue($class::$handled);
     }
 
     protected function assertJobWasDeleted($class)
@@ -466,6 +494,25 @@ class CircuitBreakerTestJob
     public function middleware()
     {
         return [(new ThrottlesExceptions(2, 10 * 60))->by('test')];
+    }
+}
+
+class CircuitBreakerReleasedJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        $this->release(5);
+    }
+
+    public function middleware()
+    {
+        return [(new ThrottlesExceptions(2, 10 * 60))->by('test')->clearWhen(fn ($job) => ! $job->job->isReleased())];
     }
 }
 

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -59,6 +59,34 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $this->assertJobWasReleasedWithDelay(CircuitBreakerWithRedisTestJob::class, $key);
     }
 
+    public function testCircuitIsNotResetWhenClearWhenCallbackReturnsFalse()
+    {
+        $this->assertJobWasReleasedImmediately(CircuitBreakerWithRedisTestJob::class, $key = Str::random());
+        $this->assertJobWasReleasedByItself(CircuitBreakerWithRedisReleasedJob::class, $key);
+        $this->assertJobWasReleasedImmediately(CircuitBreakerWithRedisTestJob::class, $key);
+        $this->assertJobWasReleasedWithDelay(CircuitBreakerWithRedisTestJob::class, $key);
+    }
+
+    protected function assertJobWasReleasedByItself($class, $key)
+    {
+        $class::$handled = false;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = Mockery::mock(Job::class);
+
+        $job->expects('hasFailed')->andReturn(false);
+        $job->expects('release')->with(5);
+        $job->expects('isReleased')->times(3)->andReturn(true);
+        $job->expects('isDeletedOrReleased')->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class($key)),
+        ]);
+
+        $this->assertTrue($class::$handled);
+    }
+
     protected function assertJobWasReleasedImmediately($class, $key)
     {
         $class::$handled = false;
@@ -206,6 +234,29 @@ class CircuitBreakerWithRedisTestJob
     public function middleware()
     {
         return [(new ThrottlesExceptionsWithRedis(2, 10 * 60))->by($this->key)];
+    }
+}
+
+class CircuitBreakerWithRedisReleasedJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function __construct(protected $key)
+    {
+    }
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        $this->release(5);
+    }
+
+    public function middleware()
+    {
+        return [(new ThrottlesExceptionsWithRedis(2, 10 * 60))->by($this->key)->clearWhen(fn ($job) => ! $job->job->isReleased())];
     }
 }
 


### PR DESCRIPTION
## Problem

`ThrottlesExceptions::handle()` treats "the job handler returned" as "the job succeeded":

    try {
        $next($job);
    } catch (Throwable $throwable) {
        ...
        throw $throwable;
    }

    $this->limiter->clear($jobKey);   // reached for every non-throwing return

A job that *releases itself* (`$this->release(60)` while waiting for a lock, a
`WithoutOverlapping` / custom middleware that releases, or a job that parks
because a batch or a full run is in progress) also returns without throwing.
The middleware therefore clears the limiter and closes a circuit that a previous
failure had just opened.

## Reproduction

1. `ThrottlesExceptions(1, 5 * 60)` on a job that talks to a shared backend.
2. Job A fails with an exception → circuit opens (`limiter->hit`).
3. Job B (same key) starts, finds a coordination lock, calls `$this->release(30)`.
4. `handle()` reaches `limiter->clear($jobKey)` → circuit closed.
5. Job C runs against the still-broken backend and fails again — the throttle
   never holds while any job in the key releases.

We hit this with a shared circuit in front of a two-worker Typesense pool: one
failure opens the circuit, the next job parks for coordination reasons, and the
circuit is cleared before Typesense has recovered. The test in this PR
(`it does not clear the limiter when the job is released`) reproduces it.

## Why not userland

The clearing happens inside `handle()` after `$next($job)`. The only way to
change it today is to subclass and override `handle()` wholesale — duplicating
the retry-until / backoff / report / deleteWhen logic and tracking future
changes to it. There is no hook between "job finished" and "limiter cleared".

## Proposed API

`clearWhen(callable $callback)`, shaped exactly like `deleteWhen` and `failWhen`:

    (new ThrottlesExceptions(10, 5 * 60))
        ->clearWhen(fn ($job) => ! $job->job->isReleased());

The callback receives the job after it was processed and returns whether the
limiter should be cleared. `ThrottlesExceptionsWithRedis` inherits it (the
limiter abstraction differs, the clearing decision does not).

## Backwards compatibility

Default behaviour is unchanged: without `clearWhen` the limiter is cleared on
every non-throwing return, as today. Not clearing on release by default would
be the "correct" behaviour but would change existing semantics, so it is opt-in.

## Tests

- ThrottlesExceptionsTest: limiter stays hit when the callback returns false;
  limiter cleared when it returns true; default unchanged.
- ThrottlesExceptionsWithRedisTest: same three cases against the Redis limiter.

CI note: the Redis Cluster job flake was fixed by
https://github.com/laravel/framework/pull/61294 (merged).