### PR TITLE
[13.x] Add `chunkBy` to collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1062,6 +1062,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function chunkWhile(callable $callback);
 
     /**
+     * Chunk the collection into chunks by comparing adjacent values using the given key or callback.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string  $key
+     * @return static<int, static<TKey, TValue>>
+     */
+    public function chunkBy($key);
+
+    /**
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -929,6 +929,21 @@ trait EnumeratesValues
     }
 
     /**
+     * Chunk the collection into chunks by comparing adjacent values using the given key or callback.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string  $key
+     * @return static<int, static<TKey, TValue>>
+     */
+    public function chunkBy($key)
+    {
+        $callback = $this->valueRetriever($key);
+
+        return $this->chunkWhile(
+            fn ($value, $key, $chunk) => $callback($value, $key) == $callback($chunk->last(), $chunk->keys()->last())
+        );
+    }
+
+    /**
      * Pass the collection to the given callback and then return it.
      *
      * @param  callable($this): mixed  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2444,6 +2444,91 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testChunkByWithCallback($collection)
+    {
+        $data = (new $collection([1, 1, 2, 2, 3, 3, 3]))
+            ->chunkBy(fn ($value) => $value);
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertEquals([0 => 1, 1 => 1], $data->first()->toArray());
+        $this->assertEquals([2 => 2, 3 => 2], $data->get(1)->toArray());
+        $this->assertEquals([4 => 3, 5 => 3, 6 => 3], $data->last()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testChunkByWithStringKey($collection)
+    {
+        $data = (new $collection([
+            ['parent' => 'a', 'name' => '1'],
+            ['parent' => 'a', 'name' => '2'],
+            ['parent' => 'b', 'name' => '3'],
+            ['parent' => 'b', 'name' => '4'],
+            ['parent' => 'a', 'name' => '5'],
+        ]))->chunkBy('parent');
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertCount(3, $data);
+        $this->assertEquals([
+            ['parent' => 'a', 'name' => '1'],
+            ['parent' => 'a', 'name' => '2'],
+        ], $data->first()->values()->toArray());
+        $this->assertEquals([
+            ['parent' => 'b', 'name' => '3'],
+            ['parent' => 'b', 'name' => '4'],
+        ], $data->get(1)->values()->toArray());
+        $this->assertEquals([
+            ['parent' => 'a', 'name' => '5'],
+        ], $data->last()->values()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testChunkByPreservesKeys($collection)
+    {
+        $data = (new $collection(['a' => 1, 'b' => 1, 'c' => 2, 'd' => 2, 'e' => 1]))
+            ->chunkBy(fn ($value) => $value);
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertCount(3, $data);
+        $this->assertEquals(['a' => 1, 'b' => 1], $data->first()->toArray());
+        $this->assertEquals(['c' => 2, 'd' => 2], $data->get(1)->toArray());
+        $this->assertEquals(['e' => 1], $data->last()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testChunkByWithDotNotation($collection)
+    {
+        $data = (new $collection([
+            (object) ['address' => (object) ['city' => 'NY']],
+            (object) ['address' => (object) ['city' => 'NY']],
+            (object) ['address' => (object) ['city' => 'LA']],
+        ]))->chunkBy('address.city');
+
+        $this->assertCount(2, $data);
+        $this->assertCount(2, $data->first());
+        $this->assertCount(1, $data->last());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testChunkByWithEmptyCollection($collection)
+    {
+        $data = (new $collection([]))->chunkBy('key');
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertCount(0, $data);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testChunkByWithSingleItem($collection)
+    {
+        $data = (new $collection([['key' => 'a']]))->chunkBy('key');
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertCount(1, $data);
+        $this->assertEquals([['key' => 'a']], $data->first()->values()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testEvery($collection)
     {
         $c = new $collection([]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -76,6 +76,23 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testChunkByIsLazy()
+    {
+        $collection = LazyCollection::make(['A', 'A', 'B', 'B', 'C', 'C', 'C']);
+
+        $this->assertDoesNotEnumerateCollection($collection, function ($collection) {
+            $collection->chunkBy(fn ($value) => $value);
+        });
+
+        $this->assertEnumeratesCollection($collection, 3, function ($collection) {
+            $collection->chunkBy(fn ($value) => $value)->first();
+        });
+
+        $this->assertEnumeratesCollectionOnce($collection, function ($collection) {
+            $collection->chunkBy(fn ($value) => $value)->all();
+        });
+    }
+
     public function testCollapseIsLazy()
     {
         $collection = LazyCollection::make([

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -832,6 +832,9 @@ assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int
     return true;
 }));
 
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunkBy(fn ($user) => $user->getKey()));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunkBy('name'));
+
 assertType('Illuminate\Support\Collection<int, User>', $collection->sort(function ($userA, $userB) {
     assertType('User', $userA);
     assertType('User', $userB);

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -723,6 +723,9 @@ assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollec
     return true;
 }));
 
+assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $collection->chunkBy(fn ($user) => $user->getKey()));
+assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $collection->chunkBy('name'));
+
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sort(function ($userA, $userB) {
     assertType('User', $userA);
     assertType('User', $userB);


### PR DESCRIPTION
Adds a `chunkBy` method to both collections, providing a convenient shorthand for the most-common `chunkWhile` pattern.

Instead of writing:

```php
$products->chunkWhile(fn ($value, $key, $chunk) => $value->parent == $chunk->last()->parent);
```

You can now write:

```php
$products->chunkBy('parent');
```

---

Note that this is different than `groupBy`, which groups all related items regardless of position (and thus needs to pull everything into memory). `chunkBy` only groups contiguous items with the same value, and is thus extremely memory efficient.

Non-adjacent items with the same key end up in separate chunks:

```php
collect([1, 1, 2, 2, 1, 1])->chunkBy(fn ($v) => $v);
// [[1, 1], [2, 2], [1, 1]]
```

If that's not what you're after, use `groupBy`.