### PR TITLE
[13.x] Add skipWhen to PreventRequestsDuringMaintenance middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -37,6 +37,13 @@ class PreventRequestsDuringMaintenance
     protected static $neverPrevent = [];
 
     /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -58,6 +65,12 @@ class PreventRequestsDuringMaintenance
      */
     public function handle($request, Closure $next)
     {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
         if ($this->inExceptArray($request)) {
             return $next($request);
         }
@@ -181,6 +194,17 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
+    }
+
+    /**
      * Flush the state of the middleware.
      *
      * @return void
@@ -188,5 +212,7 @@ class PreventRequestsDuringMaintenance
     public static function flushState()
     {
         static::$neverPrevent = [];
+
+        static::$skipCallbacks = [];
     }
 }

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -33,6 +33,13 @@ class MaintenanceModeTest extends TestCase
         parent::setUp();
     }
 
+    protected function tearDown(): void
+    {
+        PreventRequestsDuringMaintenance::flushState();
+
+        parent::tearDown();
+    }
+
     public function testBasicMaintenanceModeResponse()
     {
         file_put_contents(storage_path('framework/down'), json_encode([
@@ -221,6 +228,38 @@ class MaintenanceModeTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertSame('Hello World', $response->original);
+    }
+
+    public function testMaintenanceModeCanBeBypassedUsingSkipCallback()
+    {
+        PreventRequestsDuringMaintenance::skipWhen(fn ($request) => $request->is('allowed'));
+
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'retry' => 60,
+        ]));
+
+        Route::get('/allowed', fn () => 'Allowed')->middleware(PreventRequestsDuringMaintenance::class);
+        Route::get('/blocked', fn () => 'Blocked')->middleware(PreventRequestsDuringMaintenance::class);
+
+        $this->get('/allowed')
+            ->assertOk()
+            ->assertSeeText('Allowed');
+
+        $this->get('/blocked')->assertServiceUnavailable();
+    }
+
+    public function testMaintenanceModeSkipCallbacksCanBeFlushed()
+    {
+        PreventRequestsDuringMaintenance::skipWhen(fn () => true);
+        PreventRequestsDuringMaintenance::flushState();
+
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'retry' => 60,
+        ]));
+
+        Route::get('/blocked', fn () => 'Blocked')->middleware(PreventRequestsDuringMaintenance::class);
+
+        $this->get('/blocked')->assertServiceUnavailable();
     }
 
     public function testMaintenanceModeCantBeBypassedWithInvalidCookie()


### PR DESCRIPTION
Adds `skipWhen` functionality similar to the `TrimStrings` middleware to `PreventRequestsDuringMaintenance`

> [!NOTE]
> These do not work when using the prerendered `--render` maintenance page, I opted not to implement additional functionality here as it wasn't strictly necessary for my use-case