### PR TITLE
[13.x] Add `incrementHidden()` and `decrementHidden()` to Context

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -457,6 +457,35 @@ class Repository
     }
 
     /**
+     * Increment a hidden context counter.
+     *
+     * @param  string  $key
+     * @param  int  $amount
+     * @return $this
+     */
+    public function incrementHidden(string $key, int $amount = 1)
+    {
+        $this->addHidden(
+            $key,
+            (int) $this->getHidden($key, 0) + $amount,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Decrement a hidden context counter.
+     *
+     * @param  string  $key
+     * @param  int  $amount
+     * @return $this
+     */
+    public function decrementHidden(string $key, int $amount = 1)
+    {
+        return $this->incrementHidden($key, $amount * -1);
+    }
+
+    /**
      * Determine if the given value is in the given stack.
      *
      * @param  string  $key

--- a/tests/Integration/Log/ContextTest.php
+++ b/tests/Integration/Log/ContextTest.php
@@ -656,6 +656,28 @@ class ContextTest extends TestCase
         $this->assertSame(0, Context::get('foo'));
     }
 
+    public function test_it_increments_a_hidden_counter()
+    {
+        Context::incrementHidden('foo');
+        $this->assertSame(1, Context::getHidden('foo'));
+
+        Context::incrementHidden('foo', 2);
+        $this->assertSame(3, Context::getHidden('foo'));
+
+        $this->assertFalse(Context::has('foo'));
+    }
+
+    public function test_it_decrements_a_hidden_counter()
+    {
+        Context::incrementHidden('foo', 5);
+
+        Context::decrementHidden('foo');
+        $this->assertSame(4, Context::getHidden('foo'));
+
+        Context::decrementHidden('foo', 4);
+        $this->assertSame(0, Context::getHidden('foo'));
+    }
+
     public function test_it_remembers_a_value()
     {
         $this->assertSame(1, Context::remember('int', 1));


### PR DESCRIPTION
`Context` has a hidden counterpart for just about every method — `add`/`addHidden`,
`get`/`getHidden`, `push`/`pushHidden`, `pop`/`popHidden`, `remember`/`rememberHidden`,
and so on. `increment` and `decrement` are the only ones without.

So counting something you want in the job payload but not in the log line means
writing it out by hand:

```php
Context::addHidden('retries', (int) Context::getHidden('retries', 0) + 1);

Context::incrementHidden('retries');
Context::decrementHidden('credits', 5);