### PR TITLE
[13.x] Fix images created from a stream failing on the second read

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -54,13 +54,34 @@ class Image implements Responsable, Stringable
     protected ?string $hashName = null;
 
     /**
+     * The image contents, or a lazy loader that resolves them.
+     */
+    protected Closure|string $contents;
+
+    /**
      * Create a new image instance.
      */
     public function __construct(
-        protected Closure|string $contents,
+        Closure|string $contents,
         protected ?UploadedFile $file = null,
     ) {
+        $this->contents = $contents instanceof Closure
+            ? $this->resolveOnce($contents)
+            : $contents;
+
         $this->pipeline = new ImagePipeline;
+    }
+
+    /**
+     * Wrap a lazy contents loader so it is invoked at most once, even across clones.
+     */
+    protected function resolveOnce(Closure $loader): Closure
+    {
+        return function () use ($loader) {
+            static $contents;
+
+            return $contents ??= $loader();
+        };
     }
 
     /**

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -44,6 +44,11 @@ class Image implements Responsable, Stringable
     protected ?string $driver = null;
 
     /**
+     * The image contents, or a lazy loader that resolves them.
+     */
+    protected Closure|string $contents;
+
+    /**
      * Whether the image has been processed.
      */
     protected bool $processed = false;
@@ -52,11 +57,6 @@ class Image implements Responsable, Stringable
      * The cached hash name.
      */
     protected ?string $hashName = null;
-
-    /**
-     * The image contents, or a lazy loader that resolves them.
-     */
-    protected Closure|string $contents;
 
     /**
      * Create a new image instance.

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -227,6 +227,81 @@ class ImageManagerTest extends TestCase
         fclose($stream);
     }
 
+    public function test_from_stream_contents_are_only_read_once()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame([100, 100], $image->dimensions());
+
+        fclose($stream);
+    }
+
+    public function test_from_stream_contents_are_shared_between_clones()
+    {
+        $contents = $this->fakeImageContents();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+        $image = $manager->fromStream($stream);
+
+        $first = $image->usingGd();
+        $second = $image->usingImagick();
+
+        $this->assertSame($contents, $first->toBytes());
+        $this->assertSame($contents, $second->toBytes());
+
+        fclose($stream);
+    }
+
+    public function test_lazy_contents_are_not_shared_between_different_images()
+    {
+        $app = $this->makeApp([]);
+        $manager = new ImageManager($app);
+
+        $first = $manager->fromBase64(base64_encode('first'));
+        $second = $manager->fromBase64(base64_encode('second'));
+
+        $this->assertSame('first', $first->toBytes());
+        $this->assertSame('second', $second->toBytes());
+        $this->assertSame('first', $first->toBytes());
+    }
+
+    public function test_from_url_is_only_fetched_once()
+    {
+        $contents = $this->fakeImageContents();
+
+        $http = new HttpFactory;
+        $http->fake([
+            'https://example.com/photo.jpg' => HttpFactory::response($contents, 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+
+        $app = $this->makeApp([]);
+        $app->shouldReceive('make')
+            ->with(HttpFactory::class)
+            ->andReturn($http);
+
+        $manager = new ImageManager($app);
+        $image = $manager->fromUrl('https://example.com/photo.jpg');
+
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame($contents, $image->toBytes());
+        $this->assertSame([100, 100], $image->dimensions());
+
+        $http->assertSentCount(1);
+    }
+
     public function test_from_stream_throws_for_invalid_data()
     {
         $stream = fopen('php://memory', 'r+');


### PR DESCRIPTION
Resubmitting #61295 with the reproduction that was missing.

On a fresh Laravel app (or any `13.x` checkout):

```php
$stream = fopen('php://memory', 'r+');
fwrite($stream, file_get_contents('photo.jpg'));
rewind($stream);

Image::fromStream($stream)->width();
// Illuminate\Image\ImageException: Invalid stream image data.
```

`width()` reads the contents twice — once for the bytes, once for the mime type — because the lazy loader closure runs on every read instead of resolving once. The second `stream_get_contents()` on the exhausted stream returns `''` and throws. `store()` fails the same way, since it reads once for the hash name's extension and again to write the file. It isn't only streams: every read of a `fromUrl()` image is its own HTTP request (two for a single `dimensions()` call), and clones re-run the loader, so producing two sizes from one stream fails on the second one.

The constructor now wraps the loader so it runs at most once, with the result shared by clones. Loading stays lazy, so the existing laziness tests pass unchanged. The four new tests fail on `13.x` without the src change.
