### PR TITLE
[13.x] Restore the facade application after config:cache boots a fresh application

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
 use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
@@ -96,6 +97,10 @@ class ConfigCacheCommand extends Command
         $app->useStoragePath($this->laravel->storagePath());
 
         $app->make(ConsoleKernelContract::class)->bootstrap();
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication($this->laravel);
 
         return $app['config']->all();
     }

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Tests\Integration\Generators\TestCase;
 use LogicException;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
@@ -121,5 +122,12 @@ class ConfigCacheCommandTest extends TestCase
         }
 
         $this->assertFileDoesNotExist($this->app->getCachedConfigPath());
+    }
+
+    public function testItRestoresTheFacadeApplicationAfterBootingAFreshApplication(): void
+    {
+        $this->artisan('config:cache')->assertSuccessful();
+
+        $this->assertSame($this->app, Facade::getFacadeApplication(), 'The facade application should be restored after caching the configuration.');
     }
 }


### PR DESCRIPTION
`config:cache` has the same facade leak that #61346 fixed for `route:cache`.

`getFreshConfiguration()` boots a second application so it can export a clean config dump. Bootstrapping that app runs `RegisterFacades`, which re-points the global facade application at it. Nothing restores the original.

## Related

- Same root cause as #60758
- Follow-up to #61346

## Breaking changes

None.