### PR TITLE
[13.x] Add Postgres keepalive DSN options

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -91,7 +91,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $dsn .= ";application_name='".str_replace("'", "\'", $application_name)."'";
         }
 
-        return $this->addSslOptions($dsn, $config);
+        return $this->addKeepaliveOptions($this->addSslOptions($dsn, $config), $config);
     }
 
     /**
@@ -104,6 +104,24 @@ class PostgresConnector extends Connector implements ConnectorInterface
     protected function addSslOptions($dsn, array $config)
     {
         foreach (['sslmode', 'sslcert', 'sslkey', 'sslrootcert'] as $option) {
+            if (isset($config[$option])) {
+                $dsn .= ";{$option}={$config[$option]}";
+            }
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * Add the keepalive options to the DSN.
+     *
+     * @param  string  $dsn
+     * @param  array  $config
+     * @return string
+     */
+    protected function addKeepaliveOptions($dsn, array $config)
+    {
+        foreach (['keepalives', 'keepalives_idle', 'keepalives_interval', 'keepalives_count'] as $option) {
             if (isset($config[$option])) {
                 $dsn .= ";{$option}={$config[$option]}";
             }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -202,6 +202,38 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresKeepaliveOptionsAreSet()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111;keepalives=1;keepalives_idle=600;keepalives_interval=30;keepalives_count=5';
+        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'keepalives' => 1, 'keepalives_idle' => 600, 'keepalives_interval' => 30, 'keepalives_count' => 5];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = Mockery::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
+        $statement = Mockery::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresKeepaliveOptionsAreOmittedWhenNotConfigured()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111;keepalives_idle=600';
+        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'keepalives_idle' => 600];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = Mockery::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
+        $statement = Mockery::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresApplicationUseAlternativeDatabaseName()
     {
         $dsn = 'pgsql:dbname=\'baz\'';


### PR DESCRIPTION
 Long-lived Postgres connections - the kind a queue worker holds open between jobs - can be silently dropped by a firewall or load balancer after an idle timeout, with neither end being told. The next job then fails on a connection that looks alive but isn't. libpq supports TCP keepalives to prevent this, but PostgresConnector currently drops those keys from the DSN, so the only workaround is subclassing the connector. This adds keepalives, keepalives_idle, keepalives_interval, and keepalives_count as connection config keys, following the same pattern as the existing SSL options.