### PR TITLE
[14.x] Allow Storage::fake for ondemand disks

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -109,7 +109,7 @@ class FilesystemManager implements FactoryContract
      */
     public function build($config)
     {
-        return $this->resolve('ondemand', is_array($config) ? $config : [
+        return $this->disks['ondemand'] ?? $this->resolve('ondemand', is_array($config) ? $config : [
             'driver' => 'local',
             'root' => $config,
         ]);

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -60,6 +60,20 @@ class StorageFacadeTest extends TestCase
         $this->assertNull(Storage::persistentFake(StorageDisk::Test)->get('nonExistentFile'));
         $this->assertNull(Storage::fake(StorageDisk::Public)->get('nonExistentFile'));
     }
+
+    public function testCanFakeOnDemandDisk()
+    {
+        $fake = Storage::fake('ondemand');
+
+        Storage::build([
+            'driver' => 'ftp',
+            'host' => 'example.com',
+            'username' => 'foo',
+            'password' => 'bar',
+        ])->put('file.txt', 'contents');
+
+        $fake->assertExists('file.txt');
+    }
 }
 
 enum StorageDisk: string


### PR DESCRIPTION
We resolve a lot of filesystems dynamically via `Storage::build()` due to how customers interact with data / we interact with customers.

This however means its quite difficult to test, so you end up mocking the file system which feels odd.

This PR lets `Storage::fake('ondemand')` intercept `Storage::build()` calls, so on-demand disks can be tested the same way named disks already are.  This means testing features with on demand, we can swap a fake in rather than fighting the mock and access all Laravels assertions. 

I've sent this to 14.x just incase anyone has an `ondemand` disk in their config, unlikely, but don't fancy it breaking

The only potential downside is if you're testing two ondemand disks against each other during the same feature it resolves the same disk, but I'd rather wait for this to actually be needed and adjust if it comes up.

From what I can gather, this is a Storage only thing, as mailer on demand swaps the real thing out...

You may see a nicer way to do this, so open to your thoughts

THANKS