### PR TITLE
[13.x] Guard against non-string mac in the maintenance mode stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -62,7 +62,7 @@ if (isset($_COOKIE['laravel_maintenance']) && isset($data['secret'])) {
 
     if (is_array($payload) &&
         is_numeric($payload['expires_at'] ?? null) &&
-        isset($payload['mac']) &&
+        is_string($payload['mac'] ?? null) &&
         hash_equals(hash_hmac('sha256', $payload['expires_at'], $data['secret']), $payload['mac']) &&
         (int) $payload['expires_at'] >= time()) {
         return;

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -165,6 +165,41 @@ class MaintenanceModeTest extends TestCase
         $this->assertSame('', $output);
     }
 
+    public function testPrerenderedMaintenanceFileHandlesBypassCookieWithNonStringMac()
+    {
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'secret' => 'foo',
+            'template' => 'Rendered Content',
+        ]));
+
+        file_put_contents(
+            storage_path('framework/maintenance.php'),
+            file_get_contents(__DIR__.'/../../../src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub')
+        );
+
+        $server = $_SERVER;
+        $cookie = $_COOKIE;
+
+        try {
+            $_SERVER['REQUEST_URI'] = '/bar';
+            $_SERVER['HTTP_ACCEPT'] = 'application/json';
+
+            $_COOKIE['laravel_maintenance'] = base64_encode(json_encode([
+                'expires_at' => Carbon::now()->addHour()->getTimestamp(),
+                'mac' => ['not-a-string'],
+            ]));
+
+            ob_start();
+            include storage_path('framework/maintenance.php');
+            $output = ob_get_clean();
+        } finally {
+            $_SERVER = $server;
+            $_COOKIE = $cookie;
+        }
+
+        $this->assertSame('', $output);
+    }
+
     public function testMaintenanceModeCanRedirectWithBypassCookie()
     {
         file_put_contents(storage_path('framework/down'), json_encode([


### PR DESCRIPTION
#61314 changed `MaintenanceModeBypassCookie::isValid()` to check `is_string($payload['mac'] ?? null)` before handing the value to `hash_equals()`. The prerendered maintenance stub has the same check and still uses `isset()`, so a `laravel_maintenance` cookie with an array `mac` throws a `TypeError` there.

The stub is written to `storage/framework/maintenance.php` on every `php artisan down` and is required from `public/index.php` before the autoloader, so nothing catches it — the response is a fatal error instead of the maintenance page.

This applies the same guard. Apps already in maintenance mode keep the old file until the next `php artisan down`.