### PR TITLE
[13.x] Add connection and queue to WorkerStopping

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -13,6 +13,8 @@ class WorkerStopping
      * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
      * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
      * @param  int|float|null  $memoryUsage  The memory usage of the worker in MB.
+     * @param  string|null  $connectionName  The connection name.
+     * @param  string|null  $queue  The queue name.
      */
     public function __construct(
         public $status = 0,
@@ -21,6 +23,8 @@ class WorkerStopping
         public $jobsProcessed = null,
         public $lastJobProcessedAt = null,
         public $memoryUsage = null,
+        public $connectionName = null,
+        public $queue = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -237,7 +237,7 @@ class Worker
                 [$status, $reason] = $this->pauseWorker($options, $lastRestart, $startTime);
 
                 if (! is_null($status)) {
-                    return $this->stop($status, $options, $reason);
+                    return $this->stop($status, $options, $reason, $connectionName, $queue);
                 }
 
                 continue;
@@ -287,7 +287,7 @@ class Worker
             [$status, $reason] = $this->stopIfNecessary($options, $lastRestart, $startTime, $job);
 
             if (! is_null($status)) {
-                return $this->stop($status, $options, $reason);
+                return $this->stop($status, $options, $reason, $connectionName, $queue);
             }
         }
     }
@@ -1002,12 +1002,15 @@ class Worker
      * @param  int  $status
      * @param  WorkerOptions|null  $options
      * @param  WorkerStopReason|null  $reason
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
      * @return int
      */
-    public function stop($status = 0, $options = null, $reason = null)
+    public function stop($status = 0, $options = null, $reason = null, $connectionName = null, $queue = null)
     {
         $this->events->dispatch(new WorkerStopping(
-            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()
+            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage(),
+            $connectionName, $queue
         ));
 
         return $status;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -570,7 +570,9 @@ class QueueWorkerTest extends TestCase
                 && $event->reason === WorkerStopReason::QueueEmpty
                 && $event->jobsProcessed === 2
                 && $event->lastJobProcessedAt !== null
-                && $event->memoryUsage > 0;
+                && $event->memoryUsage > 0
+                && $event->connectionName === 'default'
+                && $event->queue === 'queue';
         }));
     }
 
@@ -733,9 +735,9 @@ class InsomniacWorker extends Worker
         parent::notifyJobOfSignal($signal);
     }
 
-    public function stop($status = 0, $options = null, $reason = null)
+    public function stop($status = 0, $options = null, $reason = null, $connectionName = null, $queue = null)
     {
-        return parent::stop($status, $options, $reason);
+        return parent::stop($status, $options, $reason, $connectionName, $queue);
     }
 
     public function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)


### PR DESCRIPTION
It's great we can see a Worker stopped, but it would be even better if we can see the connection and queue/s it related to- this is useful if we can't set the queue --name (ie managed queues.) 

Most (if not all) of the other queue events already supply the connection and queue. 

I don't love the order but to change would be breaking.. so I can change it about in 14.x if you fancy?