### PR TITLE
[13.x] Prevent orphaned Redis tagged cache entries

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -29,16 +29,18 @@ class RedisTaggedCache extends TaggedCache
 
         if ($ttl !== null) {
             $seconds = $this->getSeconds($ttl);
-
-            if ($seconds > 0) {
-                $this->tags->addEntry(
-                    $this->itemKey($key),
-                    $seconds
-                );
-            }
         }
 
-        return parent::add($key, $value, $ttl);
+        $result = parent::add($key, $value, $ttl);
+
+        if ($result && $seconds > 0 && method_exists($this->store, 'add')) {
+            $this->tags->addEntry(
+                $this->itemKey($key),
+                $seconds
+            );
+        }
+
+        return $result;
     }
 
     /**
@@ -59,14 +61,16 @@ class RedisTaggedCache extends TaggedCache
 
         $seconds = $this->getSeconds($ttl);
 
-        if ($seconds > 0) {
+        $result = parent::put($key, $value, $ttl);
+
+        if ($result && $seconds > 0) {
             $this->tags->addEntry(
                 $this->itemKey($key),
                 $seconds
             );
         }
 
-        return parent::put($key, $value, $ttl);
+        return $result;
     }
 
     /**
@@ -80,9 +84,13 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        $result = parent::increment($key, $value);
 
-        return parent::increment($key, $value);
+        if ($result !== false) {
+            $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        }
+
+        return $result;
     }
 
     /**
@@ -96,9 +104,13 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        $result = parent::decrement($key, $value);
 
-        return parent::decrement($key, $value);
+        if ($result !== false) {
+            $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
+        }
+
+        return $result;
     }
 
     /**
@@ -112,9 +124,13 @@ class RedisTaggedCache extends TaggedCache
     {
         $key = enum_value($key);
 
-        $this->tags->addEntry($this->itemKey($key));
+        $result = parent::forever($key, $value);
 
-        return parent::forever($key, $value);
+        if ($result) {
+            $this->tags->addEntry($this->itemKey($key));
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Cache/CacheRedisTaggedCacheTest.php
+++ b/tests/Cache/CacheRedisTaggedCacheTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\RedisTaggedCache;
+use Illuminate\Cache\RedisTagSet;
+use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CacheRedisTaggedCacheTest extends TestCase
+{
+    #[DataProvider('successfulWrites')]
+    public function testTagEntriesAreRegisteredAfterSuccessfulWrites(string $method, array $arguments, string $storeMethod, array $storeArguments, array $tagArguments, mixed $result)
+    {
+        [$cache, $store, $tags, $itemKey] = $this->getCache();
+
+        $store->expects($storeMethod)
+            ->with($itemKey, ...$storeArguments)
+            ->once()
+            ->globally()->ordered()
+            ->andReturn($result);
+
+        $tags->expects('addEntry')
+            ->with($itemKey, ...$tagArguments)
+            ->once()
+            ->globally()->ordered();
+
+        $this->assertSame($result, $cache->{$method}('key', ...$arguments));
+    }
+
+    public static function successfulWrites(): array
+    {
+        return [
+            'put' => ['put', ['value', 60], 'put', ['value', 60], [60], true],
+            'forever' => ['forever', ['value'], 'forever', ['value'], [], true],
+            'add' => ['add', ['value', 60], 'add', ['value', 60], [60], true],
+            'increment' => ['increment', [2], 'increment', [2], [null, 'NX'], 2],
+            'decrement' => ['decrement', [2], 'decrement', [2], [null, 'NX'], -2],
+        ];
+    }
+
+    #[DataProvider('failedWrites')]
+    public function testFailedWritesDoNotRegisterTagEntries(string $method, array $arguments, string $storeMethod, array $storeArguments)
+    {
+        [$cache, $store, $tags, $itemKey] = $this->getCache();
+
+        $store->expects($storeMethod)
+            ->with($itemKey, ...$storeArguments)
+            ->once()
+            ->andReturn(false);
+
+        $tags->expects('addEntry')->never();
+
+        $this->assertFalse($cache->{$method}('key', ...$arguments));
+    }
+
+    public static function failedWrites(): array
+    {
+        return [
+            'put' => ['put', ['value', 60], 'put', ['value', 60]],
+            'forever' => ['forever', ['value'], 'forever', ['value']],
+            'add' => ['add', ['value', 60], 'add', ['value', 60]],
+            'increment' => ['increment', [2], 'increment', [2]],
+            'decrement' => ['decrement', [2], 'decrement', [2]],
+        ];
+    }
+
+    private function getCache(): array
+    {
+        $store = Mockery::mock(RedisStore::class);
+        $tags = Mockery::mock(RedisTagSet::class);
+        $tags->allows('getNamespace')->andReturn('namespace');
+        $tags->allows('getNames')->andReturn([]);
+
+        return [
+            new RedisTaggedCache($store, $tags),
+            $store,
+            $tags,
+            sha1('namespace').':key',
+        ];
+    }
+}


### PR DESCRIPTION
This resolves #61328.

Redis tagged cache writes currently add the item to the tag set before mutating the value key. If a concurrent `flush()` runs between those operations, it can remove the only tag reference before the value exists. The later write then creates a cache entry that no future tagged flush can reach.

This change performs the value mutation first and registers the tag only after it succeeds for `put`, `forever`, atomic `add`, `increment`, and `decrement`. Existing TTL behavior, return values, and the `NX` registration semantics for counters are preserved.

The regression coverage verifies the store mutation occurs before tag registration for all five paths and that failed writes leave no tag reference.

Validation:

- `vendor/bin/phpunit tests/Cache/CacheRedisTaggedCacheTest.php`
- `vendor/bin/phpunit tests/Cache` with 358 tests and 679 assertions
- `vendor/bin/pint --test src/Illuminate/Cache/RedisTaggedCache.php tests/Cache/CacheRedisTaggedCacheTest.php`
- `git diff --check`
