### PR TITLE
[13.x] Treat asterisks as literal keys when merging request input

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -391,7 +391,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         return tap($this, function (Request $request) use ($input) {
             $request->getInputSource()
                 ->replace((new Collection($input))->reduce(
-                    fn ($requestInput, $value, $key) => data_set($requestInput, $key, $value),
+                    function ($requestInput, $value, $key) {
+                        Arr::set($requestInput, $key, $value);
+
+                        return $requestInput;
+                    },
                     $this->getInputSource()->all()
                 ));
         });

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1216,6 +1216,39 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeMethodTreatsAsterisksAsLiteralKeys()
+    {
+        $request = Request::create('/', 'GET', []);
+        $request->merge(['*' => 226]);
+        $this->assertSame(226, $request->all()['*']);
+
+        $request = Request::create('/', 'GET', ['organisation_id' => 10, 'name' => 'Taylor']);
+        $request->merge(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
+
+        $request = Request::create('/', 'GET', ['profile' => ['name' => 'Taylor', 'email' => 'taylor@laravel.com']]);
+        $request->merge(['profile.*' => 'masked']);
+        $this->assertSame('Taylor', $request->input('profile.name'));
+        $this->assertSame('taylor@laravel.com', $request->input('profile.email'));
+        $this->assertSame('masked', $request->all()['profile']['*']);
+
+        $request = Request::create('/', 'GET', ['profile' => ['name' => 'Taylor', 'email' => 'taylor@laravel.com']]);
+        $request->merge(['profile.name' => 'Otwell']);
+        $this->assertSame('Otwell', $request->input('profile.name'));
+        $this->assertSame('taylor@laravel.com', $request->input('profile.email'));
+    }
+
+    public function testMergeMethodTreatsAsterisksAsLiteralKeysOnJsonRequests()
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['organisation_id' => 10, 'name' => 'Taylor']));
+        $request->merge(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
+    }
+
     public function testMergeIfMissingMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
@@ -1239,6 +1272,15 @@ class HttpRequestTest extends TestCase
         $merge = ['user.first_name' => 'John'];
         $request->mergeIfMissing($merge);
         $this->assertSame('Taylor', $request->input('user.first_name'));
+    }
+
+    public function testMergeIfMissingMethodTreatsAsterisksAsLiteralKeys()
+    {
+        $request = Request::create('/', 'GET', ['organisation_id' => 10, 'name' => 'Taylor']);
+        $request->mergeIfMissing(['*' => 226]);
+        $this->assertSame(10, $request->input('organisation_id'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(226, $request->all()['*']);
     }
 
     public function testReplaceMethod()


### PR DESCRIPTION
`Request::merge(['*' => 226])` wipes out the whole input array instead of just adding a `*` key. The reducer runs each key through `data_set()`, which treats `*` as a wildcard, so every existing value at that level gets overwritten (and merging into an empty body drops the key entirely). Nested keys like `profile.*` do the same thing to everything under `profile`.

Funnily enough, this was introduced by me at https://github.com/laravel/framework/pull/52242 😶‍🌫️ on July 29, 2024.

So given this request:

```php
$request = Request::create('/', 'GET', ['organisation_id' => 10, 'name' => 'Taylor']);

$request->merge(['*' => 226]);
```

you'd expect `organisation_id` and `name` to be preserved and `*` added alongside them. Instead both get overwritten with `226` and the `*` key is never stored.

The fix swaps `data_set()` for `Arr::set()` in the reducer. `Arr::set()` still handles dot notation for genuine nested merges (`merge(['profile.name' => 'Otwell'])` keeps working), but treats `*` as a literal key. The closure returns `$requestInput` explicitly rather than returning `Arr::set()` directly, since for dotted keys `Arr::set()` returns the innermost nested array, not the root.

```php
$request->getInputSource()
    ->replace((new Collection($input))->reduce(
        function ($requestInput, $value, $key) {
            Arr::set($requestInput, $key, $value);

            return $requestInput;
        },
        $this->getInputSource()->all()
    ));
```

The only behavioral change is for keys containing `*`, which used to destroy or drop data and are now stored literally. `mergeIfMissing()` gets the fix for free since it delegates to `merge()`. Existing merge tests still pass, and I've added regression tests for the literal `*`, nested `profile.*`, `mergeIfMissing()`, JSON input, and empty-body cases.
