### PR TITLE
[13.x] Reject explicit locales containing path separators

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -366,6 +366,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function load($namespace, $group, $locale)
     {
+        $this->ensureLocaleIsValid($locale);
+
         if ($this->isLoaded($namespace, $group, $locale)) {
             return;
         }
@@ -575,11 +577,24 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function setLocale($locale)
     {
-        if (Str::contains($locale, ['/', '\\'])) {
-            throw new InvalidArgumentException('Invalid characters present in locale.');
-        }
+        $this->ensureLocaleIsValid($locale);
 
         $this->locale = $locale;
+    }
+
+    /**
+     * Ensure the given locale may be safely used to resolve translation files.
+     *
+     * @param  string|null  $locale
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function ensureLocaleIsValid($locale)
+    {
+        if (Str::contains((string) $locale, ['/', '\\'])) {
+            throw new InvalidArgumentException('Invalid characters present in locale.');
+        }
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -3,15 +3,19 @@
 namespace Illuminate\Tests\Translation;
 
 use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Tests\Translation\Fixtures\Enums\Bar;
 use Illuminate\Tests\Translation\Fixtures\Enums\Baz;
 use Illuminate\Tests\Translation\Fixtures\Enums\Foo;
+use Illuminate\Translation\FileLoader;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use InvalidArgumentException;
 use Mockery;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class TranslationTranslatorTest extends TestCase
@@ -409,6 +413,93 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->expects('load')->with('en', 'foo', '*')->andReturn([]);
         $t->getLoader()->expects('load')->with('lz', 'foo', '*')->andReturn([]);
         $this->assertSame('foo', $t->get('foo'));
+    }
+
+    #[TestWith(['../../config'])]
+    #[TestWith(['..\..\config'])]
+    #[TestWith(['en/../../config'])]
+    #[TestWith(['/etc/passwd'])]
+    public function testGetMethodRejectsExplicitLocaleContainingPathSeparators($locale)
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+        $t->get('messages.title', [], $locale);
+    }
+
+    #[TestWith(['../../config'])]
+    #[TestWith(['..\..\config'])]
+    public function testChoiceMethodRejectsExplicitLocaleContainingPathSeparators($locale)
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+        $t->choice('messages.title', 1, [], $locale);
+    }
+
+    #[TestWith(['has'])]
+    #[TestWith(['hasForLocale'])]
+    public function testHasMethodsRejectExplicitLocaleContainingPathSeparators($method)
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+        $t->{$method}('messages.title', '../../config');
+    }
+
+    public function testLoadMethodRejectsLocaleContainingPathSeparators()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+        $t->load('*', 'messages', '../../config');
+    }
+
+    public function testSetLocaleRejectsLocaleContainingPathSeparators()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+        $t->setLocale('../../config');
+    }
+
+    #[TestWith(['en'])]
+    #[TestWith(['en_US'])]
+    #[TestWith(['pt-BR'])]
+    public function testValidExplicitLocalesAreStillLoaded($locale)
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->expects('load')->with($locale, '*', '*')->andReturn([]);
+        $t->getLoader()->expects('load')->with($locale, 'messages', '*')->andReturn(['title' => 'Hello']);
+
+        $this->assertSame('Hello', $t->get('messages.title', [], $locale));
+    }
+
+    public function testExplicitLocaleCannotLoadFilesOutsideOfTheTranslationPaths()
+    {
+        $base = sys_get_temp_dir().'/laravel-translation-'.Str::random(8);
+
+        mkdir($base.'/lang/en', 0777, true);
+        mkdir($base.'/config', 0777, true);
+        file_put_contents($base.'/lang/en/messages.php', '<?php return ["title" => "Hello"];');
+        file_put_contents($base.'/config/app.php', '<?php return ["title" => "secret"];');
+
+        try {
+            $t = new Translator(new FileLoader(new Filesystem, $base.'/lang'), 'en');
+
+            $this->assertSame('Hello', $t->get('messages.title'));
+
+            $this->expectExceptionObject(new InvalidArgumentException('Invalid characters present in locale.'));
+
+            $t->get('app.title', [], '../config');
+        } finally {
+            (new Filesystem)->deleteDirectory($base);
+        }
     }
 
     protected function getLoader()


### PR DESCRIPTION
`Translator::setLocale()` rejects `/` and `\`, but the same value passed as an explicit locale to `trans()`, `__()` or `trans_choice()` skips that check entirely:

```php
App::setLocale('../config');
// InvalidArgumentException: Invalid characters present in locale.

trans('app', [], '../config');
// no exception, and it dumps the whole of config/app.php:
// ['name' => 'Laravel', 'env' => 'production', 'key' => 'base64:...', ...]
```

The locale is dropped straight into the path `FileLoader` builds for the translation file:

```php
"{$path}/{$locale}/{$group}.php"
```

which then goes to `Filesystem::getRequire()`. So `../config` walks out of the lang directory and loads whatever it lands on. If the locale comes from the request at all, a `?lang=` parameter or a stored user preference, that reaches any `.php` file the process can read.

A check for `/` and `\` check to `setLocale()` was added back in [prevent insecure characters in locale](https://github.com/laravel/framework/commit/c248521f502c74c6cea7b0d221639d4aa752d5db), it just never applied to a locale passed in by hand. This moves that same check to a spot both paths go through, so `trans()` and other similar methods are covered by it too.

Nothing else changes. `en`, `en_US` and `pt-BR` work as before, and the only locales that throw now are ones you could never have set through `App::setLocale()` anyway.
