### PR TITLE
[13.x] Add `insertOrIgnoreReturning()` to the Eloquent builder passthru

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -126,6 +126,7 @@ class Builder implements BuilderContract
         'insert',
         'insertgetid',
         'insertorignore',
+        'insertorignorereturning',
         'insertusing',
         'insertorignoreusing',
         'max',

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1006,6 +1006,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('foo', $builder->insertOrIgnore(['bar']));
 
         $builder = $this->getBuilder();
+        $builder->getQuery()->expects('insertOrIgnoreReturning')->with(['bar'], ['baz'])->andReturn('foo');
+
+        $this->assertSame('foo', $builder->insertOrIgnoreReturning(['bar'], ['baz']));
+
+        $builder = $this->getBuilder();
         $builder->getQuery()->expects('insertOrIgnoreUsing')->with(['bar'], 'baz')->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertOrIgnoreUsing(['bar'], 'baz'));


### PR DESCRIPTION
`insertOrIgnoreReturning()` was added to the query builder in #59025 but never added to the Eloquent builder's `$passthru`, so on a model the returned rows are lost:

```php
$new = Tag::insertOrIgnoreReturning([
    ['name' => 'php'],
    ['name' => 'laravel'],
], ['id', 'name']);

$new->pluck('id');
// today: runs "select id from tags" and returns every tag in the table
// expected: the ids that were just inserted
```

The insert itself works, only the return value is wrong. `DB::table('tags')` is unaffected.