### PR TITLE
[13.x] Include connection and queue on WorkerStopping when worker is killed

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -255,7 +255,7 @@ class Worker
             );
 
             if ($supportsAsyncSignals) {
-                $this->registerTimeoutHandler($job, $options);
+                $this->registerTimeoutHandler($job, $options, $connectionName, $queue);
             }
 
             // If the daemon should run (not in maintenance mode, etc.), then we can run
@@ -297,14 +297,16 @@ class Worker
      *
      * @param  \Illuminate\Contracts\Queue\Job|null  $job
      * @param  \Illuminate\Queue\WorkerOptions  $options
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
      * @return void
      */
-    protected function registerTimeoutHandler($job, WorkerOptions $options)
+    protected function registerTimeoutHandler($job, WorkerOptions $options, $connectionName = null, $queue = null)
     {
         // We will register a signal handler for the alarm signal so that we can kill this
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
-        pcntl_signal(SIGALRM, function () use ($job, $options) {
+        pcntl_signal(SIGALRM, function () use ($job, $options, $connectionName, $queue) {
             if ($job) {
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
                     $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timeoutExceededException($job)
@@ -323,7 +325,9 @@ class Worker
                 ));
             }
 
-            $this->kill(static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
+            $this->kill(
+                static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut, $connectionName, $queue
+            );
         }, true);
 
         pcntl_alarm(
@@ -1022,12 +1026,15 @@ class Worker
      * @param  int  $status
      * @param  \Illuminate\Queue\WorkerOptions|null  $options
      * @param  \Illuminate\Queue\WorkerStopReason|null  $reason
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
      * @return never
      */
-    public function kill($status = 0, $options = null, $reason = null)
+    public function kill($status = 0, $options = null, $reason = null, $connectionName = null, $queue = null)
     {
         $this->events->dispatch(new WorkerStopping(
-            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()
+            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage(),
+            $connectionName, $queue
         ));
 
         if (extension_loaded('posix')) {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -326,7 +326,8 @@ class Worker
             }
 
             $this->kill(
-                static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut, $connectionName, $queue
+                static::$timedOutExitCode ?? static::EXIT_ERROR,
+                $options, WorkerStopReason::TimedOut, $connectionName, $queue
             );
         }, true);
 


### PR DESCRIPTION
if a worker was killed (such as a job timing out), the dispatched `WorkerStopping` event had no connectionName/queue so this PR ensures WorkerStopping always provides it.  

I missed this in my last PR, cos we of course have kill and stop methods :trollface: 

We can tidy this up in 14.x if you like, happy to take your direction just lmk where you want it going.

No tests cos it's all signals, but hopefully code is simple to follow