### PR TITLE
Simplify storage path resolution using null coalescing operator

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -627,15 +627,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        if (isset($_ENV['LARAVEL_STORAGE_PATH'])) {
-            return $this->joinPaths($this->storagePath ?: $_ENV['LARAVEL_STORAGE_PATH'], $path);
-        }
-
-        if (isset($_SERVER['LARAVEL_STORAGE_PATH'])) {
-            return $this->joinPaths($this->storagePath ?: $_SERVER['LARAVEL_STORAGE_PATH'], $path);
-        }
-
-        return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);
+        return $this->joinPaths(
+            $this->storagePath ?: (
+                $_ENV['LARAVEL_STORAGE_PATH']
+                ?? $_SERVER['LARAVEL_STORAGE_PATH']
+                ?? $this->basePath('storage')
+            ),
+            $path,
+        );
     }
 
     /**


### PR DESCRIPTION
Use the null coalescing operator (??) to resolve LARAVEL_STORAGE_PATH from $_ENV or $_SERVER before falling back to the base path. This reduces redundant code branches and improves readability.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request simplifies the logic for determining the storage path in the `storagePath` method of the `Application` class. The new implementation uses a more concise approach to select the correct storage path by leveraging the null coalescing operator.

**Refactoring and simplification:**

* Refactored the `storagePath` method in `src/Illuminate/Foundation/Application.php` to use the null coalescing operator, reducing code duplication and improving readability by consolidating the logic for selecting the storage path.