### PR TITLE
[13.x] Treat literal dots in input keys correctly when rejecting unknown fields

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -15,7 +15,6 @@ use Illuminate\Foundation\Http\Attributes\RedirectToRoute;
 use Illuminate\Foundation\Http\Attributes\StopOnFirstFailure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use ReflectionClass;
 
@@ -233,13 +232,39 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         $input = $this->isJson() ? $this->json()->all() : $this->request->all();
 
-        foreach (array_keys(Arr::dot($input)) as $inputKey) {
+        foreach ($this->dotInputKeys($input) as $inputKey) {
             if (! $this->isKnownField($inputKey, $allowedKeys)) {
+                $inputKey = str_replace('\.', '.', $inputKey);
+
                 $validator->errors()->add($inputKey, trans('validation.prohibited', [
                     'attribute' => str_replace('_', ' ', $inputKey),
                 ]));
             }
         }
+    }
+
+    /**
+     * Flatten the given input's keys into dot notation, escaping literal dots within keys.
+     *
+     * @param  array  $input
+     * @param  string  $prefix
+     * @return array
+     */
+    protected function dotInputKeys(array $input, string $prefix = ''): array
+    {
+        $keys = [];
+
+        foreach ($input as $key => $value) {
+            $key = $prefix.str_replace('.', '\.', (string) $key);
+
+            if (is_array($value) && $value !== []) {
+                $keys = array_merge($keys, $this->dotInputKeys($value, $key.'.'));
+            } else {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
     }
 
     /**
@@ -262,7 +287,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             }
 
             if (str_contains($ruleKey, '*')) {
-                $pattern = '/^'.str_replace('\*', '[^.]+', preg_quote($ruleKey, '/')).'$/';
+                $pattern = '/^'.str_replace('\*', '(?:[^.\\\\]|\\\\.)+', preg_quote($ruleKey, '/')).'$/';
 
                 if (preg_match($pattern, $inputKey)) {
                     return true;

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -384,6 +384,62 @@ class FoundationFormRequestTest extends TestCase
         $this->assertTrue($exception->validator->errors()->has('items.0.name'));
     }
 
+    public function testFailOnUnknownFieldsRejectsLiteralDottedKeysOnlyMatchingNestedRules()
+    {
+        $request = $this->createRequest(
+            ['profile.name' => 'not-an-integer'],
+            FoundationTestFormRequestFailOnUnknownFieldsLiteralDotStub::class,
+            'POST'
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('profile.name'));
+    }
+
+    public function testFailOnUnknownFieldsRejectsLiteralDottedKeysOnlyMatchingWildcardRules()
+    {
+        $request = $this->createRequest(
+            ['items.0.id' => 'not-an-integer'],
+            FoundationTestFormRequestFailOnUnknownFieldsSometimesWildcardStub::class,
+            'POST'
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('items.0.id'));
+    }
+
+    public function testFailOnUnknownFieldsAllowsLiteralDottedKeysMatchingEscapedDotRules()
+    {
+        $request = $this->createRequest(
+            ['profile.name' => 'Taylor'],
+            FoundationTestFormRequestFailOnUnknownFieldsEscapedDotStub::class,
+            'POST'
+        );
+
+        $request->validateResolved();
+
+        $this->assertEquals(['profile.name' => 'Taylor'], $request->validated());
+    }
+
+    public function testFailOnUnknownFieldsAllowsNestedKeysContainingLiteralDotsMatchingWildcardRules()
+    {
+        $request = $this->createRequest(
+            ['items' => ['a.b' => 5]],
+            FoundationTestFormRequestFailOnUnknownFieldsSometimesSingleSegmentWildcardStub::class,
+            'POST'
+        );
+
+        $request->validateResolved();
+
+        $this->assertEquals(['items' => ['a.b' => 5]], $request->validated());
+    }
+
     public function testFailOnUnknownFieldsRejectsMultipleUnknownKeys()
     {
         $request = $this->createRequest(
@@ -921,6 +977,62 @@ class FoundationTestFormRequestFailOnUnknownFieldsSingleSegmentWildcardStub exte
     public function rules()
     {
         return ['items.*' => 'array'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsLiteralDotStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['profile.name' => 'sometimes|integer'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsEscapedDotStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['profile\.name' => 'sometimes|string'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsSometimesWildcardStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['items.*.id' => 'sometimes|integer'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsSometimesSingleSegmentWildcardStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['items.*' => 'sometimes|integer'];
     }
 
     public function authorize()


### PR DESCRIPTION
Update:
@taylorotwell I know you are currently reviewing PRs. Therefore, to grab your attention - please check your email. I have a serious security report that might need your immediate attention. The bug is reported responsibly to security@laravel.com and taylor@laravel.com. Let me know if you need extra assistence on reproducing it or etc.

If a request sends a key with a dot in its name, like `"profile.name"`, the unknown-field check added in #59430 mistakes it for a nested `profile[name]` field and lets it through as if it were known. But the validator reads it as a plain key with a dot in it, so the `profile.name` rule never runs against it. So the request passes, no rule was applied, and the raw value is still sitting there in `$request->all()`.

With unknown-field rejection on and `['profile.name' => 'sometimes|integer']` in the rules:

```json
{"profile.name": "not-an-integer"}
```

passes validation, and `$request->validated()` comes back empty. Wildcard rules like `items.*.id` have the same hole with a `"items.0.id"` key.

The cause is `validateNoUnknownFields()` flattening the input with `Arr::dot()`, which produces identical keys for a nested array and a literal dotted key. The validator, meanwhile, escapes literal dots inside keys (that's why the rule syntax for a literal key is `profile\.name`), so the two are comparing keys in different languages. The mismatch goes both ways: literal keys that only look like nested rules slip through, and a key that genuinely matches an escaped-dot rule (`'profile\.name' => 'string'`) gets wrongly rejected as unknown.

The fix flattens the input keys with literal dots escaped as `\.`, the same convention the rule keys use, so the check and the validator finally agree:

```php
protected function dotInputKeys(array $input, string $prefix = ''): array
{
    $keys = [];

    foreach ($input as $key => $value) {
        $key = $prefix.str_replace('.', '\.', (string) $key);

        if (is_array($value) && $value !== []) {
            $keys = array_merge($keys, $this->dotInputKeys($value, $key.'.'));
        } else {
            $keys[] = $key;
        }
    }

    return $keys;
}
```

Nested input still flattens to plain `profile.name`, so anything without literal dots in its keys behaves exactly as before. A literal `profile.name` key now becomes `profile\.name`, which no longer matches the nested rule (rejected, like the validator does) but matches an escaped `profile\.name` rule exactly (allowed). The wildcard match in `isKnownField()` is adjusted so a `*` segment can also cover an escaped dot, since the validator does apply single-segment wildcard rules to keys like `a.b` inside a nested array, and error keys are unescaped before hitting the error bag so users still see `profile.name`.
