### PR TITLE
[13.x] Add `NotifcationSkipped` event

### DIFF
--- a/src/Illuminate/Notifications/Events/NotificationSkipped.php
+++ b/src/Illuminate/Notifications/Events/NotificationSkipped.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Notifications\Events;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+
+class NotificationSkipped
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  mixed  $notifiable  The notifiable entity who would have received the notification.
+     * @param  \Illuminate\Notifications\Notification  $notification  The notification instance.
+     * @param  string  $channel  The channel name.
+     */
+    public function __construct(
+        public $notifiable,
+        public $notification,
+        public $channel,
+    ) {
+    }
+}

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Notifications\Events\NotificationSkipped;
 use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\Queue as QueueAttribute;
@@ -158,6 +159,10 @@ class NotificationSender
         }
 
         if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
+            $this->events->dispatch(
+                new NotificationSkipped($notifiable, $notification, $channel)
+            );
+
             return;
         }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -12,6 +12,7 @@ use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Notifications\Events\NotificationSkipped;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
@@ -87,6 +88,7 @@ class NotificationChannelManagerTest extends TestCase
         $driver = Mockery::mock();
         $manager->expects('driver')->andReturn($driver);
         $driver->expects('send');
+        $events->expects('dispatch')->with(Mockery::type(NotificationSkipped::class));
         $events->expects('dispatch')->with(Mockery::type(NotificationSent::class));
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotificationWithTwoChannels);
@@ -104,7 +106,8 @@ class NotificationChannelManagerTest extends TestCase
         $manager = Mockery::mock(ChannelManager::class.'[driver]', [$container]);
         $events->expects('listen');
         $manager->shouldNotReceive('driver');
-        $events->shouldNotReceive('dispatch');
+        $events->expects('dispatch')->with(Mockery::type(NotificationSkipped::class));
+        $events->shouldNotReceive('dispatch')->with(Mockery::type(NotificationSent::class));
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestCancelledNotification);
     }


### PR DESCRIPTION
Notifications can decide themselves based on userland logic if it's dispatched or not, ie `shouldSend`, 
or `NotificationSending` can return false...but, if it's not dispatched there's no event.. this means we end up using our own events, or logging logic.

This PR adds a `NotificationSkipped` event so it's easy to trace locally and in production. 

This means we go from "Eh, why is that not dispatching" to "I can see why this isnt dispatching"