### PR TITLE
[13.x] Add totalSize method to Queue 

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -96,6 +96,16 @@ class Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the number of jobs across every managed queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return (new Collection($this->managedQueues()))->sum(fn ($queue) => $this->size($queue));
+    }
+
+    /**
      * Get the number of pending jobs across every managed queue.
      *
      * @return int

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -116,6 +116,16 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return 0;
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -136,6 +136,16 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return $this->database->table($this->table)->count();
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -74,6 +74,16 @@ class FailoverQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return $this->manager->connection($this->connections[0])->totalSize();
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -52,6 +52,16 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return 0;
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -156,6 +156,16 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return $this->allQueueNames()->sum(fn ($name) => $this->size($name));
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -172,6 +172,16 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return 0;
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -69,6 +69,16 @@ class SyncQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return 0;
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -504,6 +504,16 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
+     * Get the number of jobs across every queue.
+     *
+     * @return int
+     */
+    public function totalSize()
+    {
+        return $this->allPendingJobs()->count() + $this->allReservedJobs()->count();
+    }
+
+    /**
      * Get the number of pending jobs across every queue.
      *
      * @return int

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -1838,6 +1838,23 @@ class QueueTest extends TestCase
         $this->assertSame(['default', 'emails'], $queue->managedQueues());
     }
 
+    public function testTotalSizeSumsAcrossManagedQueues()
+    {
+        config(['queue.connections.cloud.queues' => ['default', 'emails']]);
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->expects('getQueueAttributes')->twice()->andReturn(new Result([
+            'Attributes' => [
+                'ApproximateNumberOfMessages' => 2,
+                'ApproximateNumberOfMessagesDelayed' => 1,
+                'ApproximateNumberOfMessagesNotVisible' => 3,
+            ],
+        ]));
+
+        $this->assertSame(12, $queue->totalSize());
+    }
+
     public function testTotalPendingSizeSumsAcrossManagedQueues()
     {
         config(['queue.connections.cloud.queues' => ['default', 'emails']]);

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -729,6 +729,18 @@ class RedisQueueTest extends TestCase
     }
 
     #[DataProvider('redisDriverProvider')]
+    public function testTotalSize($driver)
+    {
+        $this->setQueue($driver, config('queue.connections.redis.queue', 'default'));
+
+        $this->queue->push(new RedisQueueIntegrationTestJob(1));
+        $this->queue->pushOn('emails', new RedisQueueIntegrationTestJob(2));
+        $this->queue->later(60, new RedisQueueIntegrationTestJob(3));
+
+        $this->assertSame(3, $this->queue->totalSize());
+    }
+
+    #[DataProvider('redisDriverProvider')]
     public function testTotalPendingSize($driver)
     {
         $this->setQueue($driver, config('queue.connections.redis.queue', 'default'));

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -491,6 +491,19 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('emails', $jobs->last()->queue);
     }
 
+    public function testTotalSize()
+    {
+        $database = Mockery::mock(Connection::class);
+        $queue = new DatabaseQueue($database, 'table', 'default');
+        $queue->setContainer(Mockery::spy(Container::class));
+
+        $query = Mockery::mock(QueryBuilder::class);
+        $database->expects('table')->with('table')->andReturn($query);
+        $query->expects('count')->andReturn(9);
+
+        $this->assertSame(9, $queue->totalSize());
+    }
+
     public function testTotalPendingSize()
     {
         $database = Mockery::mock(Connection::class);

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -634,6 +634,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertTrue($pending->contains(fn ($job) => $job->name === JobToFakeStub::class));
     }
 
+    public function testTotalSize()
+    {
+        $this->fake->push($this->job, '', 'foo');
+        $this->fake->later(10, new JobToFakeStub, '', 'bar');
+        $this->fake->reserve(new JobToFakeStub, 'baz');
+
+        $this->assertSame(3, $this->fake->totalSize());
+    }
+
     public function testTotalPendingSize()
     {
         $this->fake->push($this->job, '', 'foo');


### PR DESCRIPTION
This is **the last** of the total method series, this PR adds a `totalSize` method.

This answers the question "how many total jobs do I have in my X connection right now?"  

This is especially useful for the database queue, as its less queries. 

Before, this looked like:

```php
Queue::totalPendingSize() +  Queue::totalDelayedSize() + Queue::totalReservedSize(); 

// or calling ::size on every named queue
```

Now:

```php
Queue::totalSize();
```

This only works for the Database, Redis, and Cloud queue connections (and the fake, of course)