### PR TITLE
[13.x] Fix images created from a stream failing on the second read

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -54,13 +54,34 @@ class Image implements Responsable, Stringable
     protected ?string $hashName = null;
 
     /**
+     * The image contents, or a lazy loader that resolves them.
+     */
+    protected Closure|string $contents;
+
+    /**
      * Create a new image instance.
      */
     public function __construct(
-        protected Closure|string $contents,
+        Closure|string $contents,
         protected ?UploadedFile $file = null,
     ) {
+        $this->contents = $contents instanceof Closure
+            ? $this->resolveOnce($contents)
+            : $contents;
+
         $this->pipeline = new ImagePipeline;
+    }
+
+    /**
+     * Wrap a lazy contents loader so it is invoked at most once, even across clones.
+     */
+    protected function resolveOnce(Closure $loader): Closure
+    {
+        return function () use ($loader) {
+            static $contents;
+
+            return $contents ??= $loader();
+        };
     }
 
     /**

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -227,6 +227,81 @@ class ImageManagerTest extends TestCase
         fclose($stream);
     }
 
+    public function test_from_stream_contents_are_only_read_once()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame([100, 100], $image->dimensions());
+
+        fclose($stream);
+    }
+
+    public function test_from_stream_contents_are_shared_between_clones()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $first = $image->usingGd();
+        $second = $image->usingImagick();
+
+        $this->assertSame($contents, $first->toBytes());
+        $this->assertSame($contents, $second->toBytes());
+
+        fclose($stream);
+    }
+
+    public function test_lazy_contents_are_not_shared_between_different_images()
+    {
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+
+        $first = $manager->fromBase64(base64_encode('first'));
+        $second = $manager->fromBase64(base64_encode('second'));
+
+        $this->assertSame('first', $first->toBytes());
+        $this->assertSame('second', $second->toBytes());
+        $this->assertSame('first', $first->toBytes());
+    }
+
+    public function test_from_url_is_only_fetched_once()
+    {
+        $contents = $this->fakeImageContents();
+
+        $http = new HttpFactory;
+        $http->fake([
+            'https://example.com/photo.jpg' => HttpFactory::response($contents, 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+
+        $app = $this->makeApp([]);
+        $app->shouldReceive('make')
+            ->with(HttpFactory::class)
+            ->andReturn($http);
+
+        $manager = new ImageManager($app);
+        $image = $manager->fromUrl('https://example.com/photo.jpg');
+
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame([100, 100], $image->dimensions());
+
+        $http->assertSentCount(1);
+    }
+
     public function test_from_stream_throws_for_invalid_data()
     {
         $stream = fopen('php://memory', 'r+');


### PR DESCRIPTION
`Image::fromStream()` only works for the first read. The loader closure is called again on every `toBytes()`, so the second call runs `stream_get_contents()` on a stream that is already at EOF, gets `''` and throws `Invalid stream image data.` That makes `Image::fromStream($stream)->width()` throw (it reads once for the bytes and again for the mime type), and `store()` too, since it reads once for the hash name's extension and again to write the file.

The other sources don't throw but repeat the work. `fromUrl()` ends up sending four requests for a single `dimensions()` call, and `fromPath()` / `fromStorage()` read the file on every access. Clones share the same closure, so `$image->cover(100, 100)` and `$image->cover(800, 800)` from one stream fail on the second one as well.

The constructor now wraps the closure so it runs at most once and the result is shared by clones. Nothing is read until it's needed, so the existing laziness tests are unchanged. Added tests for the stream, clone and URL cases.
