### PR TITLE
[13.x] Fix JSON:API resource collection return type

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -203,6 +203,18 @@ class JsonApiResource extends JsonResource
     }
 
     /**
+     * Create a new anonymous JSON:API resource collection.
+     *
+     * @param  mixed  $resource
+     * @return \Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection
+     */
+    #[\Override]
+    public static function collection($resource)
+    {
+        return parent::collection($resource);
+    }
+
+    /**
      * Create a new resource collection instance.
      *
      * @param  mixed  $resource

--- a/types/Http/Resources/JsonApi/JsonApiResource.php
+++ b/types/Http/Resources/JsonApi/JsonApiResource.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+use function PHPStan\Testing\assertType;
+
+assertType(
+    'Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection',
+    JsonApiResource::collection([]),
+);


### PR DESCRIPTION
I used OpenAI Codex to assist with investigating and preparing this change.
I encountered the issue in a Laravel 13 application using Larastan/PHPStan at level 7. A controller returning JsonApi\AnonymousResourceCollection was reported as receiving the broader Json\AnonymousResourceCollection.

This pull request narrows the advertised return type of JSON:API resource collections.

JsonApiResource overrides newCollection() to create a JsonApi\AnonymousResourceCollection, but inherits the public collection() PHPDoc from JsonResource. Static analysis therefore reports the broader Json\AnonymousResourceCollection even though the runtime result is always the JSON:API subclass.

The new PHPDoc-only override delegates to the parent implementation, preserving Laravel's existing collection creation and key-preservation behavior. Avoiding a native return type also keeps this change backward compatible with application resources that may already override collection().

This allows controllers and other consumers to use the precise JSON:API collection return type without application-level bridge classes, casts, or suppressions. A max-level PHPStan type fixture covers the inferred return type.

Verified with:

- vendor/bin/phpstan analyse --configuration=phpstan.types.neon.dist --no-progress types/Http/Resources/JsonApi/JsonApiResource.php
- vendor/bin/phpstan analyse --configuration=phpstan.src.neon.dist --no-progress src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
- vendor/bin/phpunit tests/Http/Resources/JsonApi/JsonApiResourceTest.php
- vendor/bin/phpunit tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
- vendor/bin/pint --test src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php types/Http/Resources/JsonApi/JsonApiResource.php
