### PR TITLE
Register Redis cache tag entries after the value is written

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -25,22 +25,16 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $seconds = null;
+        $seconds = $ttl !== null ? $this->getSeconds($ttl) : null;
 
-        $result = parent::add($key, $value, $ttl);
-
-        if ($ttl !== null) {
-            $seconds = $this->getSeconds($ttl);
-
+        return tap(parent::add($key, $value, $ttl), function () use ($key, $seconds) {
             if ($seconds > 0) {
                 $this->tags->addEntry(
                     $this->itemKey($key),
                     $seconds
                 );
             }
-        }
-
-        return $result;
+        });
     }
 
     /**
@@ -61,16 +55,14 @@ class RedisTaggedCache extends TaggedCache
 
         $seconds = $this->getSeconds($ttl);
 
-        $result = parent::put($key, $value, $ttl);
-
-        if ($seconds > 0) {
-            $this->tags->addEntry(
-                $this->itemKey($key),
-                $seconds
-            );
-        }
-
-        return $result;
+        return tap(parent::put($key, $value, $ttl), function () use ($key, $seconds) {
+            if ($seconds > 0) {
+                $this->tags->addEntry(
+                    $this->itemKey($key),
+                    $seconds
+                );
+            }
+        });
     }
 
     /**
@@ -84,11 +76,9 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $result = parent::increment($key, $value);
-
-        $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
-
-        return $result;
+        return tap(parent::increment($key, $value), function () use ($key) {
+            $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        });
     }
 
     /**
@@ -102,11 +92,9 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $result = parent::decrement($key, $value);
-
-        $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
-
-        return $result;
+        return tap(parent::decrement($key, $value), function () use ($key) {
+            $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        });
     }
 
     /**
@@ -120,11 +108,9 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $result = parent::forever($key, $value);
-
-        $this->tags->addEntry($this->itemKey($key));
-
-        return $result;
+        return tap(parent::forever($key, $value), function () use ($key) {
+            $this->tags->addEntry($this->itemKey($key));
+        });
     }
 
     /**

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -27,6 +27,8 @@ class RedisTaggedCache extends TaggedCache
 
         $seconds = null;
 
+        $result = parent::add($key, $value, $ttl);
+
         if ($ttl !== null) {
             $seconds = $this->getSeconds($ttl);
 
@@ -38,7 +40,7 @@ class RedisTaggedCache extends TaggedCache
             }
         }
 
-        return parent::add($key, $value, $ttl);
+        return $result;
     }
 
     /**
@@ -59,6 +61,8 @@ class RedisTaggedCache extends TaggedCache
 
         $seconds = $this->getSeconds($ttl);
 
+        $result = parent::put($key, $value, $ttl);
+
         if ($seconds > 0) {
             $this->tags->addEntry(
                 $this->itemKey($key),
@@ -66,7 +70,7 @@ class RedisTaggedCache extends TaggedCache
             );
         }
 
-        return parent::put($key, $value, $ttl);
+        return $result;
     }
 
     /**
@@ -80,9 +84,11 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
+        $result = parent::increment($key, $value);
+
         $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
 
-        return parent::increment($key, $value);
+        return $result;
     }
 
     /**
@@ -96,9 +102,11 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
+        $result = parent::decrement($key, $value);
+
         $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
 
-        return parent::decrement($key, $value);
+        return $result;
     }
 
     /**
@@ -112,9 +120,11 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
+        $result = parent::forever($key, $value);
+
         $this->tags->addEntry($this->itemKey($key));
 
-        return parent::forever($key, $value);
+        return $result;
     }
 
     /**

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -131,6 +131,34 @@ class RedisStoreTest extends TestCase
         $this->assertCount(0, $keyCount);
     }
 
+    public function testTagEntriesWrittenDuringAFlushCanStillBeFlushed()
+    {
+        Cache::store('redis')->clear();
+
+        $flushed = false;
+
+        Cache::store('redis')->connection()->setEventDispatcher($this->app['events']);
+
+        Cache::store('redis')->connection()->listen(function ($event) use (&$flushed) {
+            if ($flushed || $event->command !== 'zadd') {
+                return;
+            }
+
+            $flushed = true;
+
+            Cache::store('redis')->tags(['people'])->flush();
+        });
+
+        Cache::store('redis')->tags(['people'])->forever('name', 'Sally');
+
+        $this->assertTrue($flushed);
+
+        Cache::store('redis')->tags(['people'])->flush();
+
+        $keyCount = Cache::store('redis')->connection()->keys('*');
+        $this->assertCount(0, $keyCount);
+    }
+
     public function testTagEntriesCanBeIncremented()
     {
         Cache::store('redis')->clear();


### PR DESCRIPTION
`RedisTaggedCache` adds the key to the tag set before it writes the value. When a `flush()` from another request lands between those two statements it reads the member, deletes nothing because the key does not exist yet, removes the reference, and then our write lands. The key is now in Redis with no tag set referencing it, so no later `flush()` of that tag can reach it. Written through `rememberForever()` it also carries no TTL, so it keeps serving a stale value indefinitely.

Writing the value first closes that window: a flush running before the registration cannot delete a key it does not know about, and by the time the key is visible to a flush it is registered. This mirrors what #57098 did on the flush side.

Fixes #61328
