### PR TITLE
[14.x] use connectionName in paused/resumed event

### DIFF
--- a/src/Illuminate/Queue/Events/QueuePaused.php
+++ b/src/Illuminate/Queue/Events/QueuePaused.php
@@ -7,12 +7,12 @@ class QueuePaused
     /**
      * Create a new event instance.
      *
-     * @param  string  $connection  The connection name.
+     * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      */
     public function __construct(
-        public $connection,
+        public $connectionName,
         public $queue,
         public $ttl = null,
     ) {

--- a/src/Illuminate/Queue/Events/QueueResumed.php
+++ b/src/Illuminate/Queue/Events/QueueResumed.php
@@ -7,11 +7,11 @@ class QueueResumed
     /**
      * Create a new event instance.
      *
-     * @param  string  $connection  The connection name.
+     * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
      */
     public function __construct(
-        public $connection,
+        public $connectionName,
         public $queue,
     ) {
     }


### PR DESCRIPTION
Every single queue event uses `connectionName`, but these two dont. 

It bothered me, so this targets 14.x as it's a B/C in the name of taste..