### PR TITLE
[13.x] Prevent loose comparison bypass in `in_array` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1582,7 +1582,7 @@ trait ValidatesAttributes
             return Str::is($parameters[0], $key);
         });
 
-        return in_array($value, $otherValues);
+        return in_array($value, $otherValues, true);
     }
 
     /**

--- a/tests/Validation/ValidationInArrayRuleTest.php
+++ b/tests/Validation/ValidationInArrayRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class ValidationInArrayRuleTest extends TestCase
+{
+    #[TestWith(['0e123456789', '0', false])]
+    #[TestWith(['1e0', '1', false])]
+    #[TestWith([1, '1', false])]
+    #[TestWith(['1', 1, false])]
+    #[TestWith([1, 1, true])]
+    #[TestWith(['1', '1', true])]
+    public function testInArrayRuleUsesStrictComparison(mixed $value, mixed $otherValue, bool $expectation)
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['value' => $value, 'other' => [$otherValue]], ['value' => 'in_array:other.*']);
+
+        $this->assertSame($expectation, $v->passes());
+    }
+}


### PR DESCRIPTION
The `in_array` validation rule currently uses non-strict `in_array()` comparison against values extracted from request data, so numeric-looking values such as `"1e0"` and `"0e123456789"` can match `"1"` and `"0"`.

Use strict comparison for this rule and add regression coverage for loose numeric-string matches while preserving exact matches. This follows the same fix and test shape as #61146 for the `in` rule.

Since `in_array` compares against request values rather than string rule parameters, the tests also verify that integer/string mismatches fail while exact integer and string matches continue to pass.