### PR TITLE
[13.x] Add createPayloadUsing directly to the queue manager

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -469,6 +469,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Register a callback to be executed when creating job payloads.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function createPayloadUsing($callback)
+    {
+        Queue::createPayloadUsing($callback);
+    }
+
+    /**
      * Dynamically pass calls to the default connection.
      *
      * @param  string  $method


### PR DESCRIPTION
We set custom payload data via the Queue facade,  that looks like: 

```php
            Queue::createPayloadUsing(function ($connection, $queue, $payload) {
                $job = $payload['data']['command'] ?? null;

                return $job instanceof HasContext
                    ? ['context' => $job->context()]
                    : [];
            });
```

When using injected queues as a default, at times, it complains it can't resolve the connection.. ie

<details>

```bash
{
      "file": "/var/www/html/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php:201",
      "message": "The [cloud] queue connection has not been configured.",
      "trace": [
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php:180",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php:480",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:364",
        "/var/www/html/app/Providers/QueueServiceProvider.php:32",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1201",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1144",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/BootProviders.php:17",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:349",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:494",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:196",
        "/var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1242",
        "/var/www/html/artisan:14"
      ]
    }
  },
}
```

</details>

This is because... the QueueManager  `_call` always passes the connection https://github.com/laravel/framework/blob/bf309ebfd509b23b25bd830ff8982755820ad5bd/src/Illuminate/Queue/QueueManager.php#L480 

But, to set a payload, we dont need to care about the connection.. its just static so this skips the unnecessary connection resolution.

So to avoid this happening to anyone I thought i'd try this PR