### PR TITLE
[13.x] Support wildcard commands in process fake assertions

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -5,6 +5,7 @@ namespace Illuminate\Process;
 use Closure;
 use Illuminate\Contracts\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -182,7 +183,7 @@ class Factory
      */
     public function assertRan(Closure|array|string $callback)
     {
-        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $this->commandMatches($process, $callback);
 
         PHPUnit::assertTrue(
             (new Collection($this->recorded))->contains(function ($pair) use ($callback) {
@@ -203,7 +204,7 @@ class Factory
      */
     public function assertRanTimes(Closure|array|string $callback, int $times = 1)
     {
-        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $this->commandMatches($process, $callback);
 
         $count = (new Collection($this->recorded))
             ->filter(fn ($pair) => $callback($pair[0], $pair[1]))
@@ -230,7 +231,7 @@ class Factory
         foreach ($callbacks as $index => $callback) {
             $callback = $callback instanceof Closure
                 ? $callback
-                : fn ($process) => $process->command === $callback;
+                : fn ($process) => $this->commandMatches($process, $callback);
 
             PHPUnit::assertTrue(
                 $callback($this->recorded[$index][0], $this->recorded[$index][1]),
@@ -262,7 +263,7 @@ class Factory
      */
     public function assertNotRan(Closure|array|string $callback)
     {
-        $callback = $callback instanceof Closure ? $callback : fn ($process) => $process->command === $callback;
+        $callback = $callback instanceof Closure ? $callback : fn ($process) => $this->commandMatches($process, $callback);
 
         PHPUnit::assertTrue(
             (new Collection($this->recorded))->doesntContain(function ($pair) use ($callback) {
@@ -298,6 +299,28 @@ class Factory
         );
 
         return $this;
+    }
+
+    /**
+     * Determine if the given process was invoked with the given command.
+     *
+     * @param  \Illuminate\Process\PendingProcess  $process
+     * @param  array<array-key, string>|string  $command
+     * @return bool
+     */
+    protected function commandMatches(PendingProcess $process, array|string $command)
+    {
+        if ($process->command === $command) {
+            return true;
+        }
+
+        if (is_array($command)) {
+            return false;
+        }
+
+        return Str::is($command, is_array($process->command)
+            ? implode(' ', $process->command)
+            : (string) $process->command);
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1387,6 +1387,68 @@ class ProcessTest extends TestCase
         $factory->assertRanInOrder([['php', 'artisan', 'migrate']]);
     }
 
+    public function testFakeAssertionsSupportWildcardCommands()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('git commit -m "Add tests"');
+
+        $factory->assertRan('git commit *');
+        $factory->assertRanTimes('git *', 1);
+        $factory->assertNotRan('git push *');
+        $factory->assertDidntRun('composer *');
+    }
+
+    public function testFakeAssertionsSupportWildcardsForArrayCommands()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run(['php', 'artisan', 'migrate', '--force']);
+
+        $factory->assertRan('php artisan migrate*');
+        $factory->assertRanTimes('php artisan *', 1);
+        $factory->assertNotRan('php artisan migrate:rollback*');
+    }
+
+    public function testAssertingProcessesRanInOrderSupportsWildcards()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('git fetch origin main');
+        $factory->run('composer install --no-dev');
+
+        $factory->assertRanInOrder([
+            'git fetch *',
+            'composer install *',
+        ]);
+    }
+
+    public function testFakeAssertionsWithWildcardsFailWhenNoProcessMatches()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('git commit -m "Add tests"');
+
+        $factory->assertRan('composer *');
+    }
+
+    public function testFakeAssertionsStillMatchCommandsContainingWildcardCharacters()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $factory->run('rm *.log');
+
+        $factory->assertRan('rm *.log');
+        $factory->assertRanTimes('rm *.log', 1);
+    }
+
     public function testAssertingThatNothingRan()
     {
         $factory = new Factory;


### PR DESCRIPTION
`Process::fake()` matches commands with `Str::is()`, so faking with a pattern has always worked:

```php
Process::fake(['git *' => Process::result('ok')]);
```

The assertions compare with `===`, though, so that pattern can't be reused to assert with. Any command carrying a generated value — a commit message, a temp path, a timestamp — currently needs a closure:

```php
Process::assertRan(fn ($process) => str_starts_with($process->command, 'git commit'));
```

This allows the same patterns in `assertRan`, `assertRanTimes`, `assertNotRan` and `assertRanInOrder`:

```php
Process::assertRan('git commit -m *');
Process::assertRanTimes('git push *', 1);
Process::assertNotRan('git reset --hard *');
Process::assertRanInOrder(['git fetch *', 'composer install *']);
``` 