### PR TITLE
[13.x] Fix lazy() and lazyById() ignoring limit() and offset()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -258,19 +258,38 @@ trait BuildsQueries
 
         $this->enforceOrderBy();
 
-        return new LazyCollection(function () use ($chunkSize) {
+        $skip = $this->getOffset();
+        $remaining = $this->getLimit();
+
+        return new LazyCollection(function () use ($chunkSize, $skip, $remaining) {
             $page = 1;
 
             while (true) {
-                $results = $this->forPage($page++, $chunkSize)->get();
+                $offset = (($page - 1) * $chunkSize) + (int) $skip;
+
+                $limit = is_null($remaining) ? $chunkSize : min($chunkSize, $remaining);
+
+                if ($limit === 0) {
+                    return;
+                }
+
+                $results = $this->offset($offset)->limit($limit)->get();
 
                 foreach ($results as $result) {
                     yield $result;
                 }
 
-                if ($results->count() < $chunkSize) {
+                $countResults = $results->count();
+
+                if (! is_null($remaining)) {
+                    $remaining = max($remaining - $countResults, 0);
+                }
+
+                if ($countResults < $chunkSize) {
                     return;
                 }
+
+                $page++;
             }
         });
     }
@@ -327,22 +346,43 @@ trait BuildsQueries
 
         $alias ??= $column;
 
-        return new LazyCollection(function () use ($chunkSize, $column, $alias, $descending) {
+        $skip = $this->getOffset();
+        $remaining = $this->getLimit();
+
+        return new LazyCollection(function () use ($chunkSize, $column, $alias, $descending, $skip, $remaining) {
             $lastId = null;
+
+            $page = 1;
 
             while (true) {
                 $clone = clone $this;
 
+                if ($skip && $page > 1) {
+                    $clone->offset(0);
+                }
+
+                $limit = is_null($remaining) ? $chunkSize : min($chunkSize, $remaining);
+
+                if ($limit === 0) {
+                    return;
+                }
+
                 $results = match ($descending) {
-                    SortDirection::Ascending, false => $clone->forPageAfterId($chunkSize, $lastId, $column)->get(),
-                    SortDirection::Descending, true => $clone->forPageBeforeId($chunkSize, $lastId, $column)->get(),
+                    SortDirection::Ascending, false => $clone->forPageAfterId($limit, $lastId, $column)->get(),
+                    SortDirection::Descending, true => $clone->forPageBeforeId($limit, $lastId, $column)->get(),
                 };
 
                 foreach ($results as $result) {
                     yield $result;
                 }
 
-                if ($results->count() < $chunkSize) {
+                $countResults = $results->count();
+
+                if (! is_null($remaining)) {
+                    $remaining = max($remaining - $countResults, 0);
+                }
+
+                if ($countResults < $chunkSize) {
                     return;
                 }
 
@@ -351,6 +391,8 @@ trait BuildsQueries
                 if ($lastId === null) {
                     throw new RuntimeException("The lazyById operation was aborted because the [{$alias}] column is not present in the query result.");
                 }
+
+                $page++;
             }
         });
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -547,12 +547,15 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkComplete()
     {
-        $builder = Mockery::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $builder->expects('forPage')->with(1, 2)->andReturnSelf();
-        $builder->expects('forPage')->with(2, 2)->andReturnSelf();
-        $builder->expects('forPage')->with(3, 2)->andReturnSelf();
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
+        $builder->expects('offset')->with(0)->andReturnSelf();
+        $builder->expects('offset')->with(2)->andReturnSelf();
+        $builder->expects('offset')->with(4)->andReturnSelf();
+        $builder->expects('limit')->times(3)->with(2)->andReturnSelf();
         $builder->expects('get')->times(3)->andReturn(
             new Collection(['foo1', 'foo2']),
             new Collection(['foo3', 'foo4']),
@@ -567,11 +570,14 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkPartial()
     {
-        $builder = Mockery::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $builder->expects('forPage')->with(1, 2)->andReturnSelf();
-        $builder->expects('forPage')->with(2, 2)->andReturnSelf();
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
+        $builder->expects('offset')->with(0)->andReturnSelf();
+        $builder->expects('offset')->with(2)->andReturnSelf();
+        $builder->expects('limit')->twice()->with(2)->andReturnSelf();
         $builder->expects('get')->times(2)->andReturn(
             new Collection(['foo1', 'foo2']),
             new Collection(['foo3'])
@@ -585,10 +591,13 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyIsLazy()
     {
-        $builder = Mockery::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $builder->expects('forPage')->with(1, 2)->andReturnSelf();
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
+        $builder->expects('offset')->with(0)->andReturnSelf();
+        $builder->expects('limit')->with(2)->andReturnSelf();
         $builder->expects('get')->andReturn(new Collection(['foo1', 'foo2']));
 
         $this->assertEquals(['foo1', 'foo2'], $builder->lazy(2)->take(2)->all());
@@ -596,12 +605,14 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkComplete()
     {
-        $builder = Mockery::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
         $chunk3 = new Collection([]);
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
         $builder->expects('forPageAfterId')->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->expects('forPageAfterId')->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->expects('forPageAfterId')->with(2, 11, 'someIdField')->andReturnSelf();
@@ -620,11 +631,13 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkPartial()
     {
-        $builder = Mockery::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10]]);
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
         $builder->expects('forPageAfterId')->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->expects('forPageAfterId')->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->expects('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -641,10 +654,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdIsLazy()
     {
-        $builder = Mockery::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = Mockery::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $builder->expects('getOffset')->andReturnNull();
+        $builder->expects('getLimit')->andReturnNull();
         $builder->expects('forPageAfterId')->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->expects('get')->andReturn($chunk1);
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -940,6 +940,72 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, $chunks);
     }
 
+    public function testLazyWithLimits()
+    {
+        EloquentTestUser::insert([
+            ['name' => 'First', 'email' => 'first@example.com'],
+            ['name' => 'Second', 'email' => 'second@example.com'],
+            ['name' => 'Third', 'email' => 'third@example.com'],
+        ]);
+
+        DB::enableQueryLog();
+
+        $users = EloquentTestUser::query()->orderBy('id', 'asc')->limit(2)->lazy(2);
+
+        $this->assertSame(['First', 'Second'], $users->pluck('name')->all());
+        $this->assertCount(1, DB::getQueryLog());
+    }
+
+    public function testLazyWithLimitsAndOffsets()
+    {
+        EloquentTestUser::insert([
+            ['name' => 'First', 'email' => 'first@example.com'],
+            ['name' => 'Second', 'email' => 'second@example.com'],
+            ['name' => 'Third', 'email' => 'third@example.com'],
+            ['name' => 'Fourth', 'email' => 'fourth@example.com'],
+            ['name' => 'Fifth', 'email' => 'fifth@example.com'],
+            ['name' => 'Sixth', 'email' => 'sixth@example.com'],
+            ['name' => 'Seventh', 'email' => 'seventh@example.com'],
+        ]);
+
+        $users = EloquentTestUser::query()->orderBy('id', 'asc')->offset(2)->limit(3)->lazy(2);
+
+        $this->assertSame(['Third', 'Fourth', 'Fifth'], $users->pluck('name')->all());
+    }
+
+    public function testLazyByIdWithLimits()
+    {
+        EloquentTestUser::insert([
+            ['name' => 'First', 'email' => 'first@example.com'],
+            ['name' => 'Second', 'email' => 'second@example.com'],
+            ['name' => 'Third', 'email' => 'third@example.com'],
+        ]);
+
+        DB::enableQueryLog();
+
+        $users = EloquentTestUser::query()->limit(2)->lazyById(2);
+
+        $this->assertSame(['First', 'Second'], $users->pluck('name')->all());
+        $this->assertCount(1, DB::getQueryLog());
+    }
+
+    public function testLazyByIdWithLimitsAndOffsets()
+    {
+        EloquentTestUser::insert([
+            ['name' => 'First', 'email' => 'first@example.com'],
+            ['name' => 'Second', 'email' => 'second@example.com'],
+            ['name' => 'Third', 'email' => 'third@example.com'],
+            ['name' => 'Fourth', 'email' => 'fourth@example.com'],
+            ['name' => 'Fifth', 'email' => 'fifth@example.com'],
+            ['name' => 'Sixth', 'email' => 'sixth@example.com'],
+            ['name' => 'Seventh', 'email' => 'seventh@example.com'],
+        ]);
+
+        $users = EloquentTestUser::query()->offset(2)->limit(3)->lazyById(2);
+
+        $this->assertSame(['Third', 'Fourth', 'Fifth'], $users->pluck('name')->all());
+    }
+
     public function testChunkByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::insert([


### PR DESCRIPTION
`chunk()` and `chunkById()` have respected a `limit()` or `offset()` set on the query since #52093, but `lazy()` and `lazyById()` were left out and still walk the whole table.

```php
User::query()->orderBy('id')->limit(5)->chunk(2, fn ($users) => ...); // 5 users
User::query()->orderBy('id')->limit(5)->lazy(2);                      // every user
```

This applies the same handling to `lazy()`, `lazyById()` and `lazyByIdDesc()`.