### PR TITLE
[13.x] Fix uncaught Brick MathException escaping the numeric comparison rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -520,7 +520,7 @@ trait ValidatesAttributes
             $size = BigNumber::of($this->getSize($attribute, $value));
 
             return $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]));
-        } catch (MathException) {
+        } catch (MathException|BrickMathException) {
             return false;
         }
     }
@@ -1323,7 +1323,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isGreaterThan($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1335,7 +1335,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isGreaterThan($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1370,7 +1370,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isLessThan($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1380,7 +1380,11 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
+            try {
+                return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
+            } catch (MathException|BrickMathException) {
+                return false;
+            }
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1413,7 +1417,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1425,7 +1429,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isGreaterThanOrEqualTo($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1460,7 +1464,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1470,7 +1474,11 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
+            try {
+                return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
+            } catch (MathException|BrickMathException) {
+                return false;
+            }
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1709,7 +1717,7 @@ trait ValidatesAttributes
 
         try {
             return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($this->trim($parameters[0]));
-        } catch (MathException) {
+        } catch (MathException|BrickMathException) {
             return false;
         }
     }
@@ -1819,7 +1827,7 @@ trait ValidatesAttributes
 
         try {
             return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($this->trim($parameters[0]));
-        } catch (MathException) {
+        } catch (MathException|BrickMathException) {
             return false;
         }
     }
@@ -2638,7 +2646,7 @@ trait ValidatesAttributes
 
         try {
             return BigNumber::of($this->getSize($attribute, $value))->isEqualTo($this->trim($parameters[0]));
-        } catch (MathException) {
+        } catch (MathException|BrickMathException) {
             return false;
         }
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10154,6 +10154,51 @@ class ValidationValidatorTest extends TestCase
         ], $validator->messages()->keys());
     }
 
+    #[DataProvider('untrimmableWhitespaceLiteralParameterRules')]
+    public function testItFailsSizeRulesForNumericStringsWithUntrimmableWhitespaceWithoutThrowing($value, $rule)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $validator = new Validator($trans, ['foo' => $value], ['foo' => ['numeric', $rule]]);
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public static function untrimmableWhitespaceLiteralParameterRules()
+    {
+        $data = [];
+
+        foreach (["\x0C5", "5\x0C"] as $value) {
+            foreach (['min:3', 'max:3', 'size:3', 'between:1,5', 'gt:0', 'lt:10', 'gte:0', 'lte:10'] as $rule) {
+                $data[] = [$value, $rule];
+            }
+        }
+
+        return $data;
+    }
+
+    #[DataProvider('untrimmableWhitespaceFieldComparisonRules')]
+    public function testItFailsFieldComparisonRulesForUntrimmableWhitespaceWithoutThrowing($data, $rule)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $validator = new Validator($trans, $data, ['foo' => ['numeric', $rule]]);
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public static function untrimmableWhitespaceFieldComparisonRules()
+    {
+        $data = [];
+
+        foreach (['gt:bar', 'lt:bar', 'gte:bar', 'lte:bar'] as $rule) {
+            foreach (["\x0C5", "5\x0C"] as $value) {
+                $data[] = [['foo' => $value, 'bar' => 5], $rule];
+                $data[] = [['foo' => 5, 'bar' => $value], $rule];
+            }
+        }
+
+        return $data;
+    }
+
     #[DataProvider('outsideRangeExponents')]
     public function testItLimitsLengthOfScientificNotationExponent($value)
     {


### PR DESCRIPTION
In the `gt` and `gte` branches that compare against another field, the existing `catch (MathException)` is dead code: nothing inside that `try` can raise the framework's `MathException`, so the guard has never caught anything. The matching `lt` and `lte` branches have no guard at all. In every case a `Brick\Math\Exception\NumberFormatException` from `BigNumber::of()` leaves the rule uncaught.

The cause is a name collision: the rules catch `Illuminate\Support\Exceptions\MathException`, while `brick/math` signals failure with the unrelated `Brick\Math\Exception\MathException`, already imported in this trait as `BrickMathException`.

The input that reaches it is any string `is_numeric()` accepts but `trim()` does not clean — PHP's trim charlist contains `\x0B` but not `\x0C`, so a form feed beside a digit survives, as in `"\x0C5"` (the form feed is the only such byte). To be clear about reachability: the `TrimStrings` middleware strips this from ordinary HTTP input, so a stock request path is not affected. It surfaces where the validator runs on data that middleware never touched — `Validator::make()` on queue payloads, imported files, console input or third-party API responses — and on fields listed in `TrimStrings::$except`.

This is a different trigger from the previously reported `INF`/`NAN` cases: `is_numeric('INF') === false` and `json_decode` rejects the literal `Infinity`, so those need a non-finite PHP float to reach the validator, whereas this value is a plain string and arrives wherever strings arrive.

Fixes #61325.

Each affected catch now also catches the Brick type, and `lt`/`lte` gain the same `try`/`catch` their `gt`/`gte` counterparts already use. 32 tests cover both unclean positions across all eight rules, and both comparison paths of the four relational rules; every modified site was verified individually by reverting it alone and confirming a test fails. `multiple_of` documents `@throws` and deliberately wraps and rethrows as the framework's `MathException` rather than returning false, so it is out of scope.
