### PR TITLE
[13.x] Resolve the dev command's NodePackageManager from the container

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -446,6 +446,6 @@ class DevCommands
      */
     protected static function getPackageManager(): NodePackageManager
     {
-        return self::$packageManager ??= new NodePackageManager();
+        return self::$packageManager ??= app(NodePackageManager::class);
     }
 }

--- a/tests/Foundation/Console/DevCommandTest.php
+++ b/tests/Foundation/Console/DevCommandTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Console\DevCommand;
 use Illuminate\Foundation\DevCommandMode;
 use Illuminate\Foundation\DevCommands;
+use Illuminate\Support\NodePackageManager;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -24,6 +25,8 @@ class DevCommandTest extends TestCase
             'autoRestart' => true,
             'bufferSize' => null,
             'streamBufferSize' => null,
+            'commands' => [],
+            'packageManager' => null,
         ] as $prop => $value) {
             $ref->getProperty($prop)->setValue(null, $value);
         }
@@ -187,6 +190,25 @@ class DevCommandTest extends TestCase
             '--timestamp-format="HH:mm:ss" -p "{time} [{name}]"',
             $this->command()->buildConcurrentlyCommandForTesting($this->devCommands())
         );
+    }
+
+    public function testNodeCommandsUseThePackageManagerResolvedFromTheContainer()
+    {
+        app()->instance(NodePackageManager::class, new class extends NodePackageManager
+        {
+            public function getRunCommand(string $command): string
+            {
+                return "custom-manager run {$command}";
+            }
+
+            public function getExecCommand(string $command): string
+            {
+                return "custom-manager exec {$command}";
+            }
+        });
+
+        $this->assertSame('custom-manager run dev', DevCommands::node('dev', 'vite')->toArray()['command']);
+        $this->assertSame('custom-manager exec vite', DevCommands::nodeExec('vite', 'bundler')->toArray()['command']);
     }
 
     protected function command(array $options = [])


### PR DESCRIPTION
Refs #61203.

`DevCommand::handle()` receives `NodePackageManager` through the container, so binding a custom implementation changes how multiplex/concurrently are executed. `DevCommands::getPackageManager()` instantiates it directly instead, so the same binding is ignored by `DevCommands::node()` and `nodeExec()` - including the built-in `vite` process registered by `registerDefaults()`.

The result is that overriding the package manager takes effect for part of `artisan dev` and not the rest. This resolves it from the container in both places. Default behaviour is unchanged: with no binding, the container builds the same `new NodePackageManager()`.
