### PR TITLE
[13.x] `JobInterrupted` event

### DIFF
--- a/src/Illuminate/Queue/Events/JobInterrupted.php
+++ b/src/Illuminate/Queue/Events/JobInterrupted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobInterrupted
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName  The connection name.
+     * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
+     * @param  int  $signal  The signal that was sent.
+     */
+    public function __construct(
+        public $connectionName,
+        public $job,
+        public $signal,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -972,11 +972,11 @@ class Worker
         $job = $handler->getRunningCommand();
 
         if ($job instanceof Interruptible) {
+            $job->interrupted($signal);
+
             $this->events->dispatch(new JobInterrupted(
                 $this->currentJob->getConnectionName(), $this->currentJob, $signal
             ));
-
-            $job->interrupted($signal);
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobInterrupted;
 use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
@@ -971,6 +972,10 @@ class Worker
         $job = $handler->getRunningCommand();
 
         if ($job instanceof Interruptible) {
+            $this->events->dispatch(new JobInterrupted(
+                $this->currentJob->getConnectionName(), $this->currentJob, $signal
+            ));
+
             $job->interrupted($signal);
         }
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobInterrupted;
 use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
@@ -671,6 +672,35 @@ class QueueWorkerTest extends TestCase
         $worker->notifyJobOfSignal(15);
 
         $this->assertSame(15, $interruptible->receivedSignal);
+    }
+
+    public function testJobInterruptedEventIsDispatchedForInterruptibleJobs()
+    {
+        $interruptible = new class implements Interruptible
+        {
+            public function interrupted(int $signal): void
+            {
+                //
+            }
+        };
+
+        $handler = Mockery::mock(CallQueuedHandler::class);
+        $handler->expects('getRunningCommand')->andReturn($interruptible);
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $job = new WorkerFakeJob;
+        $job->connectionName = 'default';
+        $job->resolvedJob = $handler;
+
+        $worker->currentJob = $job;
+        $worker->notifyJobOfSignal(15);
+
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::on(function ($event) use ($job) {
+            return $event instanceof JobInterrupted
+                && $event->connectionName === 'default'
+                && $event->job === $job
+                && $event->signal === 15;
+        }))->once();
     }
 
     /**


### PR DESCRIPTION
We use  a variety of interruptible jobs, we want to do our own logic when we know these jobs are interrupted.

This PR adds a `JobInterrupted `event which dispatches only when a job implementing Interruptible is sent the signal.

`WorkerInterrupted` is sent on every signal, even when no job is running. This is different as it's only sent when a job is sent the interruption.

<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/d2f7070d-3733-4a91-91bf-34f57b44e627" />

