### PR TITLE
[13.x] Adjust `ConcurrencyTest` & `SerializableClosureV1QueueTest`

### DIFF
--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[RequiresOperatingSystem('Linux|Darwin')]
-#[WithEnv('APP_KEY', 'somerandomstring')]
+#[WithEnv('APP_KEY', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -8,11 +8,13 @@ use Illuminate\Concurrency\SyncDriver;
 use Illuminate\Foundation\Application;
 use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Support\Facades\Concurrency;
+use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[RequiresOperatingSystem('Linux|Darwin')]
+#[WithEnv('APP_KEY', 'somerandomstring')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Queue/SerializableClosureV1QueueTest.php
+++ b/tests/Integration/Queue/SerializableClosureV1QueueTest.php
@@ -4,11 +4,13 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
 
 #[WithMigration]
+#[WithEnv('APP_KEY', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 class SerializableClosureV1QueueTest extends TestCase
 {
     use RefreshDatabase;
@@ -21,7 +23,6 @@ class SerializableClosureV1QueueTest extends TestCase
 
         tap($app->make('config'), function ($config) {
             $config->set([
-                'app.key' => 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF',
                 'queue.default' => 'database',
             ]);
         });


### PR DESCRIPTION
There's was hella broken tests: https://github.com/laravel/framework/actions/runs/32863503072/job/97852999069#step:5:415 

This was because https://github.com/laravel/serializable-closure/pull/174 

TLDR is, the tests wasn't getting the same key as the signer..... or it was too late (ie needs to be present at register time)

So, now they doooooo which fixes the frameworks tests

In real apps, the app key should always be present, so this only really affects tests - and not sure how many people really are testing bits like this, so didn't go for revert. 

I always check the tests when I get something merged and feel responsible for fixing it.. so here we are 🫡 