### PR TITLE
[13.x] Prevent loose comparisons in `doesnt_contain` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -588,7 +588,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value));
+        return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value, true));
     }
 
     /**

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -6,6 +6,7 @@ use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
@@ -85,5 +86,16 @@ class ValidationRuleDoesntContainTest extends TestCase
         // Test with nullable field
         $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::doesntContain('admin')]]);
         $this->assertTrue($v->passes());
+    }
+
+    #[TestWith([['0e123'], true])]
+    #[TestWith([['0'], false])]
+    public function testDoesntContainRuleDoesNotUseLooseComparisons(array $value, bool $expectation)
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => $value], ['x' => ['doesnt_contain:0']]);
+
+        $this->assertSame($expectation, $v->passes());
     }
 }


### PR DESCRIPTION
The `doesnt_contain` validation rule currently checks prohibited values with a loose `in_array()` comparison, so `["0e123"]` is treated as if it contains the prohibited value `"0"` and validation fails.

#61146 fixed the same numeric-string comparison issue for the `in` rule by enabling strict comparison. This applies that narrowly to `validateDoesntContain()` and adds regression coverage proving `"0e123"` passes while an exact `"0"` still fails. No other validation rules are changed.

Verification:

- `phpunit tests/Validation/ValidationRuleDoesntContainTest.php`
- `phpunit tests/Validation/ValidationRuleDoesntContainTest.php tests/Validation/ValidationRuleContainsTest.php tests/Validation/ValidationInRuleTest.php tests/Validation/ValidationNotInRuleTest.php tests/Validation/ValidationValidatorTest.php`
- `pint --test src/Illuminate/Validation/Concerns/ValidatesAttributes.php tests/Validation/ValidationRuleDoesntContainTest.php`