### PR TITLE
[13.x] Set visibility on files that only exist on a read-through disk's fallback

### DIFF
--- a/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/ReadThroughFilesystemAdapter.php
@@ -169,7 +169,7 @@ class ReadThroughFilesystemAdapter implements FilesystemAdapter
      */
     public function setVisibility(string $path, string $visibility): void
     {
-        $this->primary->setVisibility($path, $visibility);
+        $this->readerFor($path)->setVisibility($path, $visibility);
     }
 
     /**

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -461,6 +461,7 @@ class FilesystemManagerTest extends TestCase
         $filesystem->disk('read-through')->get('fallback.txt');
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testReadThroughDisksSetVisibilityOnTheDiskContainingTheFile()
     {
         $filesystem = $this->readThroughFilesystemManager();

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -461,6 +461,25 @@ class FilesystemManagerTest extends TestCase
         $filesystem->disk('read-through')->get('fallback.txt');
     }
 
+    public function testReadThroughDisksSetVisibilityOnTheDiskContainingTheFile()
+    {
+        $filesystem = $this->readThroughFilesystemManager();
+        $primary = $filesystem->disk('primary');
+        $fallback = $filesystem->disk('fallback');
+        $readThrough = $filesystem->disk('read-through');
+
+        $fallback->put('fallback.txt', 'fallback contents');
+        $primary->put('primary.txt', 'primary contents');
+
+        $this->assertTrue($readThrough->setVisibility('fallback.txt', 'private'));
+        $this->assertSame('private', $fallback->getVisibility('fallback.txt'));
+        $this->assertSame('private', $readThrough->getVisibility('fallback.txt'));
+        $this->assertTrue($primary->missing('fallback.txt'));
+
+        $this->assertTrue($readThrough->setVisibility('primary.txt', 'private'));
+        $this->assertSame('private', $primary->getVisibility('primary.txt'));
+    }
+
     public function testReadThroughDisksDelegateUrlsToTheDiskContainingTheFile()
     {
         $filesystem = $this->readThroughFilesystemManager([], [


### PR DESCRIPTION
this is #61370 with the windows guard my test was missing. `testCanBuildScopedDisksWithVisibility` in the same file already skips for the same reason.

on a read-through disk `setVisibility()` only touches the primary, so it silently does nothing for a file that hasn't been promoted yet.

```php
$fallback->put('avatar.jpg', $contents);

$readThrough->setVisibility('avatar.jpg', 'private'); // false, nothing changes
$readThrough->getVisibility('avatar.jpg');            // still 'public'
```

`getVisibility()`, `mimeType()` and `fileSize()` all resolve with `readerFor()`. `setVisibility()` was the only one that didn't.
