### PR TITLE
[12.x] Fix TypeError in userFromRecaller() when the recaller matches no user

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -227,7 +227,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             $recaller->id(), $recaller->token()
         ));
 
-        $userPassword = $this->viaRemember ? $user->getAuthPassword() : null;
+        if (! $this->viaRemember) {
+            return;
+        }
+
+        $userPassword = $user->getAuthPassword();
 
         $recallerHash = $recaller->hash();
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -611,6 +611,17 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->viaRemember());
     }
 
+    public function testUserReturnsNullWhenRememberCookieTokenDoesNotMatchAnyUser()
+    {
+        $guard = $this->getGuard();
+        [$session, $provider, $request, $cookie] = $this->getMocks();
+        $request = Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
+        $guard = new SessionGuard('default', $provider, $session, $request);
+        $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
+        $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn(null);
+        $this->assertNull($guard->user());
+    }
+
     public function testLoginOnceSetsUser()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -620,6 +620,7 @@ class AuthGuardTest extends TestCase
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn(null);
         $this->assertNull($guard->user());
+        $this->assertFalse($guard->viaRemember());
     }
 
     public function testLoginOnceSetsUser()


### PR DESCRIPTION
#61386 added a password hash check to `userFromRecaller()`, but `retrieveByToken()` still returns null whenever the remember token has been rotated or the user no longer exists. On that path `$userPassword` is null, so `hash_equals()` gets a null argument and throws instead of the request falling through as a guest.

Returning as soon as the provider gives back no user restores the 12.68 behavior.

Fixes #61396
