### PR TITLE
Let Monolog handle deprecation exceptions

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -106,7 +106,7 @@ class HandleExceptions
             with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
                 if ($options['trace'] ?? false) {
                     $log->warning($message, [
-                        'exception' => new ErrorException($message, 0, $level, $file, $line)
+                        'exception' => new ErrorException($message, 0, $level, $file, $line),
                     ]);
                 } else {
                     $log->warning(sprintf('%s in %s on line %s',

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -105,7 +105,9 @@ class HandleExceptions
 
             with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
                 if ($options['trace'] ?? false) {
-                    $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
+                    $log->warning($message, [
+                        'exception' => new ErrorException($message, 0, $level, $file, $line)
+                    ]);
                 } else {
                     $log->warning(sprintf('%s in %s on line %s',
                         $message, $file, $line

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -82,18 +82,11 @@ class HandleExceptionsTest extends TestCase
             )),
             Mockery::on(function (array $context) {
                 $exception = $context['exception'] ?? null;
-            
+
                 return $exception instanceof \ErrorException
-                    && preg_match(
-                        <<<'REGEXP'
-                        #\#0 .*helpers\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                        \#1 .*HandleExceptions\.php\(.*\): with.*
-                        \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                        \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
-                        [\s\S]*#i
-                        REGEXP,
-                        $exception->getTraceAsString()
-                    );
+                    && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
+                    && str_contains($exception->getTraceAsString(), 'HandleExceptionsTest.php')
+                    && str_contains($exception->getTraceAsString(), 'HandleExceptions->handleError');
             })
         );
 
@@ -179,18 +172,11 @@ class HandleExceptionsTest extends TestCase
             )),
             Mockery::on(function (array $context) {
                 $exception = $context['exception'] ?? null;
-            
+
                 return $exception instanceof \ErrorException
-                    && preg_match(
-                        <<<'REGEXP'
-                        #\#0 .*helpers\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                        \#1 .*HandleExceptions\.php\(.*\): with.*
-                        \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                        \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
-                        [\s\S]*#i
-                        REGEXP,
-                        $exception->getTraceAsString()
-                    );
+                    && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
+                    && str_contains($exception->getTraceAsString(), 'HandleExceptionsTest.php')
+                    && str_contains($exception->getTraceAsString(), 'HandleExceptions->handleError');
             })
         );
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -76,15 +76,11 @@ class HandleExceptionsTest extends TestCase
 
         $logger->expects('channel')->with('deprecations')->andReturnSelf();
         $logger->expects('warning')->with(
-            Mockery::on(fn (string $message) => (bool) preg_match(
-                '#^str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated$#',
-                $message
-            )),
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
             Mockery::on(function (array $context) {
                 $exception = $context['exception'] ?? null;
 
                 return $exception instanceof \ErrorException
-                    && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
                     && $exception->getSeverity() === E_USER_DEPRECATED
                     && $exception->getFile() === '/home/user/laravel/routes/web.php'
                     && $exception->getLine() === 17
@@ -168,15 +164,11 @@ class HandleExceptionsTest extends TestCase
 
         $logger->expects('channel')->with('deprecations')->andReturnSelf();
         $logger->expects('warning')->with(
-            Mockery::on(fn (string $message) => (bool) preg_match(
-                '#^str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated$#',
-                $message
-            )),
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             Mockery::on(function (array $context) {
                 $exception = $context['exception'] ?? null;
 
                 return $exception instanceof \ErrorException
-                    && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
                     && $exception->getSeverity() === E_USER_DEPRECATED
                     && $exception->getFile() === '/home/user/laravel/routes/web.php'
                     && $exception->getLine() === 17

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -81,7 +81,7 @@ class HandleExceptionsTest extends TestCase
                 $exception = $context['exception'] ?? null;
 
                 return $exception instanceof \ErrorException
-                    && $exception->getSeverity() === E_USER_DEPRECATED
+                    && $exception->getSeverity() === E_DEPRECATED
                     && $exception->getFile() === '/home/user/laravel/routes/web.php'
                     && $exception->getLine() === 17
                     && $exception->getTrace();

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -78,8 +78,8 @@ class HandleExceptionsTest extends TestCase
         $logger->expects('warning')->with(
             Mockery::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
-                #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
-                Stack trace:
+                #str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated.*
+                [\s\S]*\[stacktrace\]
                 \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
                 \#1 .*HandleExceptions\.php\(.*\): with.*
                 \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
@@ -168,8 +168,8 @@ class HandleExceptionsTest extends TestCase
         $logger->expects('warning')->with(
             Mockery::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
-                #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
-                Stack trace:
+                #str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated.*
+                [\s\S]*\[stacktrace\]
                 \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
                 \#1 .*HandleExceptions\.php\(.*\): with.*
                 \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -77,17 +77,24 @@ class HandleExceptionsTest extends TestCase
         $logger->expects('channel')->with('deprecations')->andReturnSelf();
         $logger->expects('warning')->with(
             Mockery::on(fn (string $message) => (bool) preg_match(
-                <<<REGEXP
-                #str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated.*
-                [\s\S]*\[stacktrace\]
-                \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 .*HandleExceptions\.php\(.*\): with.*
-                \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
-                [\s\S]*#i
-                REGEXP,
+                '#^str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated$#',
                 $message
-            ))
+            )),
+            Mockery::on(function (array $context) {
+                $exception = $context['exception'] ?? null;
+            
+                return $exception instanceof \ErrorException
+                    && preg_match(
+                        <<<'REGEXP'
+                        #\#0 .*helpers\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                        \#1 .*HandleExceptions\.php\(.*\): with.*
+                        \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                        \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                        [\s\S]*#i
+                        REGEXP,
+                        $exception->getTraceAsString()
+                    );
+            })
         );
 
         $this->handleExceptions()->handleError(
@@ -167,17 +174,24 @@ class HandleExceptionsTest extends TestCase
         $logger->expects('channel')->with('deprecations')->andReturnSelf();
         $logger->expects('warning')->with(
             Mockery::on(fn (string $message) => (bool) preg_match(
-                <<<REGEXP
-                #str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated.*
-                [\s\S]*\[stacktrace\]
-                \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 .*HandleExceptions\.php\(.*\): with.*
-                \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
-                [\s\S]*#i
-                REGEXP,
+                '#^str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated$#',
                 $message
-            ))
+            )),
+            Mockery::on(function (array $context) {
+                $exception = $context['exception'] ?? null;
+            
+                return $exception instanceof \ErrorException
+                    && preg_match(
+                        <<<'REGEXP'
+                        #\#0 .*helpers\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                        \#1 .*HandleExceptions\.php\(.*\): with.*
+                        \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                        \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                        [\s\S]*#i
+                        REGEXP,
+                        $exception->getTraceAsString()
+                    );
+            })
         );
 
         $this->handleExceptions()->handleError(

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -85,8 +85,10 @@ class HandleExceptionsTest extends TestCase
 
                 return $exception instanceof \ErrorException
                     && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
-                    && str_contains($exception->getTraceAsString(), 'HandleExceptionsTest.php')
-                    && str_contains($exception->getTraceAsString(), 'HandleExceptions->handleError');
+                    && $exception->getSeverity() === E_USER_DEPRECATED
+                    && $exception->getFile() === '/home/user/laravel/routes/web.php'
+                    && $exception->getLine() === 17
+                    && $exception->getTrace();
             })
         );
 
@@ -175,8 +177,10 @@ class HandleExceptionsTest extends TestCase
 
                 return $exception instanceof \ErrorException
                     && $exception->getMessage() === 'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
-                    && str_contains($exception->getTraceAsString(), 'HandleExceptionsTest.php')
-                    && str_contains($exception->getTraceAsString(), 'HandleExceptions->handleError');
+                    && $exception->getSeverity() === E_USER_DEPRECATED
+                    && $exception->getFile() === '/home/user/laravel/routes/web.php'
+                    && $exception->getLine() === 17
+                    && $exception->getTrace();
             })
         );
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -76,7 +76,7 @@ class HandleExceptionsTest extends TestCase
 
         $logger->expects('channel')->with('deprecations')->andReturnSelf();
         $logger->expects('warning')->with(
-            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated'
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             Mockery::on(function (array $context) {
                 $exception = $context['exception'] ?? null;
 


### PR DESCRIPTION
I have a custom log formatter, but it isn't working for deprecations because the Monolog context isn't being used;
instead of just sending the string, It should use the established format and let Monolog handle the formatting.

```php
deprecations' => [
    'driver' => 'single',
    'tap' => [\MyCustomLineFormatter::class],
    /////
```