### PR TITLE
[13.x] Restore default database connection when seeding fails

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -84,9 +84,15 @@ class SeedCommand extends Command
 
         $startTime = microtime(true);
 
-        Model::unguarded(function () use ($seeder) {
-            $seeder->__invoke();
-        });
+        try {
+            Model::unguarded(function () use ($seeder) {
+                $seeder->__invoke();
+            });
+        } finally {
+            if ($previousConnection) {
+                $this->resolver->setDefaultConnection($previousConnection);
+            }
+        }
 
         if ($shouldReportProgress) {
             $runTime = number_format((microtime(true) - $startTime) * 1000);
@@ -96,10 +102,6 @@ class SeedCommand extends Command
             );
 
             $this->newLine();
-        }
-
-        if ($previousConnection) {
-            $this->resolver->setDefaultConnection($previousConnection);
         }
 
         return self::SUCCESS;

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -16,6 +16,7 @@ use Illuminate\Events\NullDispatcher;
 use Illuminate\Testing\Assert;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -56,6 +57,53 @@ class SeedCommandTest extends TestCase
         $command->handle();
 
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
+    }
+
+    public function testFailedSeederRestoresPreviousDefaultConnection()
+    {
+        $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = Mockery::mock(Seeder::class);
+        $seeder->expects('setContainer')->andReturnSelf();
+        $seeder->expects('setCommand')->andReturnSelf();
+        $seeder->expects('__invoke')->andThrow(new RuntimeException('Seeding failed.'));
+
+        $connections = [];
+
+        $resolver = Mockery::mock(ConnectionResolverInterface::class);
+        $resolver->expects('getDefaultConnection')->andReturn('mysql');
+        $resolver->shouldReceive('setDefaultConnection')->andReturnUsing(function ($name) use (&$connections) {
+            $connections[] = $name;
+        });
+
+        $container = Mockery::mock(Container::class);
+        $container->expects('call');
+        $container->expects('environment')->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->expects('make')->with('DatabaseSeeder')->andReturn($seeder);
+        $container->expects('make')->with(OutputStyle::class, Mockery::any())->andReturn(
+            $outputStyle
+        );
+        $container->expects('make')->with(Factory::class, Mockery::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        // call run to set up IO, then fire manually.
+        $command->run($input, $output);
+
+        try {
+            $command->handle();
+            $this->fail('Seeding should have failed.');
+        } catch (RuntimeException) {
+            //
+        }
+
+        Assert::assertSame(['sqlite', 'mysql'], $connections);
     }
 
     public function testWithoutModelEvents()


### PR DESCRIPTION
### Problem

I found an issue with Laravel's `db:seed --database` command. When we run a seeder with a specific database connection, Laravel changes the default database connection to that database. Normally, after the seeder finishes, Laravel restores the previous connection. However, if an exception occurs while running the seeder, the restoration code is never reached.

### Example

For example, suppose the application's default database is SQLite, and we run:

```bash
php artisan db:seed --database=mysql
```

Laravel changes the default connection from `sqlite` to `mysql`. If one of the seeders throws an exception, the execution stops before Laravel can restore the previous connection. As a result, the default connection remains `mysql`. Any database operation that runs afterward may unexpectedly use the MySQL database instead of SQLite.

### Fix

I fixed this by wrapping the seeder execution inside a `try...finally` block. The previous database connection is saved before switching to the requested connection, and the `finally` block restores it after the seeder finishes or even if an exception is thrown.

### How This Solves the Problem

The `finally` block always executes regardless of whether the seeder succeeds or throws an exception. Therefore, even when a seeder fails, Laravel restores the original database connection. This prevents the database connection from accidentally remaining on the connection specified by `--database` and keeps the application's database state consistent.

### Testing

I added a test `testFailedSeederRestoresPreviousDefaultConnection` to `tests/Database/SeedCommandTest.php`. The test uses a mock seeder that throws an exception and records every `setDefaultConnection()` call. It asserts that after the exception, the original default connection is restored. I confirmed the test fails on the current `13.x` branch and passes with this fix.