### PR TITLE
[13.x] Restore the facade application after route:cache boots a fresh application

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Facade;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'route:cache')]
@@ -92,7 +93,25 @@ class RouteCacheCommand extends Command
     {
         return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
             $app->make(ConsoleKernelContract::class)->bootstrap();
+
+            $this->restoreFacadeApplication();
         });
+    }
+
+    /**
+     * Re-point the facades at the running application.
+     *
+     * Bootstrapping the fresh application registers it as the facade
+     * application. Left in place, every facade resolved for the rest of the
+     * process would target that throwaway instance instead of this one.
+     *
+     * @return void
+     */
+    protected function restoreFacadeApplication()
+    {
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication($this->laravel);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -94,24 +94,10 @@ class RouteCacheCommand extends Command
         return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
             $app->make(ConsoleKernelContract::class)->bootstrap();
 
-            $this->restoreFacadeApplication();
+            Facade::clearResolvedInstances();
+
+            Facade::setFacadeApplication($this->laravel);
         });
-    }
-
-    /**
-     * Re-point the facades at the running application.
-     *
-     * Bootstrapping the fresh application registers it as the facade
-     * application. Left in place, every facade resolved for the rest of the
-     * process would target that throwaway instance instead of this one.
-     *
-     * @return void
-     */
-    protected function restoreFacadeApplication()
-    {
-        Facade::clearResolvedInstances();
-
-        Facade::setFacadeApplication($this->laravel);
     }
 
     /**

--- a/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Tests\Integration\Generators\TestCase;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+
+class RouteCacheCommandTest extends TestCase
+{
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'bootstrap/cache/routes-v7.php',
+    ];
+
+    public function testItRestoresTheFacadeApplicationAfterBootingAFreshApplication(): void
+    {
+        $this->artisan('route:cache')->assertSuccessful();
+
+        $this->assertSame($this->app, Facade::getFacadeApplication());
+    }
+
+    public function testItLeavesTheFacadeRootsPointingAtTheCurrentApplication(): void
+    {
+        $this->artisan('route:cache')->assertSuccessful();
+
+        $this->assertSame($this->app['router'], Route::getFacadeRoot());
+    }
+
+    public function testRoutesRemainAnalyzableAfterCaching(): void
+    {
+        Route::get('/posts', [RouteCacheCommandTestController::class, 'index']);
+
+        $this->artisan('route:cache')->assertSuccessful();
+
+        $route = collect(Route::getRoutes())->first(fn ($route) => $route->uri() === 'posts');
+
+        $this->assertNotNull($route, 'The registered route is no longer reachable through the route facade.');
+        $this->assertInstanceOf(RouteCacheCommandTestController::class, $route->getController());
+    }
+}
+
+class RouteCacheCommandTestController extends Controller
+{
+    public function index()
+    {
+        return 'ok';
+    }
+}


### PR DESCRIPTION
Fixes #60758

## The problem

`route:cache` boots a second, throwaway application to collect a pristine copy of
the routes:

```php
protected function getFreshApplication()
{
    return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
        $app->make(ConsoleKernelContract::class)->bootstrap();
    });
}
```

Bootstrapping that application runs `RegisterFacades`, which re-points the global
facade application at it:

```php
Facade::clearResolvedInstances();
Facade::setFacadeApplication($app);
```

Nothing puts it back. Once `route:cache` returns, every facade in the process —
`Route`, `Config`, `DB`, `Cache`, `Event`, `Log`, all of them — resolves against a
throwaway container that no one else is using, for the remainder of the process.

This is most visible under `php artisan optimize`, which runs `route:cache` before
the commands registered through `ServiceProvider::$optimizeCommands`. A package
task that inspects routes then reads them from the discarded application. Those
route instances went through `prepareForSerialization()`, which unsets `container`,
so touching them raises:

```
LogicException: Route is not bound.
```

## A note on the diagnosis

The issue title says `route:cache` mutates *live* route instances. I could not
reproduce that part, and I believe it is not what happens. Instrumenting a real
application after `route:cache`:

```
facade app === live app ?  NO
[live]   posts -> container initialised: YES  -> getController(): OK
[facade] posts -> container initialised: NO   -> getController(): LogicException: Route is not bound.
```

The routes owned by the running application are untouched. The mutated instances
belong to the fresh application — and they are only reachable because the facades
were left pointing at it. The route breakage is a symptom; the leaked facade
application is the cause.

Credit where it is due: @hosni reported this and opened #60760, which fixes the
symptom by cloning routes before serialization. That does make the reported error
go away, but it leaves every other facade bound to the throwaway container, and it
adds a full clone of the route collection on every `route:cache`. This PR targets
the root cause instead, so #60760 can be closed in favour of it if maintainers
agree with the analysis.

## The fix

Restore the facade application as soon as the fresh application has bootstrapped:

```php
protected function restoreFacadeApplication()
{
    Facade::clearResolvedInstances();

    Facade::setFacadeApplication($this->laravel);
}
```

`RouteCacheCommand` is the only command in the framework that calls
`getFreshApplication()`, so the change is contained.

## Benefit to end users

`php artisan optimize` becomes safe as a single deployment step. Packages can
register optimize tasks through `$this->optimizes()` that inspect routes,
configuration, or anything else through facades, without having to care whether
`route:cache` happened to run first. It also removes a whole class of subtle,
hard-to-trace bugs in any long-lived process that calls `route:cache`
programmatically.

## Why this does not break existing behaviour

- The generated route cache file is byte-for-byte unchanged: routes are still
  collected from the fresh application's router, still passed through
  `prepareForSerialization()` and `compile()`.
- The routes are read from `$app['router']` directly, not through a facade, so
  restoring the facade application before reading them changes nothing about
  what gets cached.
- Restoring is the correct end state regardless: before `route:cache` runs, the
  facades already point at the running application.
- No public API changes. `restoreFacadeApplication()` is a new `protected` method.

## Tests

`tests/Integration/Foundation/Console/RouteCacheCommandTest.php` covers:

- the facade application is the running application after `route:cache`
- resolved facade roots (`Route::getFacadeRoot()`) point at the live router
- a route registered before `route:cache` is still reachable and analyzable
  through the `Route` facade afterwards

All three fail on `13.x` without the fix and pass with it.
