### PR TITLE
[13.x] Escape double quotes in component attributes as HTML entities

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -499,7 +499,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            $string .= ' '.$key.'="'.str_replace('"', '&quot;', trim($value)).'"';
         }
 
         return trim($string);

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -137,6 +137,13 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('style="color: blue;"', (string) $bag->merge([]));
     }
 
+    public function testDoubleQuotesAreEscapedAsHtmlEntities()
+    {
+        $bag = new ComponentAttributeBag(['title' => '6" pipe']);
+
+        $this->assertSame('title="6&quot; pipe"', (string) $bag);
+    }
+
     public function testAttributeRetrievalUsingDotNotation()
     {
         $bag = new ComponentAttributeBag([


### PR DESCRIPTION
`ComponentAttributeBag::__toString()` currently replaces double quotes in attribute values with `\"`.

Backslashes do not escape quotes in HTML, causing static Blade component attributes containing double quotes to produce malformed markup.

For example:

```blade
{{-- resources/views/components/plain-echo.blade.php --}}
<div {{ $attributes }}>{{ $slot }}</div>
```

```blade
<x-plain-echo title='6" pipe'>S</x-plain-echo>
```

This currently renders:

```html
<div title="6\" pipe">S</div>
```

An HTML parser reads the `title` value as `6\`, because the quote terminates the attribute value. Bound attributes do not have this problem because they pass through `BladeCompiler::sanitizeComponentAttribute()` and render the quote as `&quot;`.

This PR replaces the invalid backslash escape with the equivalent HTML entity:

```html
<div title="6&quot; pipe">S</div>
```

Using `e()` inside `ComponentAttributeBag::__toString()` would double-encode values already sanitized by bound attributes and `merge()`. Replacing only literal double quotes preserves existing encoded values.

A regression test was added to `ViewComponentAttributeBagTest`.

A similar change was proposed in #56877, which was closed before review and did not include regression coverage.

Tests:

```text
vendor/bin/phpunit tests/View/ViewComponentAttributeBagTest.php
vendor/bin/phpunit tests/View
```
