### PR TITLE
[14.x] Add `stop()` and `ensureNotTimedOut()` to `InvokedProcess` contract

### DIFF
--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -27,6 +27,15 @@ interface InvokedProcess
     public function signal(int $signal);
 
     /**
+     * Stop the process if it is still running.
+     *
+     * @param  float  $timeout
+     * @param  int|null  $signal
+     * @return int|null
+     */
+    public function stop(float $timeout = 10, ?int $signal = null);
+
+    /**
      * Determine if the process is still running.
      *
      * @return bool
@@ -60,6 +69,15 @@ interface InvokedProcess
      * @return string
      */
     public function latestErrorOutput();
+
+    /**
+     * Ensure that the process has not timed out.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
+     */
+    public function ensureNotTimedOut();
 
     /**
      * Wait for the process to finish.

--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -27,15 +27,6 @@ interface InvokedProcess
     public function signal(int $signal);
 
     /**
-     * Stop the process if it is still running.
-     *
-     * @param  float  $timeout
-     * @param  int|null  $signal
-     * @return int|null
-     */
-    public function stop(float $timeout = 10, ?int $signal = null);
-
-    /**
      * Determine if the process is still running.
      *
      * @return bool
@@ -71,15 +62,6 @@ interface InvokedProcess
     public function latestErrorOutput();
 
     /**
-     * Ensure that the process has not timed out.
-     *
-     * @return void
-     *
-     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
-     */
-    public function ensureNotTimedOut();
-
-    /**
      * Wait for the process to finish.
      *
      * @param  callable|null  $output
@@ -94,4 +76,13 @@ interface InvokedProcess
      * @return \Illuminate\Process\ProcessResult
      */
     public function waitUntil(?callable $output = null);
+
+    /**
+     * Stop the process if it is still running.
+     *
+     * @param  float  $timeout
+     * @param  int|null  $signal
+     * @return int|null
+     */
+    public function stop(float $timeout = 10, ?int $signal = null);
 }


### PR DESCRIPTION
Adds the `stop()` and `ensureNotTimedOut()` methods to the `Illuminate\Contracts\Process\InvokedProcess` contract, following #61266