### PR TITLE
[13.x] Release the hasNested() recursion closure to break Builder reference cycle

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -114,7 +114,14 @@ trait QueriesRelationships
                 : $q->has(array_shift($relations), $operator, $count, 'and', $callback);
         };
 
-        return $this->has(array_shift($relations), $doesntHave ? '<' : '>=', 1, $boolean, $closure);
+        // The closure references itself so that it can recurse, which forms a reference
+        // cycle that would keep this builder alive until the cycle collector runs. It is
+        // only invoked within this "has" call, so we release it once the call returns...
+        try {
+            return $this->has(array_shift($relations), $doesntHave ? '<' : '>=', 1, $boolean, $closure);
+        } finally {
+            $closure = null;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -24,6 +24,7 @@ use Mockery;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use WeakReference;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
@@ -1737,6 +1738,35 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $model->has('foo.bar')->toSql();
 
         $this->assertEquals($builder->toSql(), $result);
+    }
+
+    public function testHasNestedDoesNotLeaveBuilderReferenceCycle()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        $builders = [
+            fn () => $model->has('foo.bar'),
+            fn () => $model->whereHas('foo.bar', fn ($q) => $q->where('baz', 'bam')),
+            fn () => $model->where('bar', 'baz')->orWhereHas('foo.bar'),
+            fn () => $model->doesntHave('foo.bar'),
+        ];
+
+        gc_disable();
+
+        try {
+            foreach ($builders as $makeBuilder) {
+                $builder = $makeBuilder();
+
+                $reference = WeakReference::create($builder);
+
+                unset($builder);
+
+                $this->assertNull($reference->get());
+            }
+        } finally {
+            gc_enable();
+        }
     }
 
     public function testHasNestedWithMorphTo()


### PR DESCRIPTION
> Resubmission of #61291, which was closed after its CI run failed on the flaky `CacheMemcachedStoreTest::testTouchMethodProperlyCallsMemcache` (unrelated to this change; test fix proposed in #61301). The diff is identical.

`QueriesRelationships::hasNested()` handles every dotted relation constraint — `has('foo.bar')`, `whereHas('foo.bar')`, `orWhereHas('foo.bar')`, `doesntHave('foo.bar')` / `whereDoesntHave('foo.bar')`. To recurse over the segments it builds a closure that captures **itself by reference** (`use (&$closure, …)`), which is a reference cycle by construction, and because the closure is non-static it is also bound to the builder:

```
Closure → use (&$closure) → Closure
Closure → $this (Builder)
```

The closure is passed to `has()` and only ever invoked inside that call, but the cycle keeps it — and the builder it is bound to, together with the model, base query, bindings, eager-load configuration and the nested `exists` sub-queries — reachable after `hasNested()` has returned. The builder is therefore no longer released by refcounting when the last external reference goes away: it survives `unset()` until the cycle collector runs. Single-level `whereHas()` and manually nested constraints (`whereHas('foo', fn ($q) => $q->whereHas('bar'))`) never go through `hasNested()` and are freed immediately. In long-running processes (queue workers, Octane) every dotted relation constraint thus becomes garbage that accumulates until the GC root buffer fills.

This is the same cycle class as #61264 (eager-load constraint closures), which does not cover this closure. Making it `static` would not be enough here either — the self-reference is a cycle on its own, so it is the captured reference that has to be released.

### Change

Release the closure once the outer `has()` call has returned:

```php
try {
    return $this->has(array_shift($relations), $doesntHave ? '<' : '>=', 1, $boolean, $closure);
} finally {
    $closure = null;
}
```

The closure is only invoked within that `has()` call — once per nesting level, and once more per morph type when the first segment is a `MorphTo` (which is what the `$initialRelations` reset branch exists for) — so nothing can observe it after the call returns and there is no behavioural change: the generated SQL is identical and the existing `testHasNested*` / `testDoesntHaveNested` tests pass unchanged.

### Verification

On `13.x` before this change (`WeakReference` probe with `gc_disable()`, sqlite in memory):

```
->whereHas('foo')                                  after unset: freed
->whereHas('foo', fn ($q) => $q->whereHas('bar'))  after unset: freed
->has('foo.bar')                                   after unset: ALIVE   after gc_collect_cycles: freed (26 values collected)
->whereHas('foo.bar', fn ($q) => $q->where(...))   after unset: ALIVE   after gc_collect_cycles: freed (31 values collected)
->orWhereHas('foo.bar')                            after unset: ALIVE   after gc_collect_cycles: freed (28 values collected)
->doesntHave('foo.bar')                            after unset: ALIVE   after gc_collect_cycles: freed (26 values collected)
```

After this change every case is freed on `unset()`.

The new `testHasNestedDoesNotLeaveBuilderReferenceCycle` asserts this via `WeakReference` with the cycle collector disabled for the duration of the test, so it cannot pass by accident; it covers `has()`, `whereHas()` with a callback, `orWhereHas()` and `doesntHave()` on a dotted relation. It fails on `13.x` without this change and passes with it; `tests/Database` is green.

As with #61264 this is not a hard leak — the cycle collector does eventually reclaim the objects — but it moves collection forward from the GC to refcounting. In our own queue workers one scheduled job that runs eight dotted `whereHas` queries per tenant left ~10,500 values (≈4.8 MB) to the collector on every run; with this change it leaves none.
