### PR TITLE
[13.x] Add macroable to CloudManager

### DIFF
--- a/src/Illuminate/Foundation/Cloud/CloudManager.php
+++ b/src/Illuminate/Foundation/Cloud/CloudManager.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Foundation\Cloud;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
 class CloudManager
 {
+    use Macroable;
+
     /**
      * Create a new Laravel Cloud manager instance.
      */

--- a/tests/Foundation/Cloud/CloudManagerTest.php
+++ b/tests/Foundation/Cloud/CloudManagerTest.php
@@ -33,4 +33,11 @@ class CloudManagerTest extends TestCase
     {
         $this->assertInstanceOf(CloudManager::class, Cloud::getFacadeRoot());
     }
+
+    public function testCloudManagerIsMacroable()
+    {
+        CloudManager::macro('foo', fn () => 'bar');
+
+        $this->assertSame('bar', Cloud::foo());
+    }
 }


### PR DESCRIPTION
Was poking the 13.x-dev branch, would be dope to make this macroable for something like..

```php
  Cloud::macro('isManagingQueue', function (string $queue) {
      return Cloud::hosted()
          && Cloud::usesManagedQueues()
          && in_array($queue, Cloud::queue()->managedQueues());
  });
``` 

So, I can just:
```php
  if (Cloud::isManagingQueue('emails')) {
```
 I went for a macro for now as still exploring what feels right 😆 

Thanks!!