### PR TITLE
[13.x] Restore the container instance after route:cache boots a fresh application

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -98,7 +98,6 @@ class RouteCacheCommand extends Command
             Facade::clearResolvedInstances();
 
             Facade::setFacadeApplication($this->laravel);
-
             Container::setInstance($this->laravel);
         });
     }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
@@ -97,6 +98,8 @@ class RouteCacheCommand extends Command
             Facade::clearResolvedInstances();
 
             Facade::setFacadeApplication($this->laravel);
+
+            Container::setInstance($this->laravel);
         });
     }
 

--- a/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
+use Illuminate\Container\Container;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Route;
@@ -21,6 +22,13 @@ class RouteCacheCommandTest extends TestCase
         $this->artisan('route:cache')->assertSuccessful();
 
         $this->assertSame($this->app, Facade::getFacadeApplication());
+    }
+
+    public function testItRestoresTheContainerInstanceAfterBootingAFreshApplication(): void
+    {
+        $this->artisan('route:cache')->assertSuccessful();
+
+        $this->assertSame($this->app, Container::getInstance());
     }
 
     public function testItLeavesTheFacadeRootsPointingAtTheCurrentApplication(): void


### PR DESCRIPTION
`getFreshApplication()` boots a throwaway application, and `Application::__construct` points `Container::getInstance()` at it. Since #61346 the facade application is restored afterwards but the container instance is not, so `app()` and `Container::getInstance()` keep resolving out of the discarded application while facades resolve out of the live one. Under `optimize` that breaks `view:cache`, which runs right after `route:cache` in the same process and builds the Blade engine from the container.

This restores the container instance alongside the facade application. On 13.29 both pointed at the throwaway application, so the split only appeared in 13.30.

Fixes #61401