### PR TITLE
[13.x] Confine `Storage::path()` to the configured disk root

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -79,13 +79,6 @@ class FilesystemAdapter implements CloudFilesystemContract
     protected $prefixer;
 
     /**
-     * The Flysystem PathNormalizer instance.
-     *
-     * @var \League\Flysystem\PathNormalizer
-     */
-    protected $pathNormalizer;
-
-    /**
      * The file server callback.
      *
      * @var \Closure|null
@@ -121,8 +114,6 @@ class FilesystemAdapter implements CloudFilesystemContract
         $separator = $config['directory_separator'] ?? DIRECTORY_SEPARATOR;
 
         $this->prefixer = new PathPrefixer($config['root'] ?? '', $separator);
-        $this->pathNormalizer = new WhitespacePathNormalizer;
-
         if (isset($config['prefix'])) {
             $this->prefixer = new PathPrefixer($this->prefixer->prefixPath($config['prefix']), $separator);
         }
@@ -303,7 +294,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function path($path)
     {
-        return $this->prefixer->prefixPath($this->pathNormalizer->normalizePath($path));
+        return $this->prefixer->prefixPath((new WhitespacePathNormalizer)->normalizePath($path));
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -34,6 +34,7 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
+use League\Flysystem\WhitespacePathNormalizer;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
@@ -78,6 +79,13 @@ class FilesystemAdapter implements CloudFilesystemContract
     protected $prefixer;
 
     /**
+     * The Flysystem PathNormalizer instance.
+     *
+     * @var \League\Flysystem\PathNormalizer
+     */
+    protected $pathNormalizer;
+
+    /**
      * The file server callback.
      *
      * @var \Closure|null
@@ -113,6 +121,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $separator = $config['directory_separator'] ?? DIRECTORY_SEPARATOR;
 
         $this->prefixer = new PathPrefixer($config['root'] ?? '', $separator);
+        $this->pathNormalizer = new WhitespacePathNormalizer;
 
         if (isset($config['prefix'])) {
             $this->prefixer = new PathPrefixer($this->prefixer->prefixPath($config['prefix']), $separator);
@@ -294,7 +303,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function path($path)
     {
-        return $this->prefixer->prefixPath($path);
+        return $this->prefixer->prefixPath($this->pathNormalizer->normalizePath($path));
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -114,6 +114,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $separator = $config['directory_separator'] ?? DIRECTORY_SEPARATOR;
 
         $this->prefixer = new PathPrefixer($config['root'] ?? '', $separator);
+
         if (isset($config['prefix'])) {
             $this->prefixer = new PathPrefixer($this->prefixer->prefixPath($config['prefix']), $separator);
         }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -16,11 +16,13 @@ use InvalidArgumentException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Ftp\FtpAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\PathTraversalDetected;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use Mockery;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -173,6 +175,57 @@ class FilesystemAdapterTest extends TestCase
             'root' => $this->tempDir.DIRECTORY_SEPARATOR,
         ]);
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
+    }
+
+    #[TestWith(['../../../.env'])]
+    #[TestWith(['..\..\..\.env'])]
+    #[TestWith(['/../../../.env'])]
+    #[TestWith(['..'])]
+    #[TestWith(['foo/../../../.env'])]
+    public function testPathRejectsTraversalOutsideOfTheRoot($path)
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
+            'root' => $this->tempDir.DIRECTORY_SEPARATOR,
+        ]);
+
+        $this->expectException(PathTraversalDetected::class);
+
+        $filesystemAdapter->path($path);
+    }
+
+    public function testPathRejectsTraversalOutsideOfThePrefix()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
+            'root' => $this->tempDir.DIRECTORY_SEPARATOR,
+            'prefix' => 'scoped',
+        ]);
+
+        $this->assertSame(
+            $this->tempDir.DIRECTORY_SEPARATOR.'scoped'.DIRECTORY_SEPARATOR.'file.txt',
+            $filesystemAdapter->path('file.txt')
+        );
+
+        $this->expectException(PathTraversalDetected::class);
+
+        $filesystemAdapter->path('../file.txt');
+    }
+
+    public function testPathResolvesRelativeSegmentsTheSameWayTheDriverDoes()
+    {
+        $this->filesystem->write('foo/bar.txt', 'Hello World');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
+            'root' => $this->tempDir.DIRECTORY_SEPARATOR,
+        ]);
+
+        $expected = $this->tempDir.DIRECTORY_SEPARATOR.'foo/bar.txt';
+
+        $this->assertSame($expected, $filesystemAdapter->path('foo/bar.txt'));
+        $this->assertSame($expected, $filesystemAdapter->path('/foo/bar.txt'));
+        $this->assertSame($expected, $filesystemAdapter->path('foo/./bar.txt'));
+        $this->assertSame($expected, $filesystemAdapter->path('foo/baz/../bar.txt'));
+
+        $this->assertSame('Hello World', $filesystemAdapter->get('foo/baz/../bar.txt'));
+        $this->assertSame('Hello World', file_get_contents($filesystemAdapter->path('foo/baz/../bar.txt')));
     }
 
     public function testGet()


### PR DESCRIPTION
Every other storage operation goes through the Flysystem driver, which normalizes the path and throws `PathTraversalDetected` when it escapes the disk root. `Storage::path()` skips that and hands the path straight to `PathPrefixer::prefixPath()`, which only concatenates strings:

```php
Storage::get('../../../.env');  // rejected
Storage::path('../../../.env'); // resolves outside the disk
```

On the default local disk `path()` returns a native path pointing at the application's `.env`, while `get()`, `delete()` and `readStream()` all refuse the same argument. Scoped disks have the same hole, where `path('../file.txt')` walks straight out of the configured prefix.

That turns dangerous the moment an application builds the path from user controlled input:

```php
response()->download(Storage::path($request->query('path')));
```

The fix runs the path through `WhitespacePathNormalizer` before prefixing, the same normalizer `League\Flysystem\Filesystem` builds for every other call and with the same defaults. `path()` now returns exactly the string the driver computes internally, so the two can't disagree about what a path means.
