### PR TITLE
[13.x] Give each Redis Cluster node its own data directory in CI

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Create Redis Cluster
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
-          timeout_seconds: 5
+          timeout_seconds: 30
           max_attempts: 5
           retry_wait_seconds: 5
           retry_on: error

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -81,9 +81,10 @@ jobs:
           sudo apt update
           sudo apt-get install -y --fix-missing redis-server
           sudo service redis-server stop
-          redis-server --daemonize yes --port 7000 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7000.conf
-          redis-server --daemonize yes --port 7001 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7001.conf
-          redis-server --daemonize yes --port 7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
+          mkdir -p /tmp/redis-7000 /tmp/redis-7001 /tmp/redis-7002
+          redis-server --daemonize yes --port 7000 --dir /tmp/redis-7000 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7000.conf
+          redis-server --daemonize yes --port 7001 --dir /tmp/redis-7001 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7001.conf
+          redis-server --daemonize yes --port 7002 --dir /tmp/redis-7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
 
       - name: Create Redis Cluster
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4


### PR DESCRIPTION
## Summary

The three Redis Cluster nodes in `redis.yml` are started daemonized from the same working directory with `--appendonly yes`, so they share one `appendonlydir/` and one AOF manifest. Whichever node loses the start-up race aborts with

Error trying to rename the temporary AOF manifest file temp-appendonly.aof.manifest into appendonly.aof.manifest: No such file or directory

and the "Create Redis Cluster" step then fails with `Connection refused` for that port on every retry, because the process is gone rather than slow. This is the intermittent "Redis Cluster (predis|phpredis) Driver" failure seen on recent 13.x pushes and on pull requests — for example https://github.com/laravel/framework/pull/61293 (run https://github.com/laravel/framework/actions/runs/32633155636, where the predis cluster job failed before any test ran and `fail-fast` cancelled the phpredis one) and https://github.com/laravel/framework/actions/runs/32627608152 on 13.x itself.

The step's 5-second `timeout_seconds` is also too tight: `redis-cli --cluster create` spends about four seconds in "Waiting for the cluster to join", so a run that gets past the start-up race can still be killed by the retry action after the cluster was already created (`[OK] All 16384 slots covered` followed by `Timeout of 5000ms hit`).

## Fix

Give each node its own data directory and give the creation step 30 seconds. Nothing else changes.

With `redis:7.0`, starting the three nodes the way the workflow does lost a node in 7 of 12 runs; with one `--dir` per node, 0 of 12. On a fork, 24 dispatched runs of the current step failed 4 times, every time with the timeout after a successful `--cluster create`; 9 runs with both changes passed every time.