### PR TITLE
[13.x] Add `havingNot()` and `orHavingNot()` to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2822,6 +2822,33 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a basic "having not" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
+     * @param  \DateTimeInterface|string|int|float|null  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\DateTimeInterface|string|int|float|null  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function havingNot($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->having($column, $operator, $value, $boolean.' not');
+    }
+
+    /**
+     * Add an "or having not" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
+     * @param  \DateTimeInterface|string|int|float|null  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\DateTimeInterface|string|int|float|null  $value
+     * @return $this
+     */
+    public function orHavingNot($column, $operator = null, $value = null)
+    {
+        return $this->havingNot($column, $operator, $value, 'or');
+    }
+
+    /**
      * Add a nested "having" statement to the query.
      *
      * @param  string  $boolean

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2761,6 +2761,26 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > ?', $builder->toSql());
     }
 
+    public function testHavingNots()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->havingNot('email', 'foo')->havingNot('email', '<>', 'bar');
+        $this->assertSame('select * from "users" having not "email" = ? and not "email" <> ?', $builder->toSql());
+        $this->assertEquals(['foo', 'bar'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->having('email', '>', 1)->orHavingNot('email', '<', 5);
+        $this->assertSame('select * from "users" having "email" > ? or not "email" < ?', $builder->toSql());
+        $this->assertEquals([1, 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->havingNot(function ($query) {
+            $query->having('email', '>', 1)->orHaving('email', '<', 5);
+        });
+        $this->assertSame('select * from "users" having not ("email" > ? or "email" < ?)', $builder->toSql());
+        $this->assertEquals([1, 5], $builder->getBindings());
+    }
+
     public function testNestedHavings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
```php
DB::table('order_items')
    ->selectRaw('product_id, count(*) as sales, avg(rating) as rating, sum(returned) as returns')
    ->groupBy('product_id')
    ->having('sales', '>', 100)
    ->havingNot(function ($query) {
        $query->having('rating', '>=', 4.5)->having('returns', '<', 5);
    })
    ->get();

// having `sales` > ? and not (`rating` >= ? and `returns` < ?)
```

Without it, the group has to be inverted by hand — flipping both operators and the connector:

```php
->havingNested(function ($query) {
    $query->having('rating', '<', 4.5)->orHaving('returns', '>=', 5);
});
```
  The or-variant:                                                                                                                                                                                                          
                                                                                                                                                                                                                           
  ```php                                                                                                                                                                                                                   
  DB::table('orders')                                                                                                                                                                                                      
      ->selectRaw('customer_id, sum(total) as lifetime, count(*) as orders')                                                                                                                                               
      ->groupBy('customer_id')                                                                                                                                                                                             
      ->having('lifetime', '>', 5000)                                                                                                                                                                                      
      ->orHavingNot('orders', '>', 1)                                                                                                                                                                                      
      ->get();                                                                                                                                                                                                             
                                                                                                                                                                                                                           
  // having `lifetime` > ? or not `orders` > ?                                                                                                                                                                             
  ```   