### PR TITLE
[13.x] Eager load included relationships across the whole JSON:API resource collection

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Http\Resources\JsonApi;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection as BaseAnonymousResourceCollection;
@@ -44,9 +46,54 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
     #[\Override]
     public function toAttributes(Request $request)
     {
+        $this->eagerLoadRequestedRelationships($this->resolveJsonApiRequestFrom($request));
+
         return $this->collection
             ->map(fn ($resource) => $resource->resolveResourceData($request))
             ->all();
+    }
+
+    /**
+     * Eager load the requested relationships across every resource in the collection.
+     */
+    protected function eagerLoadRequestedRelationships(JsonApiRequest $request): void
+    {
+        if (empty($request->sparseIncluded())) {
+            return;
+        }
+
+        $models = new Collection(
+            $this->collection
+                ->pluck('resource')
+                ->filter(fn ($model) => $model instanceof Model)
+                ->all()
+        );
+
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $relationships = $this->collection
+            ->flatMap(fn ($resource) => $resource->resolveRelationshipsToEagerLoad($request))
+            ->unique()
+            ->flatMap(fn ($relationship) => $this->expandRequestedRelationship($request, $relationship))
+            ->all();
+
+        $models->loadMissing($relationships);
+    }
+
+    /**
+     * Expand a relationship into the nested relationships requested for it.
+     *
+     * @return array<int, string>
+     */
+    protected function expandRequestedRelationship(JsonApiRequest $request, string $relationship): array
+    {
+        $nested = $request->sparseIncluded($relationship);
+
+        return empty($nested)
+            ? [$relationship]
+            : array_map(fn ($path) => $relationship.'.'.$path, $nested);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -181,6 +181,36 @@ trait ResolvesJsonApiElements
     }
 
     /**
+     * Resolve the relationships requested for the resource.
+     */
+    protected function resolveRequestedRelationships(JsonApiRequest $request): Collection
+    {
+        $sparseIncluded = match (true) {
+            $this->includesPreviouslyLoadedRelationships => array_keys($this->resource->getRelations()),
+            default => $request->sparseIncluded(),
+        };
+
+        return (new Collection($this->toRelationships($request)))
+            ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
+            ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
+            ->only($sparseIncluded);
+    }
+
+    /**
+     * Resolve the relationships that should be eager loaded for the resource.
+     *
+     * @return array<int, string>
+     */
+    public function resolveRelationshipsToEagerLoad(JsonApiRequest $request): array
+    {
+        if (! $this->resource instanceof Model) {
+            return [];
+        }
+
+        return $this->resolveRequestedRelationships($request)->keys()->all();
+    }
+
+    /**
      * Compile resource relationships.
      */
     protected function compileResourceRelationships(JsonApiRequest $request): void
@@ -189,15 +219,7 @@ trait ResolvesJsonApiElements
             return;
         }
 
-        $sparseIncluded = match (true) {
-            $this->includesPreviouslyLoadedRelationships => array_keys($this->resource->getRelations()),
-            default => $request->sparseIncluded(),
-        };
-
-        $resourceRelationships = (new Collection($this->toRelationships($request)))
-            ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
-            ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
-            ->only($sparseIncluded);
+        $resourceRelationships = $this->resolveRequestedRelationships($request);
 
         $resourceRelationshipKeys = $resourceRelationships->keys();
 

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Http\Resources\JsonApi;
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Comment;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Profile;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Team;
@@ -204,5 +206,43 @@ class JsonApiCollectionTest extends TestCase
                     ],
                 ]
             );
+    }
+
+    public function testItEagerLoadsIncludedRelationshipsForTheWholeCollectionAtOnce()
+    {
+        $this->createPostsWithComments(5);
+
+        DB::enableQueryLog();
+
+        $this->getJson('/posts?'.http_build_query(['include' => 'comments']))
+            ->assertJsonCount(5, 'data')
+            ->assertJsonCount(5, 'included');
+
+        $this->assertCount(3, DB::getQueryLog());
+    }
+
+    public function testItEagerLoadsNestedIncludedRelationshipsForTheWholeCollectionAtOnce()
+    {
+        $this->createPostsWithComments(5);
+
+        DB::enableQueryLog();
+
+        $this->getJson('/posts?'.http_build_query(['include' => 'comments.commenter']))
+            ->assertJsonCount(5, 'data');
+
+        $this->assertCount(4, DB::getQueryLog());
+    }
+
+    protected function createPostsWithComments(int $count)
+    {
+        $user = User::factory()->create();
+
+        Post::factory()->times($count)->create(['user_id' => $user->getKey()])->each(
+            fn ($post) => Comment::factory()->create([
+                'content' => 'public',
+                'post_id' => $post->getKey(),
+                'user_id' => $user->getKey(),
+            ])
+        );
     }
 }


### PR DESCRIPTION
Fixes #61252.

`compileResourceRelationships()` calls `loadMissing()` on `$this->resource`, and that's always a single model. A resource collection just maps it over every item, so `?include=` ends up costing a query per record. The batching already exists one level down, the nested `loadMissing()` runs against a collection, it just never reached the outer level.

So this loads the requested relationships once for the whole collection before the items resolve, and the per-resource `loadMissing()` becomes a no-op.

6 posts and 7 users through a plain `toResourceCollection()` endpoint:

| request | before | after |
|---|---|---|
| no `include` | 1 | 1 |
| `?include=comments` | 7 | 2 |
| `?include=author,comments` | 13 | 3 |
| `?include=comments.commenter` | 10 | 3 |
| `?include=profile,teams` (users) | 15 | 3 |
| `?include=posts.comments.commenter` (users) | 10 | 4 |

Constant now instead of growing per record.

Response bodies come out byte-identical before and after on all of those, I dumped both and diffed them. That covers the case where a relationship closure filters rows out (`PostResource::comments` drops the `private` ones), which was the bit I was most worried about.

Couple of scope notes. I expand nested paths (`comments.commenter`) instead of just top level names, otherwise the nested level is still one query per parent. And I only hooked `toAttributes()`, not `with()`, since `resolve()` runs first in both `ResourceResponse` and `PaginatedResourceResponse` and `compileResourceRelationships()` only runs once per resource anyway, so that covers it.

Full suite green, Pint clean, PHPStan unchanged (same 4 pre-existing errors in `Connector.php`, `MySqlSchemaState.php` and `Route.php`).
