### PR TITLE
[13.x] Fix flaky memcached touch test by pinning time

### DIFF
--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -64,7 +64,7 @@ class CacheMemcachedStoreTest extends TestCase
         $key = 'key';
         $ttl = 60;
 
-        $now = Carbon::now();
+        Carbon::setTestNow($now = Carbon::now());
 
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['touch'])->getMock();
 


### PR DESCRIPTION
`CacheMemcachedStoreTest::testTouchMethodProperlyCallsMemcache` (added in #55954) computes its expected expiration from a live `Carbon::now()`, and `MemcachedStore::touch()` then reads the clock a second time through `availableAt()`. When the second boundary falls between those two reads, the expectation fails by one second:

```
Parameter 1 for invocation Memcached::touch('key', 1787477094): bool does not match expected value.
Failed asserting that 1787477094 matches expected 1787477093.
```

It flaked exactly this way on the PHP 8.3 / PHPUnit 12.5.8 / prefer-stable job of #61291, which touches nothing near the cache layer.

Until #60761 the flake was masked by accident: `testSetMethodProperlyCallsMemcache` runs earlier in the same file and pins `Carbon::setTestNow()` without unpinning, so the touch test usually saw frozen time. Now that fake time is reset globally after every test, the touch test always races the real clock.

### Change

Pin time inside the touch test itself, the same way the set test in this file does:

```php
Carbon::setTestNow($now = Carbon::now());
```

No cleanup line, per #60761 — the global `AfterEachTestSubscriber` resets fake time after each test.

### Verification

With a stub `Memcached` and a forced 600 ms delay between the two clock reads, the current test shape mismatches 3 times out of 5 runs; with the pin, 0 out of 5. The store still calls `Memcached::touch()` with `availableAt($seconds)` — the assertion now just evaluates both sides against the same frozen clock.
