### PR TITLE
[13.x] Treat asterisks as literal keys when merging request input

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -391,7 +391,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         return tap($this, function (Request $request) use ($input) {
             $request->getInputSource()
                 ->replace((new Collection($input))->reduce(
-                    fn ($requestInput, $value, $key) => data_set($requestInput, $key, $value),
+                    function ($requestInput, $value, $key) {
+                        Arr::set($requestInput, $key, $value);
+
+                        return $requestInput;
+                    },
                     $this->getInputSource()->all()
                 ));
         });

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1216,6 +1216,39 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeMethodTreatsAsterisksAsLiteralKeys()
+    {
+        $request = Request::create('/', 'GET', []);
+        $request->merge(['*' => 226]);
+        $this->assertSame(226, $request->all()['*']);
+
+        $request = Request::create('/', 'GET', ['organisation_id' => 10, 'name' => 'Taylor']);
+        $request->merge(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
+
+        $request = Request::create('/', 'GET', ['profile' => ['name' => 'Taylor', 'email' => 'taylor@laravel.com']]);
+        $request->merge(['profile.*' => 'masked']);
+        $this->assertSame('Taylor', $request->input('profile.name'));
+        $this->assertSame('taylor@laravel.com', $request->input('profile.email'));
+        $this->assertSame('masked', $request->all()['profile']['*']);
+
+        $request = Request::create('/', 'GET', ['profile' => ['name' => 'Taylor', 'email' => 'taylor@laravel.com']]);
+        $request->merge(['profile.name' => 'Otwell']);
+        $this->assertSame('Otwell', $request->input('profile.name'));
+        $this->assertSame('taylor@laravel.com', $request->input('profile.email'));
+    }
+
+    public function testMergeMethodTreatsAsterisksAsLiteralKeysOnJsonRequests()
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['organisation_id' => 10, 'name' => 'Taylor']));
+        $request->merge(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
+    }
+
     public function testMergeIfMissingMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
@@ -1239,6 +1272,15 @@ class HttpRequestTest extends TestCase
         $merge = ['user.first_name' => 'John'];
         $request->mergeIfMissing($merge);
         $this->assertSame('Taylor', $request->input('user.first_name'));
+    }
+
+    public function testMergeIfMissingMethodTreatsAsterisksAsLiteralKeys()
+    {
+        $request = Request::create('/', 'GET', ['organisation_id' => 10, 'name' => 'Taylor']);
+        $request->mergeIfMissing(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
     }
 
     public function testReplaceMethod()


### PR DESCRIPTION
`Request::merge()` (and therefore `mergeIfMissing()`) passes each incoming key through `data_set()`, which interprets `*` as a wildcard rather than a literal key. As a result, merging input that contains a literal `*` key overwrites every existing value at that depth instead of adding the key — or silently drops the key when the request body is empty. This PR switches the reducer to `Arr::set()`, which treats dot-notation paths literally while preserving the existing nested-merge behavior. Regression tests are included for top-level and nested literal `*` keys, `mergeIfMissing()`, JSON input, and the empty-body case.

### Reproduction

Given the current request body:

```php
[
    'organisation_id' => 10,
    'name' => 'Taylor',
]
```

merging the following payload:

```php
$request->merge(['*' => 226]);
```

### Expected behavior

The `*` key is a literal input key, so it should simply be added alongside the existing values:

```php
[
    'organisation_id' => 10, // preserved
    'name' => 'Taylor',      // preserved
    '*' => 226,
]
```

### Current behavior

`data_set()` expands `*` as a wildcard over the existing input, so every value at that level is overwritten and the `*` key itself is never stored:

```php
[
    'organisation_id' => 226, // incorrectly overwritten
    'name' => 226,            // incorrectly overwritten
]
```

The same applies even when merging into an empty request body: `Request::create('/', 'GET', [])->merge(['*' => 226])` produces `[]` — the wildcard finds nothing to expand over and the key is silently discarded. Nested variants such as `profile.*` behave the same way, overwriting every value under `profile`.

### Root cause

The reducer in `Illuminate\Http\Request::merge()` uses `data_set($requestInput, $key, $value)`. `data_set()` is a retrieval/assignment helper with wildcard semantics: a `*` segment means "every element at this level". Request input keys coming from a client are data, not path expressions, so a payload key that happens to be `*` (or contain `.*`) is expanded instead of being stored literally.

### Fix

Replace `data_set()` with `Arr::set()` in the reducer:

```php
$request->getInputSource()
    ->replace((new Collection($input))->reduce(
        function ($requestInput, $value, $key) {
            Arr::set($requestInput, $key, $value);

            return $requestInput;
        },
        $this->getInputSource()->all()
    ));
```

`Arr::set()` supports the same dot-notation deep assignment (`profile.name` still creates/updates the nested key) but treats every segment — including `*` — as a literal key, which is the correct semantic for merging request input. Note the reducer returns `$requestInput` explicitly rather than returning `Arr::set()` directly, because `Arr::set()` returns the innermost nested array for dotted keys, not the root array.

### Backward compatibility

- Dot-notation merging is unchanged: `merge(['profile.name' => 'Otwell'])` still updates the nested key, and `mergeIfMissing(['user.last_name' => 'Otwell'])` still behaves as before (covered by the existing `testMergeMethod` / `testMergeIfMissingMethod` tests, which still pass).
- The only behavioral change is for keys containing `*`, where the previous wildcard expansion destroyed or dropped data; those keys are now stored literally.
- `mergeIfMissing()` benefits automatically since it delegates to `merge()`.

### Tests

New regression tests in `tests/Http/HttpRequestTest.php`:

- `testMergeMethodTreatsAsterisksAsLiteralKeys` — top-level `*` (including into an empty body), nested `profile.*`, and unchanged `profile.name` dot-notation merging.
- `testMergeMethodTreatsAsterisksAsLiteralKeysOnJsonRequests` — same literal handling for JSON input sources.
- `testMergeIfMissingMethodTreatsAsterisksAsLiteralKeys` — `mergeIfMissing(['*' => 226])` stores the key literally.

Results:

- `vendor/bin/phpunit tests/Http/HttpRequestTest.php` — OK, 150 tests, 619 assertions (2 pre-existing PHPUnit notices, also present on a clean `13.x` checkout).
- `vendor/bin/phpunit tests/Http` — OK, 611 tests, 1765 assertions, 6 skipped (same pre-existing notices).
- The 3 new tests fail against the unpatched `13.x` code and pass with this change.
- `vendor/bin/pint --test` on both changed files — passed.
- `vendor/bin/phpstan analyse src/Illuminate/Http/Request.php -c phpstan.src.neon.dist` — no errors.
