### PR TITLE
[13.x] Share cached AWS credentials across processes for SQS queue connections

### DIFF
--- a/src/Illuminate/Foundation/CloudBootstrapper.php
+++ b/src/Illuminate/Foundation/CloudBootstrapper.php
@@ -168,10 +168,7 @@ class CloudBootstrapper
     /**
      * Share cached AWS credentials across processes for all SQS queue connections.
      *
-     * Every PHP-FPM process resolving its own pod identity credentials can
-     * exceed the Pod Identity Agent's rate limit when many processes spawn at
-     * once, so caching defaults to enabled for every SQS connection whose
-     * credentials are resolved dynamically.
+     * Avoids Pod Identity Agent rate limiting.
      */
     public static function configureQueueCredentialCaching(Application $app): void
     {

--- a/src/Illuminate/Foundation/CloudBootstrapper.php
+++ b/src/Illuminate/Foundation/CloudBootstrapper.php
@@ -156,10 +156,10 @@ class CloudBootstrapper
             'delete_after_processing' => env('CLOUD_QUEUE_OVERFLOW_DELETE_AFTER_PROCESSING', true),
         ];
 
-        $config['connection']['credentials_cache'] ??= [
-            'enabled' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_ENABLED', true),
-            'store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_STORE'),
-            'fallback_store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_FALLBACK_STORE', 'file'),
+        $config['connection']['credential_cache'] ??= [
+            'enabled' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_ENABLED', true),
+            'store' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_STORE'),
+            'fallback_store' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_FALLBACK_STORE', 'file'),
         ];
 
         $app['config']->set('queue.connections.cloud', $config);
@@ -173,11 +173,11 @@ class CloudBootstrapper
     public static function configureQueueCredentialCaching(Application $app): void
     {
         foreach ($app['config']->get('queue.connections', []) as $name => $connection) {
-            if (($connection['driver'] ?? null) === 'sqs' && ! isset($connection['credentials_cache'])) {
-                $app['config']->set("queue.connections.{$name}.credentials_cache", [
-                    'enabled' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_ENABLED', true),
-                    'store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_STORE'),
-                    'fallback_store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_FALLBACK_STORE', 'file'),
+            if (($connection['driver'] ?? null) === 'sqs' && ! isset($connection['credential_cache'])) {
+                $app['config']->set("queue.connections.{$name}.credential_cache", [
+                    'enabled' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_ENABLED', true),
+                    'store' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_STORE'),
+                    'fallback_store' => env('CLOUD_QUEUE_CREDENTIAL_CACHE_FALLBACK_STORE', 'file'),
                 ]);
             }
         }

--- a/src/Illuminate/Foundation/CloudBootstrapper.php
+++ b/src/Illuminate/Foundation/CloudBootstrapper.php
@@ -39,6 +39,7 @@ class CloudBootstrapper
                 static::configureUnpooledPostgresConnection($app);
                 static::ensureMigrationsUseUnpooledConnection($app);
                 static::configureManagedQueues($app);
+                static::configureQueueCredentialCaching($app);
             },
             HandleExceptions::class => function () use ($app) {
                 static::configureCloudLogging($app);
@@ -155,7 +156,34 @@ class CloudBootstrapper
             'delete_after_processing' => env('CLOUD_QUEUE_OVERFLOW_DELETE_AFTER_PROCESSING', true),
         ];
 
+        $config['connection']['credentials_cache'] ??= [
+            'enabled' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_ENABLED', true),
+            'store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_STORE'),
+            'fallback_store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_FALLBACK_STORE', 'file'),
+        ];
+
         $app['config']->set('queue.connections.cloud', $config);
+    }
+
+    /**
+     * Share cached AWS credentials across processes for all SQS queue connections.
+     *
+     * Every PHP-FPM process resolving its own pod identity credentials can
+     * exceed the Pod Identity Agent's rate limit when many processes spawn at
+     * once, so caching defaults to enabled for every SQS connection whose
+     * credentials are resolved dynamically.
+     */
+    public static function configureQueueCredentialCaching(Application $app): void
+    {
+        foreach ($app['config']->get('queue.connections', []) as $name => $connection) {
+            if (($connection['driver'] ?? null) === 'sqs' && ! isset($connection['credentials_cache'])) {
+                $app['config']->set("queue.connections.{$name}.credentials_cache", [
+                    'enabled' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_ENABLED', true),
+                    'store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_STORE'),
+                    'fallback_store' => env('CLOUD_QUEUE_CREDENTIALS_CACHE_FALLBACK_STORE', 'file'),
+                ]);
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/AwsCredentialCache.php
+++ b/src/Illuminate/Queue/AwsCredentialCache.php
@@ -11,19 +11,12 @@ class AwsCredentialCache implements CacheInterface
     /**
      * The resolver for the backing cache repository.
      *
-     * The repository is resolved lazily on first use so that building a
-     * connection never touches the cache while the application is still
-     * bootstrapping.
-     *
      * @var \Closure(): \Illuminate\Contracts\Cache\Repository
      */
     protected $repository;
 
     /**
      * The resolver for the fallback cache repository, if any.
-     *
-     * The fallback is written through on every set so that it is already warm
-     * when the primary store becomes unavailable.
      *
      * @var \Closure(): \Illuminate\Contracts\Cache\Repository|null
      */

--- a/src/Illuminate/Queue/AwsCredentialCache.php
+++ b/src/Illuminate/Queue/AwsCredentialCache.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Aws\CacheInterface;
+use Closure;
+use Throwable;
+
+class AwsCredentialCache implements CacheInterface
+{
+    /**
+     * The resolver for the backing cache repository.
+     *
+     * The repository is resolved lazily on first use so that building a
+     * connection never touches the cache while the application is still
+     * bootstrapping.
+     *
+     * @var \Closure(): \Illuminate\Contracts\Cache\Repository
+     */
+    protected $repository;
+
+    /**
+     * The resolver for the fallback cache repository, if any.
+     *
+     * The fallback is written through on every set so that it is already warm
+     * when the primary store becomes unavailable.
+     *
+     * @var \Closure(): \Illuminate\Contracts\Cache\Repository|null
+     */
+    protected $fallback;
+
+    /**
+     * Create a new AWS credential cache.
+     *
+     * @param  \Closure(): \Illuminate\Contracts\Cache\Repository  $repository
+     * @param  \Closure(): \Illuminate\Contracts\Cache\Repository|null  $fallback
+     */
+    public function __construct(Closure $repository, ?Closure $fallback = null)
+    {
+        $this->repository = $repository;
+        $this->fallback = $fallback;
+    }
+
+    /**
+     * Get the cached credentials, treating an unavailable cache store as a miss.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        foreach ($this->repositories() as $repository) {
+            try {
+                if (! is_null($value = $repository()->get($key))) {
+                    return $value;
+                }
+            } catch (Throwable) {
+                //
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Store the credentials, silently ignoring unavailable cache stores.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $ttl
+     * @return void
+     */
+    public function set($key, $value, $ttl = 0)
+    {
+        foreach ($this->repositories() as $repository) {
+            try {
+                $ttl > 0
+                    ? $repository()->put($key, $value, (int) $ttl)
+                    : $repository()->forever($key, $value);
+            } catch (Throwable) {
+                //
+            }
+        }
+    }
+
+    /**
+     * Remove the cached credentials, silently ignoring unavailable cache stores.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function remove($key)
+    {
+        foreach ($this->repositories() as $repository) {
+            try {
+                $repository()->forget($key);
+            } catch (Throwable) {
+                //
+            }
+        }
+    }
+
+    /**
+     * Get the cache repository resolvers in order of preference.
+     *
+     * @return array<int, \Closure(): \Illuminate\Contracts\Cache\Repository>
+     */
+    protected function repositories()
+    {
+        return array_filter([$this->repository, $this->fallback]);
+    }
+}

--- a/src/Illuminate/Queue/AwsCredentialCache.php
+++ b/src/Illuminate/Queue/AwsCredentialCache.php
@@ -2,12 +2,37 @@
 
 namespace Illuminate\Queue;
 
-use Aws\CacheInterface;
+use Aws\Credentials\CredentialsInterface;
 use Closure;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\RejectedPromise;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockProvider;
 use Throwable;
 
-class AwsCredentialCache implements CacheInterface
+class AwsCredentialCache
 {
+    /**
+     * The number of seconds before expiration that credentials should be refreshed.
+     *
+     * @var int
+     */
+    protected const REFRESH_WINDOW = 60;
+
+    /**
+     * The number of seconds the credential refresh lock should be maintained.
+     *
+     * @var int
+     */
+    protected const LOCK_SECONDS = 15;
+
+    /**
+     * The number of seconds to wait for another process to refresh credentials.
+     *
+     * @var int
+     */
+    protected const LOCK_WAIT_SECONDS = 5;
+
     /**
      * The resolver for the backing cache repository.
      *
@@ -35,41 +60,125 @@ class AwsCredentialCache implements CacheInterface
     }
 
     /**
-     * Get the cached credentials, treating an unavailable cache store as a miss.
+     * Resolve credentials while sharing a single refresh across processes.
      *
      * @param  string  $key
-     * @return mixed
+     * @param  callable  $provider
+     * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function get($key)
+    public function resolve($key, callable $provider)
+    {
+        if ($credentials = $this->freshCredentials($key)) {
+            return Create::promiseFor($credentials);
+        }
+
+        foreach ($this->repositories() as $repository) {
+            try {
+                $store = $repository()->getStore();
+
+                if (! $store instanceof LockProvider) {
+                    continue;
+                }
+
+                $lock = $store->lock($key.':refresh', static::LOCK_SECONDS);
+
+                $lock->block(static::LOCK_WAIT_SECONDS);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if ($credentials = $this->freshCredentials($key)) {
+                $this->release($lock);
+
+                return Create::promiseFor($credentials);
+            }
+
+            return $this->resolveAndCache($key, $provider, $lock);
+        }
+
+        return $this->resolveAndCache($key, $provider);
+    }
+
+    /**
+     * Get fresh credentials from the available cache repositories.
+     *
+     * @param  string  $key
+     * @return \Aws\Credentials\CredentialsInterface|null
+     */
+    protected function freshCredentials($key)
     {
         foreach ($this->repositories() as $repository) {
             try {
-                if (! is_null($value = $repository()->get($key))) {
-                    return $value;
+                $credentials = $repository()->get($key);
+
+                if ($credentials instanceof CredentialsInterface &&
+                    (is_null($credentials->getExpiration()) ||
+                        $credentials->getExpiration() - time() > static::REFRESH_WINDOW)) {
+                    return $credentials;
                 }
             } catch (Throwable) {
                 //
             }
         }
+    }
 
-        return null;
+    /**
+     * Resolve and cache credentials before releasing the refresh lock.
+     *
+     * @param  string  $key
+     * @param  callable  $provider
+     * @param  \Illuminate\Contracts\Cache\Lock|null  $lock
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    protected function resolveAndCache($key, callable $provider, ?Lock $lock = null)
+    {
+        try {
+            $promise = $provider();
+        } catch (Throwable $e) {
+            $this->release($lock);
+
+            throw $e;
+        }
+
+        return $promise->then(
+            function (CredentialsInterface $credentials) use ($key, $lock) {
+                $expiration = $credentials->getExpiration();
+
+                if (is_null($expiration)) {
+                    $this->put($key, $credentials);
+                } elseif (($ttl = $expiration - time() - static::REFRESH_WINDOW) > 0) {
+                    $this->put($key, $credentials, $ttl);
+                } else {
+                    $this->forget($key);
+                }
+
+                $this->release($lock);
+
+                return $credentials;
+            },
+            function ($reason) use ($lock) {
+                $this->release($lock);
+
+                return new RejectedPromise($reason);
+            },
+        );
     }
 
     /**
      * Store the credentials, silently ignoring unavailable cache stores.
      *
      * @param  string  $key
-     * @param  mixed  $value
+     * @param  \Aws\Credentials\CredentialsInterface  $credentials
      * @param  int  $ttl
      * @return void
      */
-    public function set($key, $value, $ttl = 0)
+    protected function put($key, CredentialsInterface $credentials, $ttl = 0)
     {
         foreach ($this->repositories() as $repository) {
             try {
                 $ttl > 0
-                    ? $repository()->put($key, $value, (int) $ttl)
-                    : $repository()->forever($key, $value);
+                    ? $repository()->put($key, $credentials, (int) $ttl)
+                    : $repository()->forever($key, $credentials);
             } catch (Throwable) {
                 //
             }
@@ -82,7 +191,7 @@ class AwsCredentialCache implements CacheInterface
      * @param  string  $key
      * @return void
      */
-    public function remove($key)
+    protected function forget($key)
     {
         foreach ($this->repositories() as $repository) {
             try {
@@ -101,5 +210,20 @@ class AwsCredentialCache implements CacheInterface
     protected function repositories()
     {
         return array_filter([$this->repository, $this->fallback]);
+    }
+
+    /**
+     * Release the credential refresh lock without affecting credential resolution.
+     *
+     * @param  \Illuminate\Contracts\Cache\Lock|null  $lock
+     * @return void
+     */
+    protected function release(?Lock $lock)
+    {
+        try {
+            $lock?->release();
+        } catch (Throwable) {
+            //
+        }
     }
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -127,14 +127,12 @@ class SqsConnector implements ConnectorInterface
             $config['credentials_cache']['fallback_store'] ?? null,
         ];
 
-        return CredentialProvider::cache(
-            $provider,
-            new AwsCredentialCache(
-                fn () => Container::getInstance()->make('cache')->store($store),
-                $fallbackStore ? fn () => Container::getInstance()->make('cache')->store($fallbackStore) : null,
-            ),
-            static::credentialsCacheKey($config),
+        $cache = new AwsCredentialCache(
+            fn () => Container::getInstance()->make('cache')->store($store),
+            $fallbackStore ? fn () => Container::getInstance()->make('cache')->store($fallbackStore) : null,
         );
+
+        return fn () => $cache->resolve(static::credentialsCacheKey($config), $provider);
     }
 
     /**

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -26,7 +26,7 @@ class SqsConnector implements ConnectorInterface
 
         return new SqsQueue(
             new SqsClient(
-                Arr::except($config, ['token', 'overflow', 'credentials_cache'])
+                Arr::except($config, ['token', 'overflow', 'credential_cache'])
             ),
             $config['queue'],
             $config['prefix'] ?? '',
@@ -123,8 +123,8 @@ class SqsConnector implements ConnectorInterface
     protected function cachedCredentialProvider(callable $provider, array $config)
     {
         [$store, $fallbackStore] = [
-            $config['credentials_cache']['store'] ?? null,
-            $config['credentials_cache']['fallback_store'] ?? null,
+            $config['credential_cache']['store'] ?? null,
+            $config['credential_cache']['fallback_store'] ?? null,
         ];
 
         $cache = new AwsCredentialCache(
@@ -165,6 +165,6 @@ class SqsConnector implements ConnectorInterface
      */
     protected function credentialCachingEnabled(array $config)
     {
-        return (bool) ($config['credentials_cache']['enabled'] ?? false);
+        return (bool) ($config['credential_cache']['enabled'] ?? false);
     }
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -4,6 +4,8 @@ namespace Illuminate\Queue\Connectors;
 
 use Aws\Credentials\CredentialProvider;
 use Aws\Sqs\SqsClient;
+use Illuminate\Container\Container;
+use Illuminate\Queue\AwsCredentialCache;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -18,8 +20,30 @@ class SqsConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $config = $this->getDefaultConfiguration($config);
+        $config = $this->configureCredentials(
+            $this->getDefaultConfiguration($config)
+        );
 
+        return new SqsQueue(
+            new SqsClient(
+                Arr::except($config, ['token', 'overflow', 'credentials_cache'])
+            ),
+            $config['queue'],
+            $config['prefix'] ?? '',
+            $config['suffix'] ?? '',
+            $config['after_commit'] ?? null,
+            $config['overflow'] ?? [],
+        );
+    }
+
+    /**
+     * Configure the credentials for the given connection config.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function configureCredentials(array $config)
+    {
         if ($credentials = $this->resolveCredentialProvider($config)) {
             $config['credentials'] = $credentials;
         } elseif (! empty($config['key']) && ! empty($config['secret'])) {
@@ -28,18 +52,13 @@ class SqsConnector implements ConnectorInterface
             if (! empty($config['token'])) {
                 $config['credentials']['token'] = $config['token'];
             }
+        } elseif (! array_key_exists('credentials', $config) && $this->credentialCachingEnabled($config)) {
+            $config['credentials'] = CredentialProvider::memoize(
+                $this->cachedCredentialProvider(CredentialProvider::defaultProvider(), $config)
+            );
         }
 
-        return new SqsQueue(
-            new SqsClient(
-                Arr::except($config, ['token', 'overflow'])
-            ),
-            $config['queue'],
-            $config['prefix'] ?? '',
-            $config['suffix'] ?? '',
-            $config['after_commit'] ?? null,
-            $config['overflow'] ?? [],
-        );
+        return $config;
     }
 
     /**
@@ -70,7 +89,69 @@ class SqsConnector implements ConnectorInterface
             ),
         };
 
+        if ($this->credentialCachingEnabled($config)) {
+            $resolved = $this->cachedCredentialProvider($resolved, $config);
+        }
+
         return CredentialProvider::memoize($resolved);
+    }
+
+    /**
+     * Determine if resolved credentials should be shared across processes via the cache.
+     *
+     * @param  array  $config
+     * @return bool
+     */
+    protected function credentialCachingEnabled(array $config)
+    {
+        return (bool) ($config['credentials_cache']['enabled'] ?? false);
+    }
+
+    /**
+     * Wrap the given credential provider so the credentials it resolves are shared across processes via the cache.
+     *
+     * @param  callable  $provider
+     * @param  array  $config
+     * @return callable
+     */
+    protected function cachedCredentialProvider(callable $provider, array $config)
+    {
+        $store = $config['credentials_cache']['store'] ?? null;
+        $fallbackStore = $config['credentials_cache']['fallback_store'] ?? null;
+
+        return CredentialProvider::cache(
+            $provider,
+            new AwsCredentialCache(
+                fn () => Container::getInstance()->make('cache')->store($store),
+                $fallbackStore ? fn () => Container::getInstance()->make('cache')->store($fallbackStore) : null,
+            ),
+            static::credentialsCacheKey($config),
+        );
+    }
+
+    /**
+     * Get the cache key for the connection's shared credentials.
+     *
+     * The key is scoped so that only processes resolving the same identity
+     * (e.g. the same EKS pod identity association) share credentials.
+     *
+     * @param  array  $config
+     * @return string
+     */
+    public static function credentialsCacheKey(array $config)
+    {
+        $credentials = $config['credentials'] ?? null;
+
+        $provider = is_array($credentials) ? ($credentials['provider'] ?? null) : $credentials;
+
+        return 'aws:sqs:credentials:'.hash('sha256', implode('|', [
+            $_ENV['AWS_CONTAINER_CREDENTIALS_FULL_URI'] ?? $_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI'] ?? '',
+            $_ENV['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] ?? $_SERVER['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] ?? '',
+            is_string($provider) ? $provider : '',
+            $config['region'] ?? '',
+            $config['prefix'] ?? '',
+            $config['suffix'] ?? '',
+        ]));
     }
 
     /**

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -20,7 +20,7 @@ class SqsConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $config = $this->configureCredentials(
+        $config = $this->withCredentials(
             $this->getDefaultConfiguration($config)
         );
 
@@ -37,12 +37,29 @@ class SqsConnector implements ConnectorInterface
     }
 
     /**
+     * Get the default configuration for SQS.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function getDefaultConfiguration(array $config)
+    {
+        return array_merge([
+            'version' => 'latest',
+            'http' => [
+                'timeout' => 60,
+                'connect_timeout' => 60,
+            ],
+        ], $config);
+    }
+
+    /**
      * Configure the credentials for the given connection config.
      *
      * @param  array  $config
      * @return array
      */
-    protected function configureCredentials(array $config)
+    protected function withCredentials(array $config)
     {
         if ($credentials = $this->resolveCredentialProvider($config)) {
             $config['credentials'] = $credentials;
@@ -97,17 +114,6 @@ class SqsConnector implements ConnectorInterface
     }
 
     /**
-     * Determine if resolved credentials should be shared across processes via the cache.
-     *
-     * @param  array  $config
-     * @return bool
-     */
-    protected function credentialCachingEnabled(array $config)
-    {
-        return (bool) ($config['credentials_cache']['enabled'] ?? false);
-    }
-
-    /**
      * Wrap the given credential provider so the credentials it resolves are shared across processes via the cache.
      *
      * @param  callable  $provider
@@ -116,8 +122,10 @@ class SqsConnector implements ConnectorInterface
      */
     protected function cachedCredentialProvider(callable $provider, array $config)
     {
-        $store = $config['credentials_cache']['store'] ?? null;
-        $fallbackStore = $config['credentials_cache']['fallback_store'] ?? null;
+        [$store, $fallbackStore] = [
+            $config['credentials_cache']['store'] ?? null,
+            $config['credentials_cache']['fallback_store'] ?? null,
+        ];
 
         return CredentialProvider::cache(
             $provider,
@@ -131,9 +139,6 @@ class SqsConnector implements ConnectorInterface
 
     /**
      * Get the cache key for the connection's shared credentials.
-     *
-     * The key is scoped so that only processes resolving the same identity
-     * (e.g. the same EKS pod identity association) share credentials.
      *
      * @param  array  $config
      * @return string
@@ -155,19 +160,13 @@ class SqsConnector implements ConnectorInterface
     }
 
     /**
-     * Get the default configuration for SQS.
+     * Determine if resolved credentials should be shared across processes via the cache.
      *
      * @param  array  $config
-     * @return array
+     * @return bool
      */
-    protected function getDefaultConfiguration(array $config)
+    protected function credentialCachingEnabled(array $config)
     {
-        return array_merge([
-            'version' => 'latest',
-            'http' => [
-                'timeout' => 60,
-                'connect_timeout' => 60,
-            ],
-        ], $config);
+        return (bool) ($config['credentials_cache']['enabled'] ?? false);
     }
 }

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -153,7 +153,7 @@ class QueueTest extends TestCase
             'always' => false,
             'delete_after_processing' => true,
         ];
-        $expected['connection']['credentials_cache'] = [
+        $expected['connection']['credential_cache'] = [
             'enabled' => true,
             'store' => null,
             'fallback_store' => 'file',
@@ -241,7 +241,7 @@ class QueueTest extends TestCase
     {
         $this->app['config']->set('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default']);
         $this->app['config']->set('queue.connections.redis', ['driver' => 'redis', 'queue' => 'default']);
-        $this->app['config']->set('queue.connections.other-sqs', ['driver' => 'sqs', 'credentials_cache' => ['enabled' => false]]);
+        $this->app['config']->set('queue.connections.other-sqs', ['driver' => 'sqs', 'credential_cache' => ['enabled' => false]]);
 
         CloudBootstrapper::configureQueueCredentialCaching($this->app);
 
@@ -249,12 +249,12 @@ class QueueTest extends TestCase
         // they share the cached credentials by default too.
         $this->assertSame(
             ['enabled' => true, 'store' => null, 'fallback_store' => 'file'],
-            $this->app['config']->get('queue.connections.sqs.credentials_cache'),
+            $this->app['config']->get('queue.connections.sqs.credential_cache'),
         );
 
         // Non-SQS connections and explicit configuration are left untouched.
-        $this->assertArrayNotHasKey('credentials_cache', $this->app['config']->get('queue.connections.redis'));
-        $this->assertSame(['enabled' => false], $this->app['config']->get('queue.connections.other-sqs.credentials_cache'));
+        $this->assertArrayNotHasKey('credential_cache', $this->app['config']->get('queue.connections.redis'));
+        $this->assertSame(['enabled' => false], $this->app['config']->get('queue.connections.other-sqs.credential_cache'));
     }
 
     public function testManagedQueueCredentialsAreServedFromTheSharedCacheWithoutFetching()
@@ -263,7 +263,7 @@ class QueueTest extends TestCase
 
         try {
             CloudBootstrapper::configureManagedQueues($this->app);
-            config(['queue.connections.cloud.connection.credentials_cache.store' => 'array']);
+            config(['queue.connections.cloud.connection.credential_cache.store' => 'array']);
             CloudBootstrapper::bootManagedQueues($this->app);
 
             Cache::store('array')->forever(

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Cloud;
 
 use Aws\CommandInterface;
+use Aws\Credentials\Credentials;
 use Aws\Exception\AwsException;
 use Aws\HandlerList;
 use Aws\MockHandler;
@@ -152,6 +153,11 @@ class QueueTest extends TestCase
             'always' => false,
             'delete_after_processing' => true,
         ];
+        $expected['connection']['credentials_cache'] = [
+            'enabled' => true,
+            'store' => null,
+            'fallback_store' => 'file',
+        ];
 
         $this->assertSame(
             $expected,
@@ -218,6 +224,62 @@ class QueueTest extends TestCase
 
         $this->assertFalse($this->app->bound(Events::class));
         $this->assertSame($originalFailer, $this->app['queue.failer']);
+    }
+
+    public function testCredentialCachingIsInertWhenTheDriverIsNotCloud()
+    {
+        $this->app['config']->set('queue.connections.cloud.driver', 'sqs');
+
+        CloudBootstrapper::bootManagedQueues($this->app);
+
+        // The cloud connector - and with it the managed queue credential cache
+        // defaults - is never registered when the driver is not "cloud".
+        $this->assertFalse($this->app->bound(QueueConnector::class));
+    }
+
+    public function testItDefaultsCredentialCachingForAppLevelSqsConnections()
+    {
+        $this->app['config']->set('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default']);
+        $this->app['config']->set('queue.connections.redis', ['driver' => 'redis', 'queue' => 'default']);
+        $this->app['config']->set('queue.connections.other-sqs', ['driver' => 'sqs', 'credentials_cache' => ['enabled' => false]]);
+
+        CloudBootstrapper::configureQueueCredentialCaching($this->app);
+
+        // App-level SQS connections dispatch through the same pod identity, so
+        // they share the cached credentials by default too.
+        $this->assertSame(
+            ['enabled' => true, 'store' => null, 'fallback_store' => 'file'],
+            $this->app['config']->get('queue.connections.sqs.credentials_cache'),
+        );
+
+        // Non-SQS connections and explicit configuration are left untouched.
+        $this->assertArrayNotHasKey('credentials_cache', $this->app['config']->get('queue.connections.redis'));
+        $this->assertSame(['enabled' => false], $this->app['config']->get('queue.connections.other-sqs.credentials_cache'));
+    }
+
+    public function testManagedQueueCredentialsAreServedFromTheSharedCacheWithoutFetching()
+    {
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = 'http://169.254.170.23/v1/credentials';
+
+        try {
+            CloudBootstrapper::configureManagedQueues($this->app);
+            config(['queue.connections.cloud.connection.credentials_cache.store' => 'array']);
+            CloudBootstrapper::bootManagedQueues($this->app);
+
+            Cache::store('array')->forever(
+                SqsConnector::credentialsCacheKey(config('queue.connections.cloud.connection')),
+                new Credentials('cached-key', 'cached-secret', 'cached-token', time() + 3600),
+            );
+
+            // A cache hit resolves the fleet-shared credentials without the
+            // provider ever contacting the Pod Identity Agent.
+            $credentials = $this->app['queue']->connection('cloud')->getSqs()->getCredentials()->wait();
+
+            $this->assertSame('cached-key', $credentials->getAccessKeyId());
+            $this->assertSame('cached-secret', $credentials->getSecretKey());
+        } finally {
+            unset($_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI']);
+        }
     }
 
     public function testItDoesNotEmitEventsWhilePoppingWhenNoJobsAreProcessingAndNoJobsAreAvailableToPop()

--- a/tests/Queue/QueueSqsConnectorTest.php
+++ b/tests/Queue/QueueSqsConnectorTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+use Closure;
+use GuzzleHttp\Promise\Create;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Queue\AwsCredentialCache;
+use Illuminate\Queue\Connectors\SqsConnector;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class QueueSqsConnectorTest extends TestCase
+{
+    public function testCredentialsAreWrappedWithASharedCacheProviderWhenCachingIsEnabled()
+    {
+        $config = $this->credentials([
+            'credentials_cache' => ['enabled' => true],
+        ]);
+
+        $this->assertInstanceOf(Closure::class, $config['credentials']);
+    }
+
+    public function testCredentialsAreNotWrappedWhenCachingIsNotConfigured()
+    {
+        $config = $this->credentials([]);
+
+        $this->assertArrayNotHasKey('credentials', $config);
+    }
+
+    public function testCredentialsAreNotWrappedWhenCachingIsDisabled()
+    {
+        $config = $this->credentials([
+            'credentials_cache' => ['enabled' => false],
+        ]);
+
+        $this->assertArrayNotHasKey('credentials', $config);
+    }
+
+    public function testExplicitCredentialsAreLeftUntouched()
+    {
+        $config = $this->credentials([
+            'credentials' => false,
+            'credentials_cache' => ['enabled' => true],
+        ]);
+
+        $this->assertFalse($config['credentials']);
+    }
+
+    public function testStaticKeyAndSecretCredentialsAreLeftUntouched()
+    {
+        $config = $this->credentials([
+            'key' => 'static-key',
+            'secret' => 'static-secret',
+            'credentials_cache' => ['enabled' => true],
+        ]);
+
+        $this->assertSame(['key' => 'static-key', 'secret' => 'static-secret'], $config['credentials']);
+    }
+
+    public function testCredentialCacheHitsDoNotInvokeTheUnderlyingProvider()
+    {
+        $repository = new Repository(new ArrayStore);
+        $repository->forever('credentials', new Credentials('cached-key', 'cached-secret', 'cached-token', time() + 3600));
+
+        $provider = CredentialProvider::cache(
+            fn () => $this->fail('The underlying provider should not be invoked on a cache hit.'),
+            new AwsCredentialCache(fn () => $repository),
+            'credentials',
+        );
+
+        $this->assertSame('cached-key', $provider()->wait()->getAccessKeyId());
+    }
+
+    public function testCredentialResolutionFallsBackToADirectFetchWhenTheCacheStoreIsUnavailable()
+    {
+        // A broken cache backend (e.g. Redis down) must behave exactly like a
+        // cache miss rather than breaking credential resolution.
+        $provider = CredentialProvider::cache(
+            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
+            new AwsCredentialCache(fn () => throw new RuntimeException('Cache store is down.')),
+            'credentials',
+        );
+
+        $this->assertSame('direct-key', $provider()->wait()->getAccessKeyId());
+    }
+
+    public function testCredentialsAreServedFromTheFallbackStoreWhenThePrimaryStoreIsUnavailable()
+    {
+        $fallback = new Repository(new ArrayStore);
+        $fallback->forever('credentials', new Credentials('fallback-key', 'fallback-secret', 'fallback-token', time() + 3600));
+
+        // With the primary store down, the fallback keeps credential fetches
+        // deduplicated rather than degrading straight to one fetch per process.
+        $provider = CredentialProvider::cache(
+            fn () => $this->fail('The underlying provider should not be invoked on a fallback cache hit.'),
+            new AwsCredentialCache(
+                fn () => throw new RuntimeException('Cache store is down.'),
+                fn () => $fallback,
+            ),
+            'credentials',
+        );
+
+        $this->assertSame('fallback-key', $provider()->wait()->getAccessKeyId());
+    }
+
+    public function testCredentialsAreWrittenThroughToTheFallbackStore()
+    {
+        $primary = new Repository(new ArrayStore);
+        $fallback = new Repository(new ArrayStore);
+
+        $cache = new AwsCredentialCache(fn () => $primary, fn () => $fallback);
+
+        // The fallback is written through on every set so it is already warm
+        // when the primary store becomes unavailable.
+        $cache->set('credentials', 'value', 60);
+        $this->assertSame('value', $primary->get('credentials'));
+        $this->assertSame('value', $fallback->get('credentials'));
+
+        $cache->remove('credentials');
+        $this->assertNull($primary->get('credentials'));
+        $this->assertNull($fallback->get('credentials'));
+    }
+
+    public function testThePrimaryStoreIsPreferredOverTheFallbackStore()
+    {
+        $primary = new Repository(new ArrayStore);
+        $primary->forever('credentials', 'primary-value');
+
+        $fallback = new Repository(new ArrayStore);
+        $fallback->forever('credentials', 'fallback-value');
+
+        $cache = new AwsCredentialCache(fn () => $primary, fn () => $fallback);
+
+        $this->assertSame('primary-value', $cache->get('credentials'));
+    }
+
+    public function testCredentialResolutionFallsBackToADirectFetchWhenEveryCacheStoreIsUnavailable()
+    {
+        $provider = CredentialProvider::cache(
+            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
+            new AwsCredentialCache(
+                fn () => throw new RuntimeException('Cache store is down.'),
+                fn () => throw new RuntimeException('Fallback store is down too.'),
+            ),
+            'credentials',
+        );
+
+        $this->assertSame('direct-key', $provider()->wait()->getAccessKeyId());
+    }
+
+    public function testCredentialCacheStoresAndRemovesThroughTheRepository()
+    {
+        $repository = new Repository(new ArrayStore);
+
+        $cache = new AwsCredentialCache(fn () => $repository);
+
+        $cache->set('credentials', 'value', 60);
+        $this->assertSame('value', $cache->get('credentials'));
+
+        $cache->remove('credentials');
+        $this->assertNull($cache->get('credentials'));
+    }
+
+    public function testCredentialsCacheKeyIsScopedToThePodIdentityAndConnection()
+    {
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = 'http://169.254.170.23/v1/credentials';
+
+        try {
+            $key = SqsConnector::credentialsCacheKey(['region' => 'us-east-2', 'prefix' => 'prefix']);
+
+            $this->assertNotSame($key, SqsConnector::credentialsCacheKey(['region' => 'us-west-2', 'prefix' => 'prefix']));
+            $this->assertNotSame($key, SqsConnector::credentialsCacheKey(['region' => 'us-east-2', 'prefix' => 'other-prefix']));
+
+            $_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = 'http://169.254.170.23/v1/other-credentials';
+
+            $this->assertNotSame($key, SqsConnector::credentialsCacheKey(['region' => 'us-east-2', 'prefix' => 'prefix']));
+        } finally {
+            unset($_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI']);
+        }
+    }
+
+    /**
+     * Run the given connection config through the connector's credential resolution.
+     */
+    protected function credentials(array $config): array
+    {
+        $connector = new class extends SqsConnector
+        {
+            public function credentials(array $config)
+            {
+                return $this->configureCredentials($this->getDefaultConfiguration($config));
+            }
+        };
+
+        return $connector->credentials(array_merge([
+            'driver' => 'sqs',
+            'region' => 'us-east-2',
+            'queue' => 'default',
+        ], $config));
+    }
+}

--- a/tests/Queue/QueueSqsConnectorTest.php
+++ b/tests/Queue/QueueSqsConnectorTest.php
@@ -17,7 +17,7 @@ class QueueSqsConnectorTest extends TestCase
     public function testCredentialsAreWrappedWithASharedCacheProviderWhenCachingIsEnabled()
     {
         $config = $this->credentials([
-            'credentials_cache' => ['enabled' => true],
+            'credential_cache' => ['enabled' => true],
         ]);
 
         $this->assertInstanceOf(Closure::class, $config['credentials']);
@@ -33,7 +33,7 @@ class QueueSqsConnectorTest extends TestCase
     public function testCredentialsAreNotWrappedWhenCachingIsDisabled()
     {
         $config = $this->credentials([
-            'credentials_cache' => ['enabled' => false],
+            'credential_cache' => ['enabled' => false],
         ]);
 
         $this->assertArrayNotHasKey('credentials', $config);
@@ -43,7 +43,7 @@ class QueueSqsConnectorTest extends TestCase
     {
         $config = $this->credentials([
             'credentials' => false,
-            'credentials_cache' => ['enabled' => true],
+            'credential_cache' => ['enabled' => true],
         ]);
 
         $this->assertFalse($config['credentials']);
@@ -54,7 +54,7 @@ class QueueSqsConnectorTest extends TestCase
         $config = $this->credentials([
             'key' => 'static-key',
             'secret' => 'static-secret',
-            'credentials_cache' => ['enabled' => true],
+            'credential_cache' => ['enabled' => true],
         ]);
 
         $this->assertSame(['key' => 'static-key', 'secret' => 'static-secret'], $config['credentials']);

--- a/tests/Queue/QueueSqsConnectorTest.php
+++ b/tests/Queue/QueueSqsConnectorTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Closure;
 use GuzzleHttp\Promise\Create;
@@ -66,23 +65,80 @@ class QueueSqsConnectorTest extends TestCase
         $repository = new Repository(new ArrayStore);
         $repository->forever('credentials', new Credentials('cached-key', 'cached-secret', 'cached-token', time() + 3600));
 
-        $provider = CredentialProvider::cache(
-            fn () => $this->fail('The underlying provider should not be invoked on a cache hit.'),
-            new AwsCredentialCache(fn () => $repository),
+        $provider = fn () => (new AwsCredentialCache(fn () => $repository))->resolve(
             'credentials',
+            fn () => $this->fail('The underlying provider should not be invoked on a cache hit.'),
         );
 
         $this->assertSame('cached-key', $provider()->wait()->getAccessKeyId());
+    }
+
+    public function testCredentialResolutionRefreshesCredentialsBeforeTheyExpire()
+    {
+        $repository = new Repository(new ArrayStore);
+        $repository->forever('credentials', new Credentials('expiring-key', 'expiring-secret', expires: time() + 30));
+        $calls = 0;
+
+        $credentials = (new AwsCredentialCache(fn () => $repository))->resolve(
+            'credentials',
+            function () use (&$calls) {
+                $calls++;
+
+                return Create::promiseFor(new Credentials('fresh-key', 'fresh-secret', expires: time() + 3600));
+            },
+        )->wait();
+
+        $this->assertSame(1, $calls);
+        $this->assertSame('fresh-key', $credentials->getAccessKeyId());
+        $this->assertSame('fresh-key', $repository->get('credentials')->getAccessKeyId());
+    }
+
+    public function testCredentialResolutionReusesCredentialsRefreshedByAnotherProcess()
+    {
+        $repository = new Repository(new ArrayStore);
+        $cache = new AwsCredentialCache(fn () => $repository);
+        $calls = 0;
+        $provider = function () use (&$calls) {
+            $calls++;
+
+            return Create::promiseFor(new Credentials('shared-key', 'shared-secret', expires: time() + 3600));
+        };
+
+        $first = $cache->resolve('credentials', $provider)->wait();
+        $second = $cache->resolve('credentials', $provider)->wait();
+
+        $this->assertSame(1, $calls);
+        $this->assertSame('shared-key', $first->getAccessKeyId());
+        $this->assertSame('shared-key', $second->getAccessKeyId());
+    }
+
+    public function testCredentialResolutionCachesCredentialsWithoutAnExpiration()
+    {
+        $repository = new Repository(new ArrayStore);
+        $cache = new AwsCredentialCache(fn () => $repository);
+        $calls = 0;
+        $provider = function () use (&$calls) {
+            $calls++;
+
+            return Create::promiseFor(new Credentials('constant-key', 'constant-secret'));
+        };
+
+        $cache->resolve('credentials', $provider)->wait();
+        $credentials = $cache->resolve('credentials', $provider)->wait();
+
+        $this->assertSame(1, $calls);
+        $this->assertSame('constant-key', $credentials->getAccessKeyId());
     }
 
     public function testCredentialResolutionFallsBackToADirectFetchWhenTheCacheStoreIsUnavailable()
     {
         // A broken cache backend (e.g. Redis down) must behave exactly like a
         // cache miss rather than breaking credential resolution.
-        $provider = CredentialProvider::cache(
-            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
-            new AwsCredentialCache(fn () => throw new RuntimeException('Cache store is down.')),
+        $provider = fn () => (new AwsCredentialCache(
+            fn () => throw new RuntimeException('Cache store is down.'),
+        ))->resolve(
             'credentials',
+            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
         );
 
         $this->assertSame('direct-key', $provider()->wait()->getAccessKeyId());
@@ -95,13 +151,12 @@ class QueueSqsConnectorTest extends TestCase
 
         // With the primary store down, the fallback keeps credential fetches
         // deduplicated rather than degrading straight to one fetch per process.
-        $provider = CredentialProvider::cache(
-            fn () => $this->fail('The underlying provider should not be invoked on a fallback cache hit.'),
-            new AwsCredentialCache(
-                fn () => throw new RuntimeException('Cache store is down.'),
-                fn () => $fallback,
-            ),
+        $provider = fn () => (new AwsCredentialCache(
+            fn () => throw new RuntimeException('Cache store is down.'),
+            fn () => $fallback,
+        ))->resolve(
             'credentials',
+            fn () => $this->fail('The underlying provider should not be invoked on a fallback cache hit.'),
         );
 
         $this->assertSame('fallback-key', $provider()->wait()->getAccessKeyId());
@@ -116,53 +171,44 @@ class QueueSqsConnectorTest extends TestCase
 
         // The fallback is written through on every set so it is already warm
         // when the primary store becomes unavailable.
-        $cache->set('credentials', 'value', 60);
-        $this->assertSame('value', $primary->get('credentials'));
-        $this->assertSame('value', $fallback->get('credentials'));
+        $cache->resolve(
+            'credentials',
+            fn () => Create::promiseFor(new Credentials('shared-key', 'shared-secret', expires: time() + 3600)),
+        )->wait();
 
-        $cache->remove('credentials');
-        $this->assertNull($primary->get('credentials'));
-        $this->assertNull($fallback->get('credentials'));
+        $this->assertSame('shared-key', $primary->get('credentials')->getAccessKeyId());
+        $this->assertSame('shared-key', $fallback->get('credentials')->getAccessKeyId());
     }
 
     public function testThePrimaryStoreIsPreferredOverTheFallbackStore()
     {
         $primary = new Repository(new ArrayStore);
-        $primary->forever('credentials', 'primary-value');
+        $primary->forever('credentials', new Credentials('primary-key', 'primary-secret', expires: time() + 3600));
 
         $fallback = new Repository(new ArrayStore);
-        $fallback->forever('credentials', 'fallback-value');
+        $fallback->forever('credentials', new Credentials('fallback-key', 'fallback-secret', expires: time() + 3600));
 
         $cache = new AwsCredentialCache(fn () => $primary, fn () => $fallback);
 
-        $this->assertSame('primary-value', $cache->get('credentials'));
+        $credentials = $cache->resolve(
+            'credentials',
+            fn () => $this->fail('The underlying provider should not be invoked on a cache hit.'),
+        )->wait();
+
+        $this->assertSame('primary-key', $credentials->getAccessKeyId());
     }
 
     public function testCredentialResolutionFallsBackToADirectFetchWhenEveryCacheStoreIsUnavailable()
     {
-        $provider = CredentialProvider::cache(
-            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
-            new AwsCredentialCache(
-                fn () => throw new RuntimeException('Cache store is down.'),
-                fn () => throw new RuntimeException('Fallback store is down too.'),
-            ),
+        $provider = fn () => (new AwsCredentialCache(
+            fn () => throw new RuntimeException('Cache store is down.'),
+            fn () => throw new RuntimeException('Fallback store is down too.'),
+        ))->resolve(
             'credentials',
+            fn () => Create::promiseFor(new Credentials('direct-key', 'direct-secret')),
         );
 
         $this->assertSame('direct-key', $provider()->wait()->getAccessKeyId());
-    }
-
-    public function testCredentialCacheStoresAndRemovesThroughTheRepository()
-    {
-        $repository = new Repository(new ArrayStore);
-
-        $cache = new AwsCredentialCache(fn () => $repository);
-
-        $cache->set('credentials', 'value', 60);
-        $this->assertSame('value', $cache->get('credentials'));
-
-        $cache->remove('credentials');
-        $this->assertNull($cache->get('credentials'));
     }
 
     public function testCredentialsCacheKeyIsScopedToThePodIdentityAndConnection()
@@ -192,7 +238,7 @@ class QueueSqsConnectorTest extends TestCase
         {
             public function credentials(array $config)
             {
-                return $this->configureCredentials($this->getDefaultConfiguration($config));
+                return $this->withCredentials($this->getDefaultConfiguration($config));
             }
         };
 


### PR DESCRIPTION
### Problem

On Laravel Cloud, managed queues authenticate to SQS via EKS Pod Identity. The AWS SDK [memoizes credentials **per process only**](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/memoizing-credentials.html), so under PHP-FPM every worker process performs its own credential fetch against the Pod Identity Agent on its first dispatch. During traffic bursts (observed: ~1600 FPM workers spawning in ~20 seconds), this exceeds the agent's hard-coded, non-configurable rate limit of 1000 req/s (see [`RequestRate` in aws/eks-pod-identity-agent's `configuration/config.go`](https://github.com/aws/eks-pod-identity-agent/blob/main/configuration/config.go#L10)). The SDK does not retry that call, so job dispatches fail with credential errors. The same exposure applies to any app-defined `sqs` queue connection that resolves credentials dynamically.

### Fix

`SqsConnector` now supports a `credentials_cache` option on any SQS connection. When enabled — and only when the connection has no static `key`/`secret` and no explicit `credentials` value — the credential provider is wrapped in [`CredentialProvider::cache()`](https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.Credentials.CredentialProvider.html#method_cache) (pattern explained in the [v2 guide](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/credentials.html#caching-iam-role-credentials)) backed by a Laravel cache repository (via a new `Illuminate\Queue\AwsCredentialCache` adapter), then memoized per process. The whole fleet performs one credential fetch per STS rotation instead of one per process. Explicit string providers (`'ecs'`, `'instance'`) also participate in the cache when enabled.

On Laravel Cloud, `CloudBootstrapper` enables this by default for the managed `cloud` connection **and** every app-level `driver => 'sqs'` connection that hasn't configured it. Outside Laravel Cloud the feature is entirely opt-in — existing SQS connections are unchanged.

### Config surface

```php
'credentials_cache' => [
    'enabled' => true,          // default: false (Cloud defaults it to true)
    'store' => null,            // cache store name; null = app default store
    'fallback_store' => 'file', // tried when the primary store fails; falsy disables
],
```

Cloud env overrides: `CLOUD_QUEUE_CREDENTIALS_CACHE_ENABLED`, `CLOUD_QUEUE_CREDENTIALS_CACHE_STORE`, `CLOUD_QUEUE_CREDENTIALS_CACHE_FALLBACK_STORE`.

### Resilience

A cache failure can never break credential resolution — the degradation ladder is: shared store (fleet-wide dedup) → pod-local file store (per-pod dedup) → direct fetch (per-process). Every cache operation on every store is individually guarded, and the fallback store is written through on every set so it is already warm when the primary store becomes unavailable. Cache repositories are resolved lazily at first credential fetch, never during bootstrapping. The cache key is scoped by pod identity (credentials URI + token file path) plus provider/region/prefix/suffix, so processes assuming different roles never share credentials.

### Notes

- This should be backported to the maintenance branches that received managed queues support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)