### PR TITLE
[13.x] Fix incorrect isEmpty() docblock in MessageBag

### DIFF
--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -95,7 +95,7 @@ interface MessageBag extends Arrayable, Countable
     public function setFormat($format = ':message');
 
     /**
-     * Determine if the message bag has any messages.
+     * Determine if the message bag has no messages.
      *
      * @return bool
      */

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -349,7 +349,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     }
 
     /**
-     * Determine if the message bag has any messages.
+     * Determine if the message bag has no messages.
      *
      * @return bool
      */


### PR DESCRIPTION
`MessageBag::isEmpty()` (and the same method on the `Illuminate\Contracts\Support\MessageBag` interface) is documented as:

```php
/**
 * Determine if the message bag has any messages.
 *
 * @return bool
 */
public function isEmpty()
```

That is the opposite of what it does. `isEmpty()` returns `! $this->any()`, so it is `true` when the bag has *no* messages, not when it has any. The existing tests already confirm this:

```php
public function testIsEmptyTrue()
{
    $container = new MessageBag;
    $this->assertTrue($container->isEmpty());
}
```

An empty bag with nothing added asserts `isEmpty()` is true. The sibling method `any()` (which `isEmpty()` negates) is the one that actually matches the current wording, and `isNotEmpty()` right below it already has its own correct description.

I checked every other `isEmpty()`/`isNotEmpty()` pair across the framework (Collection, Enumerable, LazyCollection, the pagination contracts and abstract paginators, Fluent, HtmlString, Stringable, Uri, ComponentAttributeBag, ComponentSlot) and this is the only one worded backwards.

Fixes the docblock in both the interface and the concrete class to describe what the method actually returns.
