### PR TITLE
[13.x] Guard against non-string mac in maintenance bypass cookie

### DIFF
--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -36,7 +36,7 @@ class MaintenanceModeBypassCookie
 
         return is_array($payload) &&
             is_numeric($payload['expires_at'] ?? null) &&
-            isset($payload['mac']) &&
+            is_string($payload['mac'] ?? null) &&
             hash_equals(hash_hmac('sha256', $payload['expires_at'], $key), $payload['mac']) &&
             (int) $payload['expires_at'] >= Carbon::now()->getTimestamp();
     }

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -257,6 +257,15 @@ class MaintenanceModeTest extends TestCase
         $this->assertFalse(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'test-key'));
     }
 
+    public function testBypassCookieWithMalformedMacIsInvalid()
+    {
+        foreach ([['mac' => []], ['mac' => ['nested']], ['expires_at' => 9999999999]] as $payload) {
+            $cookie = base64_encode(json_encode(array_merge(['expires_at' => 9999999999], $payload)));
+
+            $this->assertFalse(MaintenanceModeBypassCookie::isValid($cookie, 'test-key'));
+        }
+    }
+
     public function testDispatchEventWhenMaintenanceModeIsEnabled()
     {
         Event::fake();


### PR DESCRIPTION
`MaintenanceModeBypassCookie::isValid()` checks that the `mac` in the decoded cookie is set, but not that it's actually a string. If someone sends a `laravel_maintenance` cookie whose `mac` is an array, `isset()` still passes and the array is handed straight to `hash_equals()`, which throws a `TypeError`. While maintenance mode is active with a secret, that turns into an unauthenticated 500 instead of the expected 503.

Reproduction, using an array for `mac`:

```php
$cookie = base64_encode(json_encode(['expires_at' => 9999999999, 'mac' => []]));

MaintenanceModeBypassCookie::isValid($cookie, $key);
// TypeError: hash_equals(): Argument #2 must be of type string, array given
```

The fix swaps the `isset()` check for `is_string()`, matching the `is_numeric()` guard already used for `expires_at` right above it. A non-string `mac` now just fails validation and the request gets the normal 503.

```php
return is_array($payload) &&
    is_numeric($payload['expires_at'] ?? null) &&
    is_string($payload['mac'] ?? null) &&
    hash_equals(hash_hmac('sha256', $payload['expires_at'], $key), $payload['mac']) &&
    (int) $payload['expires_at'] >= Carbon::now()->getTimestamp();
```
