### PR TITLE
[13.x] Make the `->explain();` return consistent results across all mysql versions

### DIFF
--- a/src/Illuminate/Database/Concerns/ExplainsQueries.php
+++ b/src/Illuminate/Database/Concerns/ExplainsQueries.php
@@ -13,11 +13,11 @@ trait ExplainsQueries
      */
     public function explain()
     {
-        $sql = $this->toSql();
+        $sql = $this->getGrammar()->compileExplain($this);
 
         $bindings = $this->getBindings();
 
-        $explanation = $this->getConnection()->select('EXPLAIN '.$sql, $bindings);
+        $explanation = $this->getConnection()->select($sql, $bindings);
 
         return new Collection($explanation);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -51,6 +51,17 @@ class Grammar extends BaseGrammar
     ];
 
     /**
+     * Compile an explain query into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileExplain(Builder $query)
+    {
+        return 'EXPLAIN '.$query->toSql();
+    }
+
+    /**
      * Compile a select query into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -535,6 +535,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile an explain query into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    #[\Override]
+    public function compileExplain(Builder $query)
+    {
+        return 'EXPLAIN FORMAT=TRADITIONAL '.$query->toSql();
+    }
+
+    /**
      * Compile a delete statement without joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Integration/Database/MySql/MysqlExplainTest.php
+++ b/tests/Integration/Database/MySql/MysqlExplainTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class MysqlExplainTest extends MySqlTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('mysql_explain', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('mysql_explain');
+    }
+
+    public function testResultIsAnObject()
+    {
+        $result = DB::table('mysql_explain')->select()->where('name', 'laravel')->explain();
+
+        $this->assertObjectHasProperty('rows', $result[0]);
+        $this->assertObjectHasProperty('select_type', $result[0]);
+        $this->assertObjectHasProperty('type', $result[0]);
+        $this->assertObjectHasProperty('Extra', $result[0]);
+        $this->assertObjectHasProperty('key', $result[0]);
+        $this->assertObjectHasProperty('key_len', $result[0]);
+        $this->assertObjectHasProperty('partitions', $result[0]);
+        $this->assertIsInt($result[0]->rows);
+        $this->assertNull($result[0]->partitions);
+    }
+}


### PR DESCRIPTION
Mysql v9 unlike v8 (or below) and MariaDB returns explain in text format by default and not in the traditional tabular format hence the shape of the PHP object we get from calling `$builder->explain();` will be different based on mysql version.
So there is an inconsistency in the object you get back between different version v9 and the previous versions of Mysql unless the format is explicitly mentioned in the initial explain query.

- This change is not fully backward-compatible but since Mysql 9 is not yet widely adopted and `explain` is only used for debug purposes it is reasonable to put it on 13.x branch.
