### PR TITLE
[13.x] Add Redis Sentinel connections to the phpredis driver

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -261,18 +261,26 @@ class PhpRedisConnector implements Connector
      */
     protected function createSentinel($host, $port, array $config)
     {
+        return new RedisSentinel(...$this->sentinelParameters($host, $port, $config));
+    }
+
+    /**
+     * Get the constructor parameters for a Redis Sentinel client.
+     *
+     * @param  string  $host
+     * @param  int  $port
+     * @param  array  $config
+     * @return array
+     */
+    protected function sentinelParameters($host, $port, array $config)
+    {
         $timeout = (float) Arr::get($config, 'timeout', 0.0);
 
         if (version_compare(phpversion('redis'), '6.0.0', '>=')) {
-            return new RedisSentinel([
-                'host' => $host,
-                'port' => $port,
-                'connectTimeout' => $timeout,
-                'readTimeout' => $timeout,
-            ]);
+            return [['host' => $host, 'port' => $port, 'connectTimeout' => $timeout, 'readTimeout' => $timeout]];
         }
 
-        return new RedisSentinel($host, $port, $timeout, null, 0, $timeout);
+        return [$host, $port, $timeout, null, 0, $timeout];
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -12,6 +12,8 @@ use InvalidArgumentException;
 use LogicException;
 use Redis;
 use RedisCluster;
+use RedisException;
+use RedisSentinel;
 
 class PhpRedisConnector implements Connector
 {
@@ -33,6 +35,30 @@ class PhpRedisConnector implements Connector
         $connector = function () use ($config, $options, $formattedOptions) {
             return $this->createClient(array_merge(
                 $config, $options, $formattedOptions
+            ));
+        };
+
+        return new PhpRedisConnection($connector(), $connector, $config);
+    }
+
+    /**
+     * Create a new PhpRedis connection to the master of a Redis Sentinel service.
+     *
+     * @param  array  $config
+     * @param  array  $options
+     * @return \Illuminate\Redis\Connections\PhpRedisConnection
+     */
+    public function connectToSentinel(array $config, array $options)
+    {
+        $formattedOptions = Arr::pull($config, 'options', []);
+
+        if (isset($config['prefix'])) {
+            $formattedOptions['prefix'] = $config['prefix'];
+        }
+
+        $connector = function () use ($config, $options, $formattedOptions) {
+            return $this->createClient(array_merge(
+                $this->resolveSentinelMaster($config), $options, $formattedOptions
             ));
         };
 
@@ -185,6 +211,68 @@ class PhpRedisConnector implements Connector
         }
 
         $client->{$persistent ? 'pconnect' : 'connect'}(...$parameters);
+    }
+
+    /**
+     * Resolve the current master of the configured Redis Sentinel service.
+     *
+     * @param  array  $config
+     * @return array
+     *
+     * @throws \RedisException
+     */
+    protected function resolveSentinelMaster(array $config)
+    {
+        $service = $config['service'] ?? 'mymaster';
+
+        $failures = [];
+
+        foreach ($config['hosts'] ?? [] as $sentinel) {
+            $host = $sentinel['host'];
+            $port = (int) ($sentinel['port'] ?? 26379);
+
+            try {
+                $master = $this->createSentinel($host, $port, $config)->getMasterAddrByName($service);
+            } catch (RedisException $e) {
+                $failures[] = "{$host}:{$port} ({$e->getMessage()})";
+
+                continue;
+            }
+
+            if (is_array($master) && isset($master[0], $master[1])) {
+                return array_merge($config, ['host' => $master[0], 'port' => (int) $master[1]]);
+            }
+
+            $failures[] = "{$host}:{$port} (no master known for service [{$service}])";
+        }
+
+        throw new RedisException(
+            "Unable to resolve the Redis master for service [{$service}] from Sentinel: ".implode('; ', $failures)
+        );
+    }
+
+    /**
+     * Create the Redis Sentinel client instance.
+     *
+     * @param  string  $host
+     * @param  int  $port
+     * @param  array  $config
+     * @return \RedisSentinel
+     */
+    protected function createSentinel($host, $port, array $config)
+    {
+        $timeout = (float) Arr::get($config, 'timeout', 0.0);
+
+        if (version_compare(phpversion('redis'), '6.0.0', '>=')) {
+            return new RedisSentinel([
+                'host' => $host,
+                'port' => $port,
+                'connectTimeout' => $timeout,
+                'readTimeout' => $timeout,
+            ]);
+        }
+
+        return new RedisSentinel($host, $port, $timeout, null, 0, $timeout);
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -119,7 +119,25 @@ class RedisManager implements Factory
             return $this->resolveCluster($name);
         }
 
+        if (isset($this->config['sentinels'][$name])) {
+            return $this->resolveSentinel($name);
+        }
+
         throw new InvalidArgumentException("Redis connection [{$name}] not configured.");
+    }
+
+    /**
+     * Resolve the given Sentinel connection by name.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    protected function resolveSentinel($name)
+    {
+        return $this->connector()->connectToSentinel(
+            $this->parseConnectionConfiguration($this->config['sentinels'][$name]),
+            $this->config['options'] ?? []
+        );
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -426,6 +426,142 @@ class PhpRedisConnectorTest extends TestCase
         $this->assertSame('bar', $connection->command('get', ['foo']));
         $this->assertSame($healthyClient, $connection->client());
     }
+
+    public function testConnectToSentinelResolvesTheMaster()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-1:26379' => fn () => ['10.0.0.9', '6380'],
+        ]);
+
+        $connection = $connector->connectToSentinel([
+            'hosts' => [['host' => 'sentinel-1', 'port' => 26379]],
+            'service' => 'mymaster',
+            'database' => 2,
+        ], []);
+
+        $this->assertInstanceOf(PhpRedisConnection::class, $connection);
+        $this->assertSame(['sentinel-1:26379'], $connector->queried);
+        $this->assertSame('10.0.0.9', $connector->lastClientConfig['host']);
+        $this->assertSame(6380, $connector->lastClientConfig['port']);
+        $this->assertSame(2, $connector->lastClientConfig['database']);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectToSentinelSkipsSentinelsThatCannotNameTheMaster()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-1:26379' => fn () => throw new RedisException('Connection refused'),
+            'sentinel-2:26379' => fn () => false,
+            'sentinel-3:26379' => fn () => ['10.0.0.9', '6380'],
+        ]);
+
+        $connector->connectToSentinel([
+            'hosts' => [['host' => 'sentinel-1'], ['host' => 'sentinel-2', 'port' => 26379], ['host' => 'sentinel-3', 'port' => '26379']],
+        ], []);
+
+        $this->assertSame(['sentinel-1:26379', 'sentinel-2:26379', 'sentinel-3:26379'], $connector->queried);
+        $this->assertSame(['10.0.0.9:6380'], $connector->clients);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectToSentinelThrowsWhenNoSentinelKnowsTheMaster()
+    {
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-1:26379' => fn () => throw new RedisException('Connection refused'),
+            'sentinel-2:26379' => fn () => false,
+        ]);
+
+        try {
+            $connector->connectToSentinel(['hosts' => [['host' => 'sentinel-1'], ['host' => 'sentinel-2']]], []);
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertStringContainsString('service [mymaster]', $e->getMessage());
+            $this->assertStringContainsString('sentinel-1:26379 (Connection refused)', $e->getMessage());
+            $this->assertStringContainsString('sentinel-2:26379 (no master known for service [mymaster])', $e->getMessage());
+        }
+
+        $this->assertSame([], $connector->clients);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testSentinelConnectionResolvesTheMasterAgainWhenRebuildingItsClient()
+    {
+        $masters = [['10.0.0.9', '6380'], ['10.0.0.2', '6380']];
+
+        $connector = new SentinelStubPhpRedisConnector([
+            'sentinel-1:26379' => function () use (&$masters) {
+                return array_shift($masters);
+            },
+        ], ['10.0.0.9']);
+
+        $connection = $connector->connectToSentinel(['hosts' => [['host' => 'sentinel-1']]], []);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+        $this->assertSame(['sentinel-1:26379', 'sentinel-1:26379'], $connector->queried);
+        $this->assertSame(['10.0.0.9:6380', '10.0.0.2:6380'], $connector->clients);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testCreateSentinelReturnsARedisSentinelInstance()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->assertInstanceOf(\RedisSentinel::class, $connector->testCreateSentinel('127.0.0.1', 26379, ['timeout' => 0.5]));
+    }
+}
+
+class SentinelStubPhpRedisConnector extends PhpRedisConnector
+{
+    public array $queried = [];
+
+    public array $clients = [];
+
+    public array $lastClientConfig = [];
+
+    public function __construct(protected array $sentinels = [], protected array $deadHosts = [])
+    {
+    }
+
+    protected function createClient(array $config)
+    {
+        $this->clients[] = $config['host'].':'.$config['port'];
+        $this->lastClientConfig = $config;
+
+        return new class($config['host'], $this->deadHosts)
+        {
+            public function __construct(protected string $host, protected array $deadHosts)
+            {
+            }
+
+            public function get($key)
+            {
+                if (in_array($this->host, $this->deadHosts, true)) {
+                    throw new RedisException('Connection lost');
+                }
+
+                return 'bar';
+            }
+        };
+    }
+
+    protected function createSentinel($host, $port, array $config)
+    {
+        $this->queried[] = "{$host}:{$port}";
+
+        $answer = $this->sentinels["{$host}:{$port}"] ?? fn () => throw new RedisException('Connection refused');
+
+        return new class($answer)
+        {
+            public function __construct(protected $answer)
+            {
+            }
+
+            public function getMasterAddrByName($service)
+            {
+                return ($this->answer)($service);
+            }
+        };
+    }
 }
 
 class ClusterStubPhpRedisConnector extends PhpRedisConnector
@@ -471,5 +607,10 @@ class TestablePhpRedisConnector extends PhpRedisConnector
     public function testFormatHost(array $options): string
     {
         return $this->formatHost($options);
+    }
+
+    public function testCreateSentinel(string $host, int $port, array $config)
+    {
+        return $this->createSentinel($host, $port, $config);
     }
 }

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -34,11 +34,58 @@ class RedisManagerExtensionTest extends TestCase
                     ],
                 ],
             ],
+            'sentinels' => [
+                'my-sentinel' => [
+                    'hosts' => [['host' => 'sentinel-1', 'port' => 26379]],
+                    'service' => 'mymaster',
+                    'database' => 5,
+                    'timeout' => 0.5,
+                ],
+            ],
         ]);
 
         $this->redis->extend('my_custom_driver', function () {
             return new FakeRedisConnector;
         });
+    }
+
+    public function testUsingCustomRedisConnectorWithRedisSentinelInstance()
+    {
+        $this->assertSame(
+            'my-redis-sentinel-connection', $this->redis->resolve('my-sentinel')
+        );
+    }
+
+    public function testParseConnectionConfigurationForSentinel()
+    {
+        $connector = new FakeRedisConnector;
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'options' => [
+                'prefix' => 'laravel_database_',
+            ],
+            'sentinels' => [
+                'my-sentinel' => [
+                    'hosts' => [['host' => 'sentinel-1', 'port' => 26379]],
+                    'service' => 'mymaster',
+                    'database' => 5,
+                ],
+            ],
+        ]);
+
+        $redis->extend('my_custom_driver', function () use ($connector) {
+            return $connector;
+        });
+
+        $redis->resolve('my-sentinel');
+
+        $this->assertSame([
+            'hosts' => [['host' => 'sentinel-1', 'port' => 26379]],
+            'service' => 'mymaster',
+            'database' => 5,
+        ], $connector->sentinelConfig);
+
+        $this->assertSame(['prefix' => 'laravel_database_'], $connector->sentinelOptions);
     }
 
     public function testUsingCustomRedisConnectorWithSingleRedisInstance()
@@ -105,6 +152,10 @@ class RedisManagerExtensionTest extends TestCase
 
 class FakeRedisConnector implements Connector
 {
+    public $sentinelConfig;
+
+    public $sentinelOptions;
+
     /**
      * Create a new clustered Predis connection.
      *
@@ -128,6 +179,21 @@ class FakeRedisConnector implements Connector
     public function connectToCluster(array $config, array $clusterOptions, array $options)
     {
         return 'my-redis-cluster-connection';
+    }
+
+    /**
+     * Create a new Sentinel connection.
+     *
+     * @param  array  $config
+     * @param  array  $options
+     * @return string
+     */
+    public function connectToSentinel(array $config, array $options)
+    {
+        $this->sentinelConfig = $config;
+        $this->sentinelOptions = $options;
+
+        return 'my-redis-sentinel-connection';
     }
 }
 


### PR DESCRIPTION
Laravel's phpredis driver cannot talk to a Redis Sentinel deployment, while the Predis driver has supported it for years. This adds a `sentinels` configuration key alongside `clusters`, mirroring its shape:

```php
  'sentinels' => [
      'default' => [
          'hosts' => [
              ['host' => '10.0.0.1', 'port' => 26379],
              ['host' => '10.0.0.2', 'port' => 26379],
          ],
          'service' => 'mymaster',
          'password' => env('REDIS_PASSWORD'),
          'database' => 0,
      ],
  ],
```

As with `clusters`, a Sentinel connection takes the place of the plain connection of the same name, so the top-level `default` entry is removed.
`RedisManager::resolveSentinel()` hands the connection to `PhpRedisConnector::connectToSentinel()`, which asks the listed sentinels for the current master of the service and opens an ordinary phpredis connection to it, re-resolving the master whenever the connection rebuilds its client so the reconnect loop added in #61175 rides out a failover. 
Nothing existing is modified - no new client name, no new connection class, and `connect()` is untouched. 
This is phpredis-only for now; a `connectToSentinel()` for the Predis connector and a documentation PR will follow separately.