### PR TITLE
[13.x] Treat asterisks as literal keys when merging URI query parameters

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -263,7 +263,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
             $mergedQuery = $this->query()->all();
 
             foreach ($query as $key => $value) {
-                data_set($mergedQuery, $key, $value);
+                Arr::set($mergedQuery, $key, $value);
             }
 
             $newQuery = $mergedQuery;
@@ -271,7 +271,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
             $newQuery = [];
 
             foreach ($query as $key => $value) {
-                data_set($newQuery, $key, $value);
+                Arr::set($newQuery, $key, $value);
             }
         }
 

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -183,6 +183,32 @@ class SupportUriTest extends TestCase
         $this->assertSame('foo[bar]=zab', $uri->replaceQuery(['foo.bar' => 'zab'])->query()->decode());
     }
 
+    public function test_query_strings_with_asterisks_are_treated_as_literal_keys()
+    {
+        $uri = Uri::of('https://laravel.com/?role=user&tenant=10');
+
+        $this->assertEquals(['role' => 'user', 'tenant' => '10', '*' => 'admin'], $uri->withQuery(['*' => 'admin'])->query()->all());
+
+        $uri = Uri::of('https://laravel.com/');
+
+        $this->assertEquals(['*' => 'admin'], $uri->withQuery(['*' => 'admin'])->query()->all());
+
+        $uri = Uri::of('https://laravel.com/?filter[name]=taylor&filter[role]=user');
+
+        $this->assertEquals(['filter' => ['name' => 'taylor', 'role' => 'user', '*' => 'masked']], $uri->withQuery(['filter.*' => 'masked'])->query()->all());
+
+        $uri = Uri::of('https://laravel.com/?role=user');
+
+        $this->assertEquals(['*' => 'admin'], $uri->withQuery(['*' => 'admin'], merge: false)->query()->all());
+    }
+
+    public function test_with_query_if_missing_treats_asterisks_as_literal_keys()
+    {
+        $uri = Uri::of('https://laravel.com/?role=user&tenant=10');
+
+        $this->assertEquals(['role' => 'user', 'tenant' => '10', '*' => 'admin'], $uri->withQueryIfMissing(['*' => 'admin'])->query()->all());
+    }
+
     public function test_decoding_the_entire_uri()
     {
         $uri = Uri::of('https://laravel.com/docs/11.x/installation')->withQuery(['tags' => ['first', 'second']]);


### PR DESCRIPTION
Same bug as #61309, one layer over. `Uri::withQuery()` feeds query keys through `data_set()`, so a literal `*` key clobbers every existing parameter instead of being added:

```php
Uri::of('https://example.com/?role=user&tenant=10')->withQuery(['*' => 'admin']);
// https://example.com/?role=admin&tenant=admin
```

The `merge: false` path builds the new query through `data_set()` too, so it's affected the same way, nested keys like `filter.*` overwrite everything under `filter`, and a query-less URI just drops the `*` key silently. This has been here since the `Uri` class landed in #53731.

The fix mirrors the request patch: `Arr::set()` instead of `data_set()` in both loops. Since `Arr::set()` mutates by reference, the loops stay exactly as they were. Dot notation for genuine nested keys (`withQuery(['foo.bar' => 'zab'])`) keeps working; only keys containing `*` change, and they're now stored literally. `withQueryIfMissing()` gets the fix for free since it delegates to `withQuery()`. Added regression tests for the top-level, nested, `merge: false`, and empty-query cases.
