### PR TITLE
[13.x] Add a command_retry_delay option to phpredis connections

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -180,6 +180,7 @@ return [
             'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
             'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
             'command_retries' => env('REDIS_COMMAND_RETRIES', 0),
+            'command_retry_delay' => env('REDIS_COMMAND_RETRY_DELAY', 0),
         ],
 
         'cache' => [
@@ -194,6 +195,7 @@ return [
             'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
             'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
             'command_retries' => env('REDIS_COMMAND_RETRIES', 0),
+            'command_retry_delay' => env('REDIS_COMMAND_RETRY_DELAY', 0),
         ],
 
     ],

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Redis\Connections;
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use RedisClusterException;
 use RedisException;
@@ -633,6 +634,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             } catch (RedisClusterException|RedisException $e) {
                 if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost', 'Error processing response from Redis node'])) {
                     throw $e;
+                }
+
+                if ($retries > 0 && ($delay = (int) ($this->config['command_retry_delay'] ?? 0)) > 0) {
+                    Sleep::usleep($delay * 1000);
                 }
 
                 $this->client = $this->connector ? call_user_func($this->connector) : $this->client;

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
+use Illuminate\Support\Sleep;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
@@ -410,6 +411,47 @@ class PhpRedisConnectorTest extends TestCase
         }
 
         $this->assertSame(3, $reconnects);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionWaitsBeforeRetryingWhenADelayIsConfigured()
+    {
+        Sleep::fake();
+
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('get')->with('foo')->willThrowException(new RedisException('Connection lost'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient, ['command_retry_delay' => 250]);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+
+        Sleep::assertSequence([Sleep::usleep(250_000)]);
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionDoesNotWaitAfterItsFinalAttempt()
+    {
+        Sleep::fake();
+
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('incr')->with('foo')->willThrowException(new RedisException('Connection lost'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->never())->method('incr');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient, ['command_retry_delay' => 250]);
+
+        try {
+            $connection->command('incr', ['foo']);
+            $this->fail('Expected RedisException was not thrown.');
+        } catch (RedisException $e) {
+            $this->assertSame('Connection lost', $e->getMessage());
+        }
+
+        Sleep::assertNeverSlept();
     }
 
     #[RequiresPhpExtension('redis')]


### PR DESCRIPTION
`command_retries` (#61175) re-issues a command immediately after rebuilding the phpredis client, so all retries land within milliseconds of the original failure, not enough for a cluster failover or a primary promotion that takes a few seconds to settle.
 
This adds a `command_retry_delay` option, in milliseconds, that pauses before each rebuild while retries remain; it defaults to `0` so nothing changes for existing configurations, and the last attempt never waits.