### PR TITLE
Fix incorrect $startTime type in Worker::stopIfNecessary docblock

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -388,7 +388,7 @@ class Worker
      *
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @param  int  $lastRestart
-     * @param  int  $startTime
+     * @param  int|float  $startTime
      * @param  mixed  $job
      * @return array|null
      */


### PR DESCRIPTION
`Worker::stopIfNecessary()`'s docblock documents `$startTime` as `int`, but the only value ever passed to it is the return value of `Worker::currentTime()`:

```php
protected function currentTime()
{
    return hrtime(true) / 1e9;
}
```

which returns a `float`. The sibling method `pauseWorker()`, which forwards to `stopIfNecessary()` with the same `$startTime`, already documents it correctly as `int|float` (the `int` comes from the `$startTime = 0` default value). This brings `stopIfNecessary()`'s docblock in line with `pauseWorker()` and with the actual runtime value.

**Benefit to end users**: accurate docblocks let IDEs and static analysis tools (PHPStan, PHPStorm, etc.) correctly infer the type instead of flagging valid `float` usage as a type error, which is exactly the kind of DocBlock issue the [contribution guide](https://laravel.com/docs/13.x/contributions#bug-reports) asks to be fixed via PR.

**Why this doesn't break anything**: this only changes a `@param` annotation in a docblock comment. PHP does not enforce or parse docblocks at runtime, and the method signature itself is unchanged, so there is no behavioral or backward-compatibility impact.

This is a docblock-only change with no behavioral impact, so no tests were added or changed.