### PR TITLE
[13.x] Output the worker stop reason in queue:work

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\WorkerQueuePaused;
 use Illuminate\Queue\Events\WorkerQueueResumed;
+use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
@@ -213,6 +214,10 @@ class WorkCommand extends Command
             $this->writeQueueStatus($event->queue, 'resumed');
         });
 
+        $this->laravel['events']->listen(WorkerStopping::class, function ($event) {
+            $this->writeStopReason($event);
+        });
+
         static::$hasRegisteredListeners = true;
     }
 
@@ -266,6 +271,39 @@ class WorkCommand extends Command
             $status === 'paused'
                 ? '<fg=yellow;options=bold>PAUSED</>'
                 : '<fg=green;options=bold>RESUMED</>',
+        ));
+    }
+
+    /**
+     * Write the status output for a queue worker that is stopping.
+     *
+     * @param  \Illuminate\Queue\Events\WorkerStopping  $event
+     * @return void
+     */
+    protected function writeStopReason(WorkerStopping $event)
+    {
+        if ($this->output->isQuiet() || $this->output->isSilent() || is_null($event->reason)) {
+            return;
+        }
+
+        if ($this->outputUsingJson()) {
+            $this->output->writeln(json_encode([
+                'level' => $event->status === 0 ? 'info' : 'warning',
+                'status' => 'stopped',
+                'reason' => $event->reason->value,
+                'exit_code' => $event->status,
+                'jobs_processed' => $event->jobsProcessed,
+                'memory' => is_null($event->memoryUsage) ? null : round($event->memoryUsage, 1),
+                'timestamp' => $this->now()->format('Y-m-d\TH:i:s.uP'),
+            ]));
+
+            return;
+        }
+
+        $this->output->writeln(sprintf(
+            '  <fg=gray>%s</> Worker <fg=yellow;options=bold>STOPPED</> <fg=gray>%s</>',
+            $this->now()->format('Y-m-d H:i:s'),
+            $event->reason->description(),
         ));
     }
 

--- a/src/Illuminate/Queue/WorkerStopReason.php
+++ b/src/Illuminate/Queue/WorkerStopReason.php
@@ -14,12 +14,7 @@ enum WorkerStopReason: string
     case ReceivedRestartSignal = 'restart_signal';
     case TimedOut = 'timed_out';
 
-    /**
-     * Get a human readable description of the stop reason.
-     *
-     * @return string
-     */
-    public function description()
+    public function description(): string
     {
         return match ($this) {
             self::Interrupted => 'Interrupted',

--- a/src/Illuminate/Queue/WorkerStopReason.php
+++ b/src/Illuminate/Queue/WorkerStopReason.php
@@ -13,4 +13,24 @@ enum WorkerStopReason: string
     case QueueEmptyFor = 'empty_for';
     case ReceivedRestartSignal = 'restart_signal';
     case TimedOut = 'timed_out';
+
+    /**
+     * Get a human readable description of the stop reason.
+     *
+     * @return string
+     */
+    public function description()
+    {
+        return match ($this) {
+            self::Interrupted => 'Interrupted',
+            self::LostConnection => 'Lost connection',
+            self::MaxJobsExceeded => 'Maximum jobs exceeded',
+            self::MaxMemoryExceeded => 'Memory limit exceeded',
+            self::MaxTimeExceeded => 'Maximum run time exceeded',
+            self::QueueEmpty => 'Queue empty',
+            self::QueueEmptyFor => 'Queue empty for the configured duration',
+            self::ReceivedRestartSignal => 'Received restart signal',
+            self::TimedOut => 'Job timed out',
+        };
+    }
 }

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -102,12 +102,24 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 1024,
-        ])->expectsOutputToContain('Queue empty')
-            ->assertExitCode(0);
+        ])->assertExitCode(0);
 
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertTrue(SecondJob::$ran);
+    }
+
+    public function testStopReasonIsWritten()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 1024,
+        ])->expectsOutputToContain('Queue empty')
+            ->assertExitCode(0);
     }
 
     public function testMemoryExceeded()
@@ -119,8 +131,7 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 1,
-        ])->expectsOutputToContain('Memory limit exceeded')
-            ->assertExitCode(12);
+        ])->assertExitCode(12);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
@@ -153,7 +164,7 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-jobs' => 1,
-        ])->expectsOutputToContain('Maximum jobs exceeded');
+        ]);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -109,19 +109,6 @@ class WorkCommandTest extends QueueTestCase
         $this->assertTrue(SecondJob::$ran);
     }
 
-    public function testStopReasonIsWritten()
-    {
-        Queue::push(new FirstJob);
-        Queue::push(new SecondJob);
-
-        $this->artisan('queue:work', [
-            '--daemon' => true,
-            '--stop-when-empty' => true,
-            '--memory' => 1024,
-        ])->expectsOutputToContain('Queue empty')
-            ->assertExitCode(0);
-    }
-
     public function testMemoryExceeded()
     {
         Queue::push(new FirstJob);
@@ -137,20 +124,6 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
-    }
-
-    public function testStopReasonIsWrittenAsJson()
-    {
-        Queue::push(new FirstJob);
-        Queue::push(new SecondJob);
-
-        $this->artisan('queue:work', [
-            '--daemon' => true,
-            '--stop-when-empty' => true,
-            '--memory' => 1,
-            '--json' => true,
-        ])->expectsOutputToContain('"status":"stopped","reason":"memory","exit_code":12')
-            ->assertExitCode(12);
     }
 
     public function testMaxJobsExceeded()
@@ -281,6 +254,33 @@ class WorkCommandTest extends QueueTestCase
         $this->withoutMockingConsoleOutput()->artisan('queue:work', ['--once' => true]);
         Exceptions::assertNotReported(UniqueConstraintViolationException::class);
         $this->assertSame(2, substr_count(Artisan::output(), JobWillFail::class));
+    }
+
+    public function testStopReasonIsWritten()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 1024,
+        ])->expectsOutputToContain('Queue empty')
+            ->assertExitCode(0);
+    }
+
+    public function testStopReasonIsWrittenAsJson()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 1,
+            '--json' => true,
+        ])->expectsOutputToContain('"status":"stopped","reason":"memory","exit_code":12')
+            ->assertExitCode(12);
     }
 }
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -102,7 +102,8 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 1024,
-        ])->assertExitCode(0);
+        ])->expectsOutputToContain('Queue empty')
+            ->assertExitCode(0);
 
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
@@ -118,12 +119,27 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 1,
-        ])->assertExitCode(12);
+        ])->expectsOutputToContain('Memory limit exceeded')
+            ->assertExitCode(12);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
+    }
+
+    public function testStopReasonIsWrittenAsJson()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 1,
+            '--json' => true,
+        ])->expectsOutputToContain('"status":"stopped","reason":"memory","exit_code":12')
+            ->assertExitCode(12);
     }
 
     public function testMaxJobsExceeded()
@@ -137,7 +153,7 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-jobs' => 1,
-        ]);
+        ])->expectsOutputToContain('Maximum jobs exceeded');
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());


### PR DESCRIPTION
This PR surfaces why the queue worker stopped directly in the `queue:work` output.

Currently, we have to use the WorkerStopping event, but, I think it would be also be nice to show this in the output which is nice for all environments, ie in prod you might be recording the logs with a third party, and locally/testing this helps too.

This means we can just follow the output rather than trying to tie events together, and just seems genuinely useful (imo)

Before: exited, no indication why: (just an example irl you could have a lot of options chained)

<img width="1203" height="186" alt="image" src="https://github.com/user-attachments/assets/73e8aafd-a277-426e-b47f-1535a6ecd2fe" />

After: we see why
<img width="1190" height="218" alt="image" src="https://github.com/user-attachments/assets/fceb97fe-8f40-4a83-9017-668c7a361706" />

Feel free to adjust the output, ie maybe we don't need the "Worker" bit

Thanks!!!!!!!!!!!!!!!!!
