### PR TITLE
[13.x] Gracefully handle missing param value or strings with request clamps

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -316,7 +316,7 @@ trait InteractsWithData
         $value = $this->data($key, $default);
 
         if (! is_numeric($value)) {
-            $value = (int) $value;
+            $value = $default;
         }
 
         return Number::clamp($value, $min, $max);

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -313,7 +313,13 @@ trait InteractsWithData
      */
     public function clamp($key, $min, $max, $default = 0)
     {
-        return Number::clamp($this->data($key, $default), $min, $max);
+        $value = $this->data($key, $default);
+
+        if (! is_numeric($value)) {
+            $value = (int) $value;
+        }
+
+        return Number::clamp($value, $min, $max);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2122,8 +2122,8 @@ class HttpRequestTest extends TestCase
         $this->assertSame(100, $request->clamp('per_page', 1, 250, 99));
         $this->assertSame(22.4, $request->clamp('per_page', 1.11, 22.4, 2));
         $this->assertSame(9.24, $request->clamp('float', 1, 10));
-        $this->assertSame(10, $request->clamp('empty', 10, 100));
-        $this->assertSame(10, $request->clamp('null', 10, 100));
-        $this->assertSame(10, $request->clamp('string', 10, 100));
+        $this->assertSame(15, $request->clamp('empty', 10, 100, 15));
+        $this->assertSame(15, $request->clamp('string', 10, 100, 15));
+        $this->assertSame(15, $request->clamp('null', 10, 100, 15));
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2108,12 +2108,22 @@ class HttpRequestTest extends TestCase
 
     public function testItClampsValues()
     {
-        $request = Request::create('/', 'GET', ['per_page' => 100, 'float' => 9.24]);
+        $request = Request::create('/', 'GET', [
+            'per_page' => 100,
+            'float' => 9.24,
+            'empty' => '',
+            'null' => null,
+            'string' => 'string',
+        ]);
+
         $this->assertSame(100, $request->clamp('per_page', 100, 101));
         $this->assertSame(10, $request->clamp('per_page', -10, 10));
         $this->assertSame(25, $request->clamp('per_page_2', 25, 100, 1));
         $this->assertSame(100, $request->clamp('per_page', 1, 250, 99));
         $this->assertSame(22.4, $request->clamp('per_page', 1.11, 22.4, 2));
         $this->assertSame(9.24, $request->clamp('float', 1, 10));
+        $this->assertSame(10, $request->clamp('empty', 10, 100));
+        $this->assertSame(10, $request->clamp('null', 10, 100));
+        $this->assertSame(10, $request->clamp('string', 10, 100));
     }
 }


### PR DESCRIPTION
See details in #61353 

### Problem

Users that corrupt a url with `?per-page=` instead of the full `?per-page=10` will receive a 500 error. This seems a bit extreme for something that should just fall back to the min or default value. In addition, if the user tries to enter an invalid value this will just ignore it and fall back too so now `?per-page=foo` will just ignore it instead of throwing a 500 and taking down your app. Originally I was thinking `$this->integer(...)` but I see that clamp should work with floats so opted for a little more logic to handle it.

### Solution

Fix here expands request clamp to have it fallback to the default value. I could also see an argument for the min as well...figure default here is best as min/max will correct that if it falls outside the bounds anyways.

Resolves #61353