### PR TITLE
[13.x] Add `dropVectorIndex()` to the schema blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -494,6 +494,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given vector index should be dropped.
+     *
+     * @param  string|array  $index
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropVectorIndex($index)
+    {
+        return $this->dropIndexCommand('dropVectorIndex', 'vectorIndex', $index);
+    }
+
+    /**
      * Indicate that the given foreign key should be dropped.
      *
      * @param  string|array  $index

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -169,6 +169,20 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a drop vector index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function compileDropVectorIndex(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('The database driver in use does not support vector indexes.');
+    }
+
+    /**
      * Compile the query to determine the foreign keys.
      *
      * @param  string|null  $schema

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -73,6 +73,18 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Compile a drop vector index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropVectorIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
+    }
+
+    /**
      * Wrap the given JSON selector.
      *
      * @param  string  $value

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -654,6 +654,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a drop vector index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropVectorIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
+    }
+
+    /**
      * Compile a drop foreign key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -276,6 +276,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
     }
 
+    public function testDropVectorIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'posts');
+        $blueprint->dropVectorIndex(['embeddings']);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `posts` drop index `posts_embeddings_vectorindex`', $statements[0]);
+    }
+
     public function testDropForeign()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -230,6 +230,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('drop index "geo_coordinates_spatialindex"', $statements[0]);
     }
 
+    public function testDropVectorIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'posts');
+        $blueprint->dropVectorIndex(['embeddings']);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop index "posts_embeddings_vectorindex"', $statements[0]);
+    }
+
     public function testDropForeign()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');


### PR DESCRIPTION
`vectorIndex()` has no matching drop method, so you have to know the generated name:

```php
$table->dropIndex('posts_embeddings_vectorindex');
```

`dropIndex(['embeddings'])` doesn't work, it looks for `posts_embeddings_index`

```php
$table->dropVectorIndex(['embeddings']);
```