### PR TITLE
[13.x] Add `orWhereVectorSimilarTo()` to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1216,21 +1216,36 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Support\Collection<int, float>|\Illuminate\Contracts\Support\Arrayable|array<int, float>|string  $vector
      * @param  float  $minSimilarity  A value between 0.0 and 1.0, where 1.0 is identical.
      * @param  bool  $order
+     * @param  string  $boolean
      * @return $this
      */
-    public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true)
+    public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true, $boolean = 'and')
     {
         if (is_string($vector)) {
             $vector = (new Stringable($vector))->toEmbeddings(cache: true);
         }
 
-        $this->whereVectorDistanceLessThan($column, $vector, 1 - $minSimilarity);
+        $this->whereVectorDistanceLessThan($column, $vector, 1 - $minSimilarity, $boolean);
 
         if ($order) {
             $this->orderByVectorDistance($column, $vector);
         }
 
         return $this;
+    }
+
+    /**
+     * Add a vector similarity "or where" clause to the query, filtering by minimum similarity and ordering by similarity.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Illuminate\Support\Collection<int, float>|\Illuminate\Contracts\Support\Arrayable|array<int, float>|string  $vector
+     * @param  float  $minSimilarity  A value between 0.0 and 1.0, where 1.0 is identical.
+     * @param  bool  $order
+     * @return $this
+     */
+    public function orWhereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true)
+    {
+        return $this->whereVectorSimilarTo($column, $vector, $minSimilarity, $order, 'or');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7900,6 +7900,30 @@ SQL;
         $this->assertEquals(['[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
     }
 
+    public function testOrWhereVectorSimilarToOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('documents')->where('title', 'foo')->orWhereVectorSimilarTo('embedding', [1, 2, 3], minSimilarity: 0.4)->limit(10);
+
+        $this->assertSame(
+            'select * from "documents" where "title" = ? or ("embedding" <=> ?) <= ? order by ("embedding" <=> ?) asc limit 10',
+            $builder->toSql()
+        );
+        $this->assertEquals(['foo', '[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
+    }
+
+    public function testOrWhereVectorSimilarToOnMariaDb()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->select('*')->from('documents')->where('title', 'foo')->orWhereVectorSimilarTo('embedding', [1, 2, 3], minSimilarity: 0.4)->limit(10);
+
+        $this->assertSame(
+            'select * from `documents` where `title` = ? or vec_distance_cosine(`embedding`, vec_fromtext(?)) <= ? order by vec_distance_cosine(`embedding`, vec_fromtext(?)) asc limit 10',
+            $builder->toSql()
+        );
+        $this->assertEquals(['foo', '[1,2,3]', 0.6, '[1,2,3]'], $builder->getBindings());
+    }
+
     public function testWhereVectorSimilarToThrowsOnUnsupportedGrammar()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
`whereVectorDistanceLessThan()` already has an `orWhereVectorDistanceLessThan()` counterpart, but `whereVectorSimilarTo()` does not. It is currently the only `where*` method on the query builder without an `or*` sibling.

```php
Document::query()
    ->where('title', 'like', "%{$term}%")
    ->orWhereVectorSimilarTo('embedding', $term, minSimilarity: 0.4)
    ->limit(10)
    ->get();
```

`whereVectorSimilarTo()` receives the usual trailing `$boolean` parameter and `orWhereVectorSimilarTo()` delegates to it, matching how the rest of the builder is written. Ordering behaviour is untouched, only the boolean of the where clause changes.
