### PR TITLE
[13.x] Ensure chunkBy callback is invoked once per item

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -938,9 +938,8 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($key);
 
-        return $this->chunkWhile(
-            fn ($value, $key, $chunk) => $callback($value, $key) == $callback($chunk->last(), $chunk->keys()->last())
-        );
+        return $this->map(fn ($value, $key) => [$value, $callback($value, $key)])->chunkWhile(
+            fn ($value, $key, $chunk) => $value[1] == $chunk->last()[1])->map(fn ($chunk) => $chunk->map(fn ($value) => $value[0]));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2457,6 +2457,27 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testChunkByInvokesCallbackOncePerItem($collection)
+    {
+        $invocations = [];
+
+        $data = (new $collection(['a' => 1, 'b' => 1, 'c' => 2, 'd' => 2]))
+            ->chunkBy(function ($value, $key) use (&$invocations) {
+                $invocations[] = [$key, $value];
+
+                return $value;
+            });
+
+        $this->assertCount(2, $data);
+        $this->assertSame([
+            ['a', 1],
+            ['b', 1],
+            ['c', 2],
+            ['d', 2],
+        ], $invocations);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testChunkByWithStringKey($collection)
     {
         $data = (new $collection([


### PR DESCRIPTION
The `chunkBy` callback was evaluated for both current and previous items during each comparison, duplicating expensive operations. This PR computes the comparison value once per item before chunking and restores the original values afterward.