### PR TITLE
[13.x] Add `assertOutgoing()` to the mail fake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -61,6 +61,24 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
+     * Assert if a mailable was sent or queued to be sent based on a truth-test callback.
+     *
+     * @param  string|\Closure  $mailable
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertOutgoing($mailable, $callback = null)
+    {
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
+
+        PHPUnit::assertTrue(
+            $this->sent($mailable, $callback)->isNotEmpty() ||
+            $this->queued($mailable, $callback)->isNotEmpty(),
+            "The expected [{$mailable}] mailable was not sent or queued."
+        );
+    }
+
+    /**
      * Assert if a mailable was sent based on a truth-test callback.
      *
      * @param  string|\Closure  $mailable

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -352,6 +352,27 @@ class SupportTestingMailFakeTest extends TestCase
         }
     }
 
+    public function testAssertOutgoing()
+    {
+        try {
+            $this->fake->assertOutgoing(MailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent or queued.', $e->getMessage());
+        }
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertOutgoing(MailableStub::class);
+    }
+
+    public function testAssertOutgoingWhenQueued()
+    {
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertOutgoing(MailableStub::class);
+    }
+
     public function testAssertOutgoingCount()
     {
         $this->fake->assertNothingOutgoing();


### PR DESCRIPTION
The mail fake has `assertNotOutgoing()`, `assertNothingOutgoing()` and
`assertOutgoingCount()`, but no positive `assertOutgoing()`.

Outgoing means sent or queued. Usually a test only cares that the mail went out.
Whether it gets queued is a detail of the mailable, so adding `ShouldQueue` to one
breaks every `assertSent()` for it even though the tested code didn't change.

```php
Mail::assertOutgoing(OrderShipped::class);