### PR TITLE
[13.x] Fix MariaDB vector distance SQL and add AsVector Eloquent cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsVector.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\Grammars\MariaDbGrammar;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class AsVector implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<array<int, float>, \Illuminate\Contracts\Support\Arrayable|array<int, float>>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // A vector assigned to the model but not yet persisted on MariaDB
+                // is held as a "vec_fromtext('[...]')" expression, so pull the
+                // JSON back out of it...
+                if ($value instanceof ExpressionContract) {
+                    $value = Str::between($value->getValue($model->getConnection()->getQueryGrammar()), "('", "')");
+                }
+
+                // Postgres (pgvector) and MariaDB's vec_totext() return JSON text...
+                if (str_starts_with($value, '[')) {
+                    return array_map(floatval(...), json_decode($value, true, flags: JSON_THROW_ON_ERROR));
+                }
+
+                // ...while MariaDB vector columns return little-endian float32 bytes.
+                return array_values(unpack('g*', $value));
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if ($value === null) {
+                    return [$key => null];
+                }
+
+                if ($value instanceof Arrayable) {
+                    $value = $value->toArray();
+                }
+
+                if (! is_array($value)) {
+                    throw new InvalidArgumentException(
+                        sprintf('The [%s] attribute must be an array of floats or an Arrayable instance.', $key)
+                    );
+                }
+
+                $vector = json_encode(array_values(array_map(floatval(...), $value)), JSON_THROW_ON_ERROR);
+
+                // MariaDB will not accept text (or raw bytes) bound directly to a
+                // vector column, so the JSON has to be converted server-side. The
+                // JSON encoding of a float array only ever contains digits, ".",
+                // "-", "e", "," and brackets, so it is safe to inline.
+                return [
+                    $key => $model->getConnection()->getQueryGrammar() instanceof MariaDbGrammar
+                        ? new Expression("vec_fromtext('{$vector}')")
+                        : $vector,
+                ];
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsVector.php
@@ -29,20 +29,22 @@ class AsVector implements Castable
                     return null;
                 }
 
-                // A vector assigned to the model but not yet persisted on MariaDB
-                // is held as a "vec_fromtext('[...]')" expression, so pull the
-                // JSON back out of it...
-                if ($value instanceof ExpressionContract) {
-                    $value = Str::between($value->getValue($model->getConnection()->getQueryGrammar()), "('", "')");
-                }
+                $grammar = $model->getConnection()->getQueryGrammar();
 
-                // Postgres (pgvector) and MariaDB's vec_totext() return JSON text...
-                if (str_starts_with($value, '[')) {
+                // Decode a MariaDB expression assigned to the model before it is persisted...
+                if ($value instanceof ExpressionContract) {
+                    $value = Str::between($value->getValue($grammar), "('", "')");
+
                     return array_map(floatval(...), json_decode($value, true, flags: JSON_THROW_ON_ERROR));
                 }
 
-                // ...while MariaDB vector columns return little-endian float32 bytes.
-                return array_values(unpack('g*', $value));
+                // MariaDB vector columns return little-endian float32 bytes...
+                if ($grammar instanceof MariaDbGrammar) {
+                    return array_values(unpack('g*', $value));
+                }
+
+                // PostgreSQL (pgvector) returns JSON text...
+                return array_map(floatval(...), json_decode($value, true, flags: JSON_THROW_ON_ERROR));
             }
 
             public function set($model, $key, $value, $attributes)
@@ -63,10 +65,7 @@ class AsVector implements Castable
 
                 $vector = json_encode(array_values(array_map(floatval(...), $value)), JSON_THROW_ON_ERROR);
 
-                // MariaDB will not accept text (or raw bytes) bound directly to a
-                // vector column, so the JSON has to be converted server-side. The
-                // JSON encoding of a float array only ever contains digits, ".",
-                // "-", "e", "," and brackets, so it is safe to inline.
+                // MariaDB requires vectors to be converted from JSON text server-side...
                 return [
                     $key => $model->getConnection()->getQueryGrammar() instanceof MariaDbGrammar
                         ? new Expression("vec_fromtext('{$vector}')")

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -46,9 +46,6 @@ class MariaDbGrammar extends MySqlGrammar
     /**
      * Compile a vector distance expression for the given column.
      *
-     * The bound vector is JSON text, so it must pass through vec_fromtext()
-     * before MariaDB will accept it as a VECTOR argument.
-     *
      * @param  string  $column
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -46,12 +46,15 @@ class MariaDbGrammar extends MySqlGrammar
     /**
      * Compile a vector distance expression for the given column.
      *
+     * The bound vector is JSON text, so it must pass through vec_fromtext()
+     * before MariaDB will accept it as a VECTOR argument.
+     *
      * @param  string  $column
      * @return string
      */
     public function compileVectorDistanceExpression($column)
     {
-        return "vec_distance_cosine({$this->wrap($column)}, ?)";
+        return "vec_distance_cosine({$this->wrap($column)}, vec_fromtext(?))";
     }
 
     /**

--- a/tests/Database/DatabaseEloquentAsVectorCastTest.php
+++ b/tests/Database/DatabaseEloquentAsVectorCastTest.php
@@ -33,6 +33,16 @@ class DatabaseEloquentAsVectorCastTest extends TestCase
         $this->assertSame([0.5, -1.25, 3.0], $model->embedding);
     }
 
+    public function testGetDecodesBinaryVectorBeginningWithOpeningBracketByte()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->setRawAttributes(['embedding' => pack('g*', 1.0000108480453491)]);
+
+        $this->assertSame([1.0000108480453491], $model->embedding);
+    }
+
     public function testGetDecodesTextVector()
     {
         $this->useGrammar(PostgresGrammar::class);

--- a/tests/Database/DatabaseEloquentAsVectorCastTest.php
+++ b/tests/Database/DatabaseEloquentAsVectorCastTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Casts\AsVector;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\Grammars\MariaDbGrammar;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentAsVectorCastTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        Model::unsetConnectionResolver();
+    }
+
+    public function testGetDecodesBinaryVector()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->setRawAttributes(['embedding' => pack('g*', 0.5, -1.25, 3)]);
+
+        $this->assertSame([0.5, -1.25, 3.0], $model->embedding);
+    }
+
+    public function testGetDecodesTextVector()
+    {
+        $this->useGrammar(PostgresGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->setRawAttributes(['embedding' => '[0.5,-1.25,3]']);
+
+        $this->assertSame([0.5, -1.25, 3.0], $model->embedding);
+    }
+
+    public function testGetReturnsNullForNullValue()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->setRawAttributes(['embedding' => null]);
+
+        $this->assertNull($model->embedding);
+    }
+
+    public function testSetOnMariaDbWrapsVectorInVecFromText()
+    {
+        $grammar = $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = [0.5, -1.25, 3.75];
+
+        $attribute = $model->getAttributes()['embedding'];
+
+        $this->assertInstanceOf(Expression::class, $attribute);
+        $this->assertSame("vec_fromtext('[0.5,-1.25,3.75]')", $attribute->getValue($grammar));
+    }
+
+    public function testSetOnPostgresStoresJson()
+    {
+        $this->useGrammar(PostgresGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = [0.5, -1.25, 3.75];
+
+        $this->assertSame('[0.5,-1.25,3.75]', $model->getAttributes()['embedding']);
+    }
+
+    public function testSetAcceptsArrayable()
+    {
+        $this->useGrammar(PostgresGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = new Collection([0.5, -1.25, 3.75]);
+
+        $this->assertSame('[0.5,-1.25,3.75]', $model->getAttributes()['embedding']);
+    }
+
+    public function testSetStoresNullAsNull()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = null;
+
+        $this->assertNull($model->getAttributes()['embedding']);
+    }
+
+    public function testSetRejectsNonArrayValues()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [embedding] attribute must be an array of floats or an Arrayable instance.');
+
+        $model = new AsVectorTestModel;
+        $model->embedding = 'not a vector';
+    }
+
+    public function testVectorCanBeReadBackBeforeSavingOnMariaDb()
+    {
+        $this->useGrammar(MariaDbGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = [0.5, -1.25, 3];
+
+        $this->assertSame([0.5, -1.25, 3.0], $model->embedding);
+    }
+
+    public function testVectorCanBeReadBackBeforeSavingOnPostgres()
+    {
+        $this->useGrammar(PostgresGrammar::class);
+
+        $model = new AsVectorTestModel;
+        $model->embedding = [0.5, -1.25, 3];
+
+        $this->assertSame([0.5, -1.25, 3.0], $model->embedding);
+    }
+
+    protected function useGrammar(string $grammar)
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = new $grammar($connection);
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('connection')->andReturn($connection);
+
+        Model::setConnectionResolver($resolver);
+
+        return $grammar;
+    }
+}
+
+class AsVectorTestModel extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'embedding' => AsVector::class,
+    ];
+}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7879,7 +7879,7 @@ SQL;
         $builder->select('*')->from('documents')->whereVectorSimilarTo('embedding', [1, 2, 3], minSimilarity: 0.4)->limit(10);
 
         $this->assertSame(
-            'select * from `documents` where vec_distance_cosine(`embedding`, ?) <= ? order by vec_distance_cosine(`embedding`, ?) asc limit 10',
+            'select * from `documents` where vec_distance_cosine(`embedding`, vec_fromtext(?)) <= ? order by vec_distance_cosine(`embedding`, vec_fromtext(?)) asc limit 10',
             $builder->toSql()
         );
         $this->assertEquals(['[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
@@ -7908,7 +7908,7 @@ SQL;
         $builder = $this->getMariaDbBuilder();
         $builder->select('*')->from('documents')->whereVectorDistanceLessThan('embedding', [1, 2, 3], 0.5);
 
-        $this->assertSame('select * from `documents` where vec_distance_cosine(`embedding`, ?) <= ?', $builder->toSql());
+        $this->assertSame('select * from `documents` where vec_distance_cosine(`embedding`, vec_fromtext(?)) <= ?', $builder->toSql());
         $this->assertEquals(['[1,2,3]', 0.5], $builder->getBindings());
     }
 
@@ -7917,7 +7917,7 @@ SQL;
         $builder = $this->getMariaDbBuilder();
         $builder->select('*')->from('documents')->orderByVectorDistance('embedding', [1, 2, 3]);
 
-        $this->assertSame('select * from `documents` order by vec_distance_cosine(`embedding`, ?) asc', $builder->toSql());
+        $this->assertSame('select * from `documents` order by vec_distance_cosine(`embedding`, vec_fromtext(?)) asc', $builder->toSql());
         $this->assertEquals(['[1,2,3]'], $builder->getBindings());
     }
 
@@ -7926,7 +7926,7 @@ SQL;
         $builder = $this->getMariaDbBuilder();
         $builder->from('documents')->selectVectorDistance('embedding', [1, 2, 3]);
 
-        $this->assertSame('select vec_distance_cosine(`embedding`, ?) as `embedding_distance` from `documents`', $builder->toSql());
+        $this->assertSame('select vec_distance_cosine(`embedding`, vec_fromtext(?)) as `embedding_distance` from `documents`', $builder->toSql());
         $this->assertEquals(['[1,2,3]'], $builder->getBindings());
     }
 

--- a/tests/Integration/Database/MariaDb/EloquentVectorTest.php
+++ b/tests/Integration/Database/MariaDb/EloquentVectorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MariaDb;
+
+use Illuminate\Database\Eloquent\Casts\AsVector;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+
+#[RequiresDatabase('mariadb', '>=11.7.0')]
+class EloquentVectorTest extends MariaDbTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->increments('id');
+            $table->vector('embedding', 3);
+            $table->vectorIndex('embedding');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('documents');
+    }
+
+    public function testVectorsCanBeStoredAndRetrieved()
+    {
+        $document = VectorDocument::create(['embedding' => [0.5, -1.25, 3]]);
+
+        $this->assertSame([0.5, -1.25, 3.0], $document->embedding);
+        $this->assertSame([0.5, -1.25, 3.0], $document->fresh()->embedding);
+    }
+
+    public function testVectorsCanBeUpdated()
+    {
+        $document = VectorDocument::create(['embedding' => [0.5, -1.25, 3]]);
+
+        $document->update(['embedding' => [1, 2, 3]]);
+
+        $this->assertSame([1.0, 2.0, 3.0], $document->fresh()->embedding);
+    }
+
+    public function testVectorsCanBeQueriedByDistance()
+    {
+        $exact = VectorDocument::create(['embedding' => [1, 0, 0]]);
+        $close = VectorDocument::create(['embedding' => [0.9, 0.1, 0]]);
+        VectorDocument::create(['embedding' => [0, 1, 0]]);
+
+        $results = VectorDocument::query()
+            ->select('id')
+            ->selectVectorDistance('embedding', [1, 0, 0])
+            ->whereVectorSimilarTo('embedding', [1, 0, 0], minSimilarity: 0.5)
+            ->get();
+
+        $this->assertSame([$exact->id, $close->id], $results->pluck('id')->all());
+        $this->assertEqualsWithDelta(0.0, (float) $results[0]->embedding_distance, 0.0001);
+        $this->assertGreaterThan(0.0, (float) $results[1]->embedding_distance);
+    }
+}
+
+class VectorDocument extends Model
+{
+    protected $table = 'documents';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'embedding' => AsVector::class,
+    ];
+}


### PR DESCRIPTION
## Summary

Follow-up to #61250, which routed the vector query builder methods through the grammar and added MariaDB support via `vec_distance_cosine()`.

### 1. Bug fix: the MariaDB SQL from #61250 is rejected by the server

MariaDB's `VEC_DISTANCE_*` functions only accept `VECTOR` arguments. The query builder binds the vector as JSON text, so `vec_distance_cosine(col, ?)` fails on a real server for every `whereVectorSimilarTo` / `whereVectorDistanceLessThan` / `orderByVectorDistance` / `selectVectorDistance` call (reproduced on MariaDB 11.8.9, with both native and emulated prepares):

```
SQLSTATE[HY000]: General error: 4079 Illegal parameter data type varchar for operation 'VEC_DISTANCE_COSINE'
```

`MariaDbGrammar::compileVectorDistanceExpression()` now emits `vec_distance_cosine(col, vec_fromtext(?))`. The bindings are unchanged (still JSON text), and `EXPLAIN` confirms the MHNSW `VECTOR INDEX` is still used for `order by vec_distance_cosine(..., vec_fromtext(?))`.

### 2. New `AsVector` Eloquent cast

Vector columns had no first-party cast. On MariaDB the `array` cast cannot work at all: the column is returned as little-endian float32 bytes, and a JSON string bound to a `VECTOR` column is rejected with `1292 Incorrect vector value` (raw packed bytes bound as a parameter are rejected too, regardless of `PDO::PARAM_LOB`).

`Illuminate\Database\Eloquent\Casts\AsVector` is driver-portable:

- **get**: decodes MariaDB's binary format (`unpack('g*')`), pgvector / `vec_totext()` JSON text, and a not-yet-persisted MariaDB value (so `$model->embedding` works right after `create()`).
- **set**: accepts an `array` or `Arrayable` (e.g. a `Collection`) of floats. On MariaDB it stores a `vec_fromtext('[...]')` expression, since the conversion has to happen server-side; on other drivers it stores the JSON string (which pgvector accepts). The inlined JSON only ever contains digits, `.`, `-`, `e`, `,` and brackets (`json_encode(..., JSON_THROW_ON_ERROR)` rejects NaN/Inf), so it is safe to inline.

```php
Schema::create('documents', function (Blueprint $table) {
    $table->id();
    $table->vector('embedding', 768);
    $table->vectorIndex('embedding');
});

class Document extends Model
{
    protected $casts = ['embedding' => AsVector::class];
}

Document::create(['embedding' => $embedding]);

Document::query()->whereVectorSimilarTo('embedding', $query, minSimilarity: 0.7)->limit(10)->get();
```

## Test plan

- [x] `tests/Database/DatabaseQueryBuilderTest.php` — MariaDB vector assertions updated to `vec_fromtext(?)`.
- [x] `tests/Database/DatabaseEloquentAsVectorCastTest.php` — new unit tests for the cast against the MariaDB and Postgres grammars (binary/text decoding, `vec_fromtext` vs JSON storage, `Arrayable` input, null handling, invalid input, read-back before save).
- [x] `tests/Integration/Database/MariaDb/EloquentVectorTest.php` — new end-to-end test (`vector()` + `vectorIndex()` migration, create/read/update through the cast, `selectVectorDistance` + `whereVectorSimilarTo`). Gated with `#[RequiresDatabase('mariadb', '>=11.7.0')]` since CI runs `mariadb:10`; passes locally against MariaDB 11.8.9.
- [x] `vendor/bin/phpunit tests/Database` (2842 tests)
- [x] `vendor/bin/pint --test`
