### PR TITLE
[13.x] Add totalXSize methods to Cloud Queue

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -92,6 +93,36 @@ class Queue implements QueueContract, ClearableQueue
     public function reservedSize($queue = null)
     {
         return $this->queue->reservedSize(...func_get_args());
+    }
+
+    /**
+     * Get the number of pending jobs across every managed queue.
+     *
+     * @return int
+     */
+    public function totalPendingSize()
+    {
+        return (new Collection($this->managedQueues()))->sum(fn ($queue) => $this->pendingSize($queue));
+    }
+
+    /**
+     * Get the number of delayed jobs across every managed queue.
+     *
+     * @return int
+     */
+    public function totalDelayedSize()
+    {
+        return (new Collection($this->managedQueues()))->sum(fn ($queue) => $this->delayedSize($queue));
+    }
+
+    /**
+     * Get the number of reserved jobs across every managed queue.
+     *
+     * @return int
+     */
+    public function totalReservedSize()
+    {
+        return (new Collection($this->managedQueues()))->sum(fn ($queue) => $this->reservedSize($queue));
     }
 
     /**

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -1830,6 +1830,45 @@ class QueueTest extends TestCase
         $this->assertSame(['default', 'emails'], $queue->managedQueues());
     }
 
+    public function testTotalPendingSizeSumsAcrossManagedQueues()
+    {
+        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->expects('getQueueAttributes')->twice()->andReturn(new Result([
+            'Attributes' => ['ApproximateNumberOfMessages' => 2],
+        ]));
+
+        $this->assertSame(4, $queue->totalPendingSize());
+    }
+
+    public function testTotalDelayedSizeSumsAcrossManagedQueues()
+    {
+        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->expects('getQueueAttributes')->twice()->andReturn(new Result([
+            'Attributes' => ['ApproximateNumberOfMessagesDelayed' => 1],
+        ]));
+
+        $this->assertSame(2, $queue->totalDelayedSize());
+    }
+
+    public function testTotalReservedSizeSumsAcrossManagedQueues()
+    {
+        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->expects('getQueueAttributes')->twice()->andReturn(new Result([
+            'Attributes' => ['ApproximateNumberOfMessagesNotVisible' => 3],
+        ]));
+
+        $this->assertSame(6, $queue->totalReservedSize());
+    }
+
     /**
      * @return array{Queue, MockInterface<SqsClient>}
      */


### PR DESCRIPTION
Here I am, once again

This PR just gives us the ability to get a real count for `totalPendingSize` `totalDelayedSize` and `totalReservedSize` from the Cloud queue.

All queue drivers have this method, usually SQS stubs 0 as you need the names... so today, all these methods give 0..

 **but** seeing as the Cloud queue already knows which queues are managed, it means we can add these methods for a total count. 

This mean in userland it's much nicer to get a total count rather than having to sum it ourselves and list out all the managed queues, for context we check the counts during deployments so it saves us having to count every single managed queue :) 

Today we do:

```php
 collect(Cloud::queue()->managedQueues())->sum(fn (string $queue): int => Cloud::queue()->reservedSize($queue));
```

Alternatively, I could macro this, but felt nicer to just get it upstreamed as it's genuinely useful (at least imo) so thought i'd give it a try.

I've added tests to just prove it works, but we could probably drop them as it's kind already covered by SQS? Idk..
