### PR TITLE
[13.x] Ability to opt out of vendor/default commands in DevCommands

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -71,14 +71,14 @@ class DevCommands
     protected static $autoRestart = true;
 
     /**
-     * Whether commands registered by packages within the "vendor" directory should be excluded.
+     * Whether to exclude vendor commands.
      *
      * @var bool
      */
     protected static $withoutVendorCommands = false;
 
     /**
-     * Whether the framework's default commands should be excluded.
+     * Whether to exclude the framework's default commands.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -71,6 +71,20 @@ class DevCommands
     protected static $autoRestart = true;
 
     /**
+     * Whether commands registered by packages within the "vendor" directory should be excluded.
+     *
+     * @var bool
+     */
+    protected static $withoutVendorCommands = false;
+
+    /**
+     * Whether the framework's default commands should be excluded.
+     *
+     * @var bool
+     */
+    protected static $withoutDefaultCommands = false;
+
+    /**
      * How many lines of output to buffer for each command when running in tabbed mode.
      *
      * @var int|null
@@ -181,6 +195,14 @@ class DevCommands
         $commands = [];
 
         foreach (self::$commands as $command) {
+            if (self::$withoutVendorCommands && $command->priority() === DevCommand::PRIORITY_VENDOR) {
+                continue;
+            }
+
+            if (self::$withoutDefaultCommands && $command->priority() === DevCommand::PRIORITY_DEFAULT) {
+                continue;
+            }
+
             $cmd = $command->toArray();
 
             if ((! empty(self::$only) && ! in_array($cmd['name'], self::$only)) || in_array($cmd['name'], self::$except)) {
@@ -437,6 +459,26 @@ class DevCommands
     public static function except(...$names): void
     {
         self::$except = $names;
+    }
+
+    /**
+     * Exclude any development commands registered by packages within the "vendor" directory.
+     *
+     * @return void
+     */
+    public static function withoutVendorCommands(): void
+    {
+        self::$withoutVendorCommands = true;
+    }
+
+    /**
+     * Exclude the framework's default development commands.
+     *
+     * @return void
+     */
+    public static function withoutDefaultCommands(): void
+    {
+        self::$withoutDefaultCommands = true;
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -462,7 +462,7 @@ class DevCommands
     }
 
     /**
-     * Exclude any development commands registered by packages within the "vendor" directory.
+     * Exclude any commands from the vendor directory.
      *
      * @return void
      */
@@ -472,7 +472,7 @@ class DevCommands
     }
 
     /**
-     * Exclude the framework's default development commands.
+     * Exclude the framework's default commands.
      *
      * @return void
      */

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -32,6 +32,8 @@ class FoundationDevCommandsTest extends TestCase
             'autoRestart' => true,
             'bufferSize' => null,
             'streamBufferSize' => null,
+            'withoutVendorCommands' => false,
+            'withoutDefaultCommands' => false,
         ] as $prop => $value) {
             $ref->getProperty($prop)->setValue(null, $value);
         }
@@ -397,5 +399,76 @@ class FoundationDevCommandsTest extends TestCase
         $this->assertArrayHasKey('source', $commands[0]);
         $this->assertIsArray($commands[0]['source']);
         $this->assertSame(__CLASS__, $commands[0]['source']['class']);
+    }
+
+    public function testVendorCommandsAreIncludedByDefault()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'vendor' => new DevCommand('echo vendor', [], 'vendor', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        DevCommands::register('echo local', 'local');
+
+        $names = array_column(DevCommands::commands(), 'name');
+
+        $this->assertContains('vendor', $names);
+        $this->assertContains('local', $names);
+    }
+
+    public function testWithoutVendorCommandsExcludesOnlyVendorCommands()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('php artisan serve', [], 'server', DevCommand::PRIORITY_DEFAULT),
+            'vendor' => new DevCommand('echo vendor', [], 'vendor', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        DevCommands::register('echo local', 'local');
+
+        DevCommands::withoutVendorCommands();
+
+        $names = array_column(DevCommands::commands(), 'name');
+
+        $this->assertNotContains('vendor', $names);
+        $this->assertContains('server', $names);
+        $this->assertContains('local', $names);
+    }
+
+    public function testWithoutDefaultCommandsExcludesOnlyFrameworkDefaultCommands()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('php artisan serve', [], 'server', DevCommand::PRIORITY_DEFAULT),
+            'vendor' => new DevCommand('echo vendor', [], 'vendor', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        DevCommands::register('echo local', 'local');
+
+        DevCommands::withoutDefaultCommands();
+
+        $names = array_column(DevCommands::commands(), 'name');
+
+        $this->assertNotContains('server', $names);
+        $this->assertContains('vendor', $names);
+        $this->assertContains('local', $names);
+    }
+
+    public function testWithoutVendorAndDefaultCommandsKeepsOnlyLocalCommands()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('php artisan serve', [], 'server', DevCommand::PRIORITY_DEFAULT),
+            'vendor' => new DevCommand('echo vendor', [], 'vendor', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        DevCommands::register('echo local', 'local');
+
+        DevCommands::withoutVendorCommands();
+        DevCommands::withoutDefaultCommands();
+
+        $names = array_column(DevCommands::commands(), 'name');
+
+        $this->assertSame(['local'], $names);
     }
 }


### PR DESCRIPTION
This PR adds two methods so we can opt out of vendor and default commands, which is completely opt in:

You can add the following to the AppServiceProvider:
```php
  DevCommands::withoutVendorCommands();   // ignore commands from vendor
  DevCommands::withoutDefaultCommands();  // ignore the framework defaults
```

Today, `DevCommands` registers everything.. that means all default and vendor commands. 

You can include or exclude them by name with `only()` / `except()` but, that means keeping a track of names and already knowing whats being added in advance.
 
This means, today in user land we end up with a bit of madness like this...  because it only takes names
```php
// We whitelist only the default, vendor and userland commands we require so when we run dev nothing new sneaks in
DevCommands::only(
    'logs',
    'vite',
    'reverb',
    'scheduler',
    'queue:a', // we have a lot of queue names...
    'queue:b',
    'queue:c',
    'queue:d',
    'queue:e', 
    // more....
);
```

We have a bunch of queues and stuff we manage, and use via DevCommands, but we never want to let vendor or default commands run when we run `php artisan dev` cos we have our own command setup. Ie tomorrow a package we use may add something it'll just come through right away.

Essentially for us, we want to ensure nothing creeps in, when we run `php artisan dev` we only wanna run what we want to run ie lock it down.

Hopefully it makes sense!  feel free to tweak cos I wasn't 100% on method names.

Thanks 🙇🏻 