### PR TITLE
[13.x] Cache derived model table names per class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -296,6 +296,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static array $classAttributes = [];
 
     /**
+     * Cache of table names derived from the model class name.
+     *
+     * @var array<class-string<self>, string>
+     */
+    protected static array $resolvedTableNames = [];
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -2300,7 +2307,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getTable()
     {
-        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
+        if (! is_null($this->table)) {
+            return $this->table;
+        }
+
+        return static::$resolvedTableNames[static::class] ??= Str::snake(Str::pluralStudly(class_basename($this)));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -52,6 +52,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
 use Illuminate\Tests\Database\Fixtures\Enums\StringStatus;
@@ -2224,6 +2225,39 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
     }
 
+    public function testDerivedTableNameIsResolvedOncePerClass()
+    {
+        $this->assertSame('eloquent_model_animals', (new EloquentModelAnimal)->getTable());
+
+        try {
+            Pluralizer::useLanguage('french');
+
+            $this->assertSame('eloquent_model_animals', (new EloquentModelAnimal)->getTable());
+        } finally {
+            Pluralizer::useLanguage('english');
+        }
+    }
+
+    public function testGetTableDoesNotMutateInstanceState()
+    {
+        $pristine = new EloquentModelWithoutTableStub;
+
+        $model = new EloquentModelWithoutTableStub;
+        $model->getTable();
+
+        $this->assertEquals($pristine, $model);
+    }
+
+    public function testSetTableTakesPrecedenceOverTheResolvedTableName()
+    {
+        $model = new EloquentModelAnimal;
+        $model->getTable();
+
+        $model->setTable('custom_animals');
+
+        $this->assertSame('custom_animals', $model->getTable());
+    }
+
     public function testTheMutatorCacheIsPopulated()
     {
         $class = new EloquentModelStub;
@@ -4372,6 +4406,11 @@ class EloquentModelWithoutRelationStub extends Model
 }
 
 class EloquentModelWithoutTableStub extends Model
+{
+    //
+}
+
+class EloquentModelAnimal extends Model
 {
     //
 }


### PR DESCRIPTION
## Summary

`Model::getTable()` currently re-derives the table name — `Str::snake(Str::pluralStudly(class_basename($this)))` — on **every call** for models that don't set an explicit `$table` (the default for most models). `getTable()` sits on several hot paths: `newQuery()`, `qualifyColumn()`, relationship construction, etc.

This PR caches the derived name in a static array keyed by class name, so the derivation runs once per class per process:

```php
public function getTable()
{
    if (! is_null($this->table)) {
        return $this->table;
    }

    return static::$resolvedTableNames[static::class] ??= Str::snake(Str::pluralStudly(class_basename($this)));
}
```

## Benchmark

PHP 8.5.4 (CLI, NTS), median of 7 rounds per measurement, model without an explicit `$table`:

| Operation | 13.x HEAD | This PR | Change |
|---|---|---|---|
| `getTable()` × 1,000,000 | 1,232.6 ms | 82.6 ms | **~15× faster** |
| `qualifyColumn('id')` × 200,000 | 256.4 ms | 29.3 ms | **~9× faster** |
| `newQuery()->where('id', 1)` × 20,000 | 192.0 ms | 156.4 ms | **~18% faster** |
| `getForeignKey()` × 200,000 | 49.7 ms | 47.6 ms | unchanged (does not use `getTable()`) |

<details>
<summary>Benchmark script</summary>

```php
<?php

require 'vendor/autoload.php';

use Illuminate\Database\Capsule\Manager as Capsule;
use Illuminate\Database\Eloquent\Model;

$capsule = new Capsule;
$capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
$capsule->setAsGlobal();
$capsule->bootEloquent();

class BenchmarkOrderLine extends Model {}

function bench(string $label, int $iterations, callable $callback): void
{
    $samples = [];
    for ($round = 0; $round < 7; $round++) {
        $start = hrtime(true);
        for ($i = 0; $i < $iterations; $i++) {
            $callback();
        }
        $samples[] = (hrtime(true) - $start) / 1e6;
    }
    sort($samples);
    printf("%-40s median %8.2f ms  (%d iterations)\n", $label, $samples[3], $iterations);
}

$model = new BenchmarkOrderLine;

bench('getTable()', 1_000_000, fn () => $model->getTable());
bench("qualifyColumn('id')", 200_000, fn () => $model->qualifyColumn('id'));
bench('getForeignKey()', 200_000, fn () => $model->getForeignKey());
bench("newQuery()->where('id', 1)", 20_000, fn () => BenchmarkOrderLine::query()->where('id', 1));
```

</details>

## Design notes

- **Static per-class cache, not instance memoization.** Assigning the derived name to `$this->table` (e.g. `$this->table ??= ...`) would mutate protected instance state, which breaks loose object comparison between fresh and used instances. A test covering this invariant is included (`testGetTableDoesNotMutateInstanceState`).
- **Bounded key space.** The cache is keyed by model class name, so its size is bounded by the number of model classes in the application — unlike caching inside `Pluralizer`/`Str`, which would be keyed by arbitrary input.
- **Explicit `$table` and `setTable()` still take precedence** — covered by `testSetTableTakesPrecedenceOverTheResolvedTableName`.

## Tests

- `testDerivedTableNameIsResolvedOncePerClass` — pins the once-per-class resolution semantics.
- `testGetTableDoesNotMutateInstanceState` — guards against instance-state mutation.
- `testSetTableTakesPrecedenceOverTheResolvedTableName` — guards `setTable()` precedence over a populated cache.

Full `tests/Database` suite passes (2,835 tests, 7,840 assertions).
