### PR TITLE
[13.x] Add `whenTableHasForeignKey()` and `whenTableDoesntHaveForeignKey()` to the schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -351,6 +351,36 @@ class Builder
     }
 
     /**
+     * Execute a table builder callback if the given table has a given foreign key.
+     *
+     * @param  string  $table
+     * @param  string|array  $foreignKey
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function whenTableHasForeignKey(string $table, string|array $foreignKey, Closure $callback)
+    {
+        if ($this->hasForeignKey($table, $foreignKey)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
+     * Execute a table builder callback if the given table doesn't have a given foreign key.
+     *
+     * @param  string  $table
+     * @param  string|array  $foreignKey
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function whenTableDoesntHaveForeignKey(string $table, string|array $foreignKey, Closure $callback)
+    {
+        if (! $this->hasForeignKey($table, $foreignKey)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
      * Get the data type for the given column name.
      *
      * @param  string  $table

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
+use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Mockery;
@@ -62,6 +64,52 @@ class DatabaseSchemaBuilderTest extends TestCase
 
         $this->assertTrue($builder->hasColumns('users', ['id', 'firstname']));
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
+    }
+
+    public function testWhenTableHasForeignKey()
+    {
+        $connection = Mockery::mock(Connection::class);
+        $connection->expects('getSchemaGrammar')->andReturn(Mockery::mock(Grammar::class));
+        $builder = Mockery::mock(Builder::class.'[hasForeignKey,table]', [$connection]);
+        $builder->expects('hasForeignKey')->with('posts', 'posts_user_id_foreign')->andReturnTrue();
+        $builder->expects('hasForeignKey')->with('posts', ['missing_id'])->andReturnFalse();
+        $builder->expects('table')->with('posts', Mockery::type(Closure::class))
+            ->andReturnUsing(fn ($table, $callback) => $callback(Mockery::mock(Blueprint::class)));
+
+        $ran = [];
+
+        $builder->whenTableHasForeignKey('posts', 'posts_user_id_foreign', function (Blueprint $table) use (&$ran) {
+            $ran[] = 'existing';
+        });
+
+        $builder->whenTableHasForeignKey('posts', ['missing_id'], function (Blueprint $table) use (&$ran) {
+            $ran[] = 'missing';
+        });
+
+        $this->assertSame(['existing'], $ran);
+    }
+
+    public function testWhenTableDoesntHaveForeignKey()
+    {
+        $connection = Mockery::mock(Connection::class);
+        $connection->expects('getSchemaGrammar')->andReturn(Mockery::mock(Grammar::class));
+        $builder = Mockery::mock(Builder::class.'[hasForeignKey,table]', [$connection]);
+        $builder->expects('hasForeignKey')->with('posts', ['missing_id'])->andReturnFalse();
+        $builder->expects('hasForeignKey')->with('posts', 'posts_user_id_foreign')->andReturnTrue();
+        $builder->expects('table')->with('posts', Mockery::type(Closure::class))
+            ->andReturnUsing(fn ($table, $callback) => $callback(Mockery::mock(Blueprint::class)));
+
+        $ran = [];
+
+        $builder->whenTableDoesntHaveForeignKey('posts', ['missing_id'], function (Blueprint $table) use (&$ran) {
+            $ran[] = 'missing';
+        });
+
+        $builder->whenTableDoesntHaveForeignKey('posts', 'posts_user_id_foreign', function (Blueprint $table) use (&$ran) {
+            $ran[] = 'existing';
+        });
+
+        $this->assertSame(['missing'], $ran);
     }
 
     public function testGetColumnTypeAddsPrefix()


### PR DESCRIPTION
```php
Schema::whenTableHasForeignKey('posts', 'posts_user_id_foreign', function (Blueprint $table) {
    $table->dropForeign('posts_user_id_foreign');
});

Schema::whenTableDoesntHaveForeignKey('posts', ['user_id'], function (Blueprint $table) {
    $table->foreign('user_id')->references('id')->on('users');
});
```