### PR TITLE
[13.x] Prevent loose comparison bypass in contains validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -571,7 +571,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($parameter) => in_array($parameter, $value));
+        return array_all($parameters, fn ($parameter) => in_array($parameter, $value, true));
     }
 
     /**

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
@@ -85,5 +86,25 @@ class ValidationRuleContainsTest extends TestCase
         // Test with nullable field
         $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::contains('admin')]]);
         $this->assertTrue($v->passes());
+    }
+
+    #[TestWith([' 1', '1', false])]
+    #[TestWith(['1 ', '1', false])]
+    #[TestWith(["\t1", '1', false])]
+    #[TestWith(["1\n", '1', false])]
+    #[TestWith(['01', '1', false])]
+    #[TestWith(['+1', '1', false])]
+    #[TestWith(['1.0', '1', false])]
+    #[TestWith(['1e0', '1', false])]
+    #[TestWith(['0e123', '0', false])]
+    #[TestWith(['1', '1', true])]
+    #[TestWith(['0', '0', true])]
+    public function testContainsRuleIsNotLooselyBypassed(mixed $value, string $parameter, bool $expectation)
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => [$value]], ['x' => ["contains:{$parameter}"]]);
+
+        $this->assertSame($expectation, $v->passes());
     }
 }


### PR DESCRIPTION
The `contains` validation rule currently uses non-strict `in_array()` comparison, so numeric-looking values such as `"1e0"` and `"0e123"` can satisfy `contains:1` and `contains:0`.

Use strict comparison for this rule and add regression coverage for loose numeric-string matches while preserving exact matches. This follows the same fix and test shape as #61146 for the `in` rule.