### PR TITLE
[13.x] Fix nested includes not being limited when maxRelationshipDepth is zero

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -78,7 +78,7 @@ class JsonApiRequest extends Request
                         return null;
                     }
 
-                    $item = implode('.', Arr::take(explode('.', $item), JsonApiResource::$maxRelationshipDepth - 1));
+                    $item = implode('.', Arr::take(explode('.', $item), max(0, JsonApiResource::$maxRelationshipDepth - 1)));
 
                     return ! empty($item) ? $item : null;
                 })->filter()->all();

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
@@ -80,6 +80,20 @@ class JsonApiRequestTest extends TestCase
         $this->assertSame(['user'], $request->sparseIncluded('profile'));
     }
 
+    public function testItDropsNestedSparseIncludedWithZeroMaxRelationshipNesting()
+    {
+        JsonApiResource::maxRelationshipDepth(0);
+
+        $request = JsonApiRequest::create(uri: '/?'.http_build_query([
+            'include' => 'teams,posts.author,profile.user.profile',
+        ]));
+
+        $this->assertSame(['teams', 'posts', 'profile'], $request->sparseIncluded());
+        $this->assertSame([], $request->sparseIncluded('teams'));
+        $this->assertSame([], $request->sparseIncluded('posts'));
+        $this->assertSame([], $request->sparseIncluded('profile'));
+    }
+
     public function testItCanResolveEmptySparseIncluded()
     {
         $request = JsonApiRequest::create(uri: '/');


### PR DESCRIPTION
Fixes #61280.

`maxRelationshipDepth(0)` is accepted by the setter (`max(0, $depth)`), but `sparseIncluded()` passes `$maxRelationshipDepth - 1` to `Arr::take()`, so the limit becomes `-1`. A negative limit takes from the *end* of the array instead of dropping segments:

| `?include=` | depth 0 (before) | depth 5 |
|---|---|---|
| `comments.author` | `comments.author` | `comments.author` |
| `comments.author.comments` | `comments.comments` -> `RelationNotFoundException` | `comments.author` |

Zero is therefore looser than one, and the only value that can throw.

Clamping the limit at zero makes depth 0 behave like depth 1 - the top-level relationship still passes (`sparseIncluded()` without a key returns `array_keys()` et never reads the limit), nested levels are dropped.
