### PR TITLE
[14.x] Redirect unauthenticated PUT/PATCH/DELETE requests with 303 See Other

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -856,7 +856,10 @@ class Handler implements ExceptionHandlerContract
             return response()->noContent(401);
         }
 
-        return redirect()->guest($redirectTo);
+        return redirect()->guest(
+            $redirectTo,
+            in_array($request->method(), ['PUT', 'PATCH', 'DELETE']) ? Response::HTTP_SEE_OTHER : Response::HTTP_FOUND
+        );
     }
 
     /**

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -336,4 +336,33 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         $this->assertCount(1, $recordedLogs);
         $this->assertStringContainsString('a really (truncated...)', $recordedLogs[0]['message']);
     }
+
+    public function testItRedirectsUnauthenticatedWritesWithSeeOtherStatus()
+    {
+        Route::get('login', fn () => 'login form')->name('login');
+        Route::put('protected-route', fn () => 'ok')->middleware('auth');
+        Route::delete('protected-route', fn () => 'ok')->middleware('auth');
+
+        // Browsers follow a 302 by replaying the request method on the
+        // redirect target (only POST is downgraded to GET), so a 302 would
+        // arrive as PUT /login and fail with a 405 instead of showing the
+        // login page. A 303 tells the browser to follow with GET.
+        $this->put('protected-route')
+            ->assertStatus(303)
+            ->assertRedirect('login');
+
+        $this->delete('protected-route')
+            ->assertStatus(303)
+            ->assertRedirect('login');
+    }
+
+    public function testItRedirectsUnauthenticatedReadsWithFoundStatus()
+    {
+        Route::get('login', fn () => 'login form')->name('login');
+        Route::get('protected-route', fn () => 'ok')->middleware('auth');
+
+        $this->get('protected-route')
+            ->assertStatus(302)
+            ->assertRedirect('login');
+    }
 }


### PR DESCRIPTION
Resubmission of #61324, which was closed for 13.x with "[feels like something I would only change on a major release](https://github.com/laravel/framework/pull/61324#issuecomment-5409249094)" — so here it is for the major release. Also incorporates the review suggestion from that PR to use the `Response` status constants instead of bare numbers.

Browsers follow a **302** by replaying the request method on the redirect target — per the fetch spec, only POST is downgraded to GET. So when an unauthenticated `PUT`, `PATCH` or `DELETE` request is redirected to the login page by `Handler::unauthenticated()`, the browser replays the same method against `/login`, which only answers GET/POST — and the user gets an unexplainable **405 Method Not Allowed** instead of the login form:

```
"PUT /dashboard/widgets" 302   ← session expired, redirect to login
"PUT /login"             405   ← browser replays the PUT on the redirect target
```

**Who hits this**

Any application whose frontend sends writes as real PUT/PATCH/DELETE (Inertia, fetch/axios-based SPAs, htmx) when a session dies mid-edit — a tab left open overnight, a logout in another tab, `AuthenticateSession` invalidating after a password change.

Inertia's own middleware upgrades in-pipeline 302s to 303 for exactly this reason, but a redirect rendered from `AuthenticationException` does not travel back through the middleware stack, so that upgrade never runs — and when `AuthenticateSession` is in the web group (Jetstream's default), middleware priority hoists `Authenticate` above application middleware, making the escape reproducible in stock applications. We diagnosed this in a production app where "save widget settings" produced 405 error modals whenever a session expired (projectsend/projectsend#1673, fixed at the application level in projectsend/projectsend#1680).

**The change**

`Handler::unauthenticated()` issues the guest redirect with **303 See Other** for PUT/PATCH/DELETE requests. 303's semantics are precisely this case: "the response to your request is at this other URI — fetch it with GET."

- GET redirects keep their 302 — no change.
- POST is deliberately left untouched: browsers already downgrade POST→GET on a 302, so a change would only churn userland tests that assert `assertStatus(302)` after an unauthenticated POST.
- JSON requests are unaffected (still 401), as is the 401 no-content answer when no redirect target is configured.

Two integration tests cover the new behavior (PUT/DELETE → 303 to login) and pin the unchanged one (GET → 302).