### PR TITLE
[13.x] Fix polymorphic type mismatch when foreign key is string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -28,6 +28,10 @@ class MorphMany extends MorphOneOrMany
                 $this->localKey
             ),
             function ($morphOne) {
+                if ($this->morphKeyType) {
+                    $morphOne->morphKeyType($this->morphKeyType);
+                }
+
                 if ($inverse = $this->getInverseRelationship()) {
                     $morphOne->inverse($inverse);
                 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -30,6 +30,13 @@ abstract class MorphOneOrMany extends HasOneOrMany
     protected $morphClass;
 
     /**
+     * The explicit polymorphic key type (e.g. 'string').
+     *
+     * @var string|null
+     */
+    protected $morphKeyType;
+
+    /**
      * Create a new morph one or many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
@@ -62,11 +69,79 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /** @inheritDoc */
+    #[\Override]
+    public function getParentKey()
+    {
+        $key = parent::getParentKey();
+
+        return $this->morphForeignKeyIsString() && ! is_null($key)
+            ? (string) $key
+            : $key;
+    }
+
+    /** @inheritDoc */
+    #[\Override]
     public function addEagerConstraints(array $models)
     {
+        if ($this->morphForeignKeyIsString()) {
+            $this->whereInEager(
+                'whereIn',
+                $this->foreignKey,
+                array_map('strval', $this->getKeys($models, $this->localKey)),
+                $this->getRelationQuery()
+            );
+
+            $this->getRelationQuery()->where($this->morphType, $this->morphClass);
+
+            return;
+        }
+
         parent::addEagerConstraints($models);
 
         $this->getRelationQuery()->where($this->morphType, $this->morphClass);
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    protected function whereInMethod(Model $model, $key)
+    {
+        if ($this->morphForeignKeyIsString()) {
+            return 'whereIn';
+        }
+
+        return parent::whereInMethod($model, $key);
+    }
+
+    /**
+     * Specify the polymorphic key type for the relationship.
+     *
+     * @param  string  $type
+     * @return $this
+     */
+    public function morphKeyType(string $type)
+    {
+        $this->morphKeyType = $type;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the polymorphic foreign key column should be treated as a string.
+     *
+     * @return bool
+     */
+    protected function morphForeignKeyIsString()
+    {
+        if ($this->morphKeyType === 'string') {
+            return true;
+        }
+
+        try {
+            return method_exists($this->related, 'hasCast')
+                && $this->related->hasCast($this->getForeignKeyName(), ['string']);
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -546,9 +546,69 @@ class DatabaseEloquentMorphTest extends TestCase
 
         return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
+
+    public function testMorphManySetsProperConstraintsWithStringMorphKeyFromCasts()
+    {
+        $relation = $this->getStringKeyManyRelation();
+        $this->assertSame('1', $relation->getParentKey());
+    }
+
+    public function testMorphManySetsProperConstraintsWithExplicitStringMorphKeyType()
+    {
+        $relation = $this->getManyRelation();
+        $this->assertSame(1, $relation->getParentKey());
+
+        $relation->morphKeyType('string');
+        $this->assertSame('1', $relation->getParentKey());
+    }
+
+    public function testMorphManyEagerConstraintsAreProperlyAddedWithStringMorphKey()
+    {
+        $relation = $this->getStringKeyManyRelation();
+        $relation->getQuery()->expects('whereIn')->with('table.morph_id', ['1', '2']);
+        $relation->getQuery()->expects('where')->with('table.morph_type', get_class($relation->getParent()));
+
+        $model1 = new EloquentMorphResetModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentMorphResetModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testMorphManyOnePreservesMorphKeyType()
+    {
+        $relation = $this->getManyRelation();
+        $relation->morphKeyType('string');
+
+        $one = $relation->one();
+        $this->assertInstanceOf(MorphOne::class, $one);
+        $this->assertSame('1', $one->getParentKey());
+    }
+
+    protected function getStringKeyManyRelation()
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->expects('whereNotNull')->with('table.morph_id');
+        $builder->expects('where')->with('table.morph_id', '=', '1');
+        $related = new EloquentMorphStringKeyModelStub;
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = Mockery::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $builder->expects('where')->with('table.morph_type', get_class($parent));
+
+        return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+    }
 }
 
 class EloquentMorphResetModelStub extends Model
 {
     //
+}
+
+class EloquentMorphStringKeyModelStub extends Model
+{
+    protected $casts = [
+        'morph_id' => 'string',
+    ];
 }

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -27,6 +27,14 @@ class EloquentMorphManyTest extends DatabaseTestCase
             $table->string('commentable_type');
             $table->timestamps();
         });
+
+        Schema::create('string_comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('commentable_id');
+            $table->string('commentable_type');
+            $table->timestamps();
+        });
     }
 
     public function testUpdateModelWithDefaultWithCount()
@@ -69,6 +77,26 @@ class EloquentMorphManyTest extends DatabaseTestCase
         $this->assertEquals($latestComment->id, $post->latestComment->id);
         $this->assertEquals($oldestComment->id, $post->oldestComment->id);
     }
+
+    public function testPolymorphicWithExplicitStringForeignKey()
+    {
+        $post = Post::create(['title' => 'Post 1']);
+
+        $comment = $post->stringComments()->create(['name' => 'String FK Comment']);
+
+        $this->assertSame((string) $post->id, (string) $comment->commentable_id);
+
+        $comments = $post->stringComments()->get();
+        $this->assertCount(1, $comments);
+        $this->assertSame($comment->id, $comments->first()->id);
+
+        $loadedPost = Post::with('stringComments')->find($post->id);
+        $this->assertCount(1, $loadedPost->stringComments);
+        $this->assertSame($comment->id, $loadedPost->stringComments->first()->id);
+
+        $query = $post->stringComments()->getQuery();
+        $this->assertContains((string) $post->id, $query->getBindings());
+    }
 }
 
 class Post extends Model
@@ -81,6 +109,11 @@ class Post extends Model
     public function comments()
     {
         return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    public function stringComments()
+    {
+        return $this->morphMany(StringComment::class, 'commentable');
     }
 
     public function latestComment(): MorphOne
@@ -108,5 +141,21 @@ class Comment extends Model
     public function replies()
     {
         return $this->morphMany(self::class, 'commentable');
+    }
+}
+
+class StringComment extends Model
+{
+    public $table = 'string_comments';
+    public $timestamps = true;
+    protected $guarded = [];
+
+    protected $casts = [
+        'commentable_id' => 'string',
+    ];
+
+    public function commentable()
+    {
+        return $this->morphTo();
     }
 }


### PR DESCRIPTION
Fixes #54401

### Description

When using polymorphic relationships where the foreign key column is defined as `string` (e.g. `VARCHAR`) while the parent model uses an integer primary key, PostgreSQL throws a type mismatch error:

ERROR: operator does not exist: character varying = integer


This happens because Eloquent derives the constraint binding type from the parent model's `$keyType` (`int`), binding raw integer values into the query without checking the related model's foreign key type.

### Solution

1. Automatically detect if the related model defines a `string` cast for the polymorphic foreign key column via `$casts` or `casts()`.
2. Allow explicitly specifying the key type on the relationship via `->morphKeyType('string')`.
3. When the foreign key is typed as a string:
   - Bind string values (`'1'`) in `getParentKey()`.
   - Use `whereIn` with string bindings in `addEagerConstraints()` instead of `whereIntegerInRaw`.
4. Keep standard integer polymorphic relationships untouched, preserving existing `whereIntegerInRaw` optimizations.
5. Added unit tests and database integration tests.
