### PR TITLE
[14.x] Adjust `lazy()` mutating the underlying query builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -257,14 +257,14 @@ trait BuildsQueries
         }
 
         return new LazyCollection(function () use ($chunkSize) {
-            $base = clone $this;
-
-            $base->enforceOrderBy();
-
             $page = 1;
 
             while (true) {
-                $results = (clone $base)->forPage($page++, $chunkSize)->get();
+                $clone = clone $this;
+
+                $clone->enforceOrderBy();
+
+                $results = $clone->forPage($page++, $chunkSize)->get();
 
                 foreach ($results as $result) {
                     yield $result;

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -256,13 +256,15 @@ trait BuildsQueries
             throw new InvalidArgumentException('The chunk size should be at least 1');
         }
 
-        $this->enforceOrderBy();
-
         return new LazyCollection(function () use ($chunkSize) {
+            $base = clone $this;
+
+            $base->enforceOrderBy();
+
             $page = 1;
 
             while (true) {
-                $results = $this->forPage($page++, $chunkSize)->get();
+                $results = (clone $base)->forPage($page++, $chunkSize)->get();
 
                 foreach ($results as $result) {
                     yield $result;

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -257,13 +257,13 @@ trait BuildsQueries
         }
 
         return new LazyCollection(function () use ($chunkSize) {
+            $clone = clone $this;
+
+            $clone->enforceOrderBy();
+
             $page = 1;
 
             while (true) {
-                $clone = clone $this;
-
-                $clone->enforceOrderBy();
-
                 $results = $clone->forPage($page++, $chunkSize)->get();
 
                 foreach ($results as $result) {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -594,6 +594,30 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo1', 'foo2'], $builder->lazy(2)->take(2)->all());
     }
 
+    public function testLazyDoesNotMutateTheOriginalBuilder()
+    {
+        $model = new EloquentBuilderTestStub;
+
+        $connection = $this->mockConnectionForModel($model, '');
+        $connection->shouldReceive('getName')->andReturn('default');
+        $connection->shouldReceive('select')->andReturn(
+            [(object) ['id' => 1], (object) ['id' => 2]],
+            [(object) ['id' => 3]],
+            [(object) ['id' => 1], (object) ['id' => 2]],
+            [(object) ['id' => 3]],
+        );
+
+        $builder = $model->newQuery();
+
+        $builder->lazy(2)->all();
+
+        $this->assertNull($builder->getQuery()->offset);
+        $this->assertNull($builder->getQuery()->limit);
+        $this->assertEmpty($builder->getQuery()->orders);
+
+        $this->assertEquals([1, 2, 3], $builder->lazy(2)->pluck('id')->all());
+    }
+
     public function testLazyByIdWithLastChunkComplete()
     {
         $builder = Mockery::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
`lazy()` mutates the builder as it paginates, so reusing the same builder means you end up with the wrong data if you call another method on the same builder, as we found out 🌚  

This PR ensures it doesn't mutate it, as I can't think of a reason this would be expected? As `lazyById` also clones.

Take this super simple failing test you can run without these changes:

```php
 public function testMutatedState()
    {
        EloquentTestUser::insert([
            ['id' => 1, 'email' => 'jack@gmail.com'],
            ['id' => 2, 'email' => 'taylor@gmail.com'],
            ['id' => 3, 'email' => 'baz@gmail.com'],
        ]);

        $query = EloquentTestUser::query();

       foreach($query->lazy(2) as $item) {
           // do something....
       }

         // Later on reuse the same query... it says 0?! bruhhhh
        $this->assertSame(3, $query->count());
    }
 ```
 
 This may also occur for other methods ie chunk, but focusing on what we've seen locally. 
  
 I've sent this to 14.x, as I wasn't sure if this is expected behaviour.
 
 If this is expected behaviour, that's fine, but I had to try this as it caught us out.