### PR TITLE
[13.x] Fix LazyCollection::skip() with a negative count

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1231,13 +1231,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Skip the first {$count} items.
+     * Skip the first or last {$count} items.
      *
      * @param  int  $count
      * @return static
      */
     public function skip($count)
     {
+        if ($count < 0) {
+            return $this->passthru(__FUNCTION__, func_get_args());
+        }
+
         return new static(function () use ($count) {
             $iterator = $this->getIterator();
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -592,6 +592,9 @@ class SupportCollectionTest extends TestCase
 
         // Total items to skip is more than collection length
         $this->assertSame([], $data->skip(10)->values()->all());
+
+        // A negative count skips from the end, like slice()
+        $this->assertSame([4 => 5, 5 => 6], $data->skip(-2)->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
`LazyCollection::skip()` returns an empty collection when it is given a negative count. `Collection::skip()` handles the same input correctly, so the two classes disagree on the same API.

```php
(new Collection([1, 2, 3, 4, 5, 6]))->skip(-2);     // [5, 6]
(new LazyCollection([1, 2, 3, 4, 5, 6]))->skip(-2); // []
```

`Collection::skip()` is `return $this->slice($count)`, and `slice()` reads a negative offset as "from the end". `LazyCollection::skip()` has its own loop instead:

```php
while ($iterator->valid() && $count--) {
    $iterator->next();
}
```

With a negative `$count` the counter moves away from zero (-2, -3, -4 and so on), and `0` is the only falsy integer in PHP, so the guard never fails. The loop keeps running until the iterator is exhausted and nothing is ever yielded. `skip(-10)` on six items has the same problem: `Collection` returns all six, `LazyCollection` returns nothing.

This is easy to miss because `slice()` already guards a negative offset before it reaches `skip()`, so only a direct call to `skip()` with a negative count runs into it. There is no error or warning either, just an empty collection, so switching a `Collection` to a `LazyCollection` to save memory can quietly drop data.

Negative counts are now handed to the eager implementation:

```php
if ($count < 0) {
    return $this->passthru(__FUNCTION__, func_get_args());
}
```

`take()` already does this for its own negative branch, and `pad()` and `slice()` use the same guard, so this follows what the class does elsewhere. Skipping from the end means knowing where the end is, which is not something a lazy source can answer without reading to completion, so this does buffer the collection. A count of zero or more still takes the original lazy path and is not affected.

The assertion was added to the existing `testSkipMethod()`, which runs against both `Collection` and `LazyCollection` through the collection class provider. It fails on `LazyCollection` without the fix and passes with it.
