### PR TITLE
[13.x] Fix context not being propagated to concurrent processes

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -11,6 +11,7 @@ use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Process\Pool;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Defer\DeferredCallback;
+use Illuminate\Support\Facades\Context;
 use Laravel\SerializableClosure\SerializableClosure;
 
 use function Illuminate\Support\defer;
@@ -37,6 +38,7 @@ class ProcessDriver implements Driver
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
             foreach (Arr::wrap($tasks) as $key => $task) {
                 $process = $pool->as($key)->path(base_path())->env([
+                    '__LARAVEL_CONTEXT' => json_encode(Context::dehydrate()),
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
                         serialize(new SerializableClosure($task))
                     ),
@@ -83,6 +85,7 @@ class ProcessDriver implements Driver
         return defer(function () use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {
                 $this->processFactory->path(base_path())->env([
+                    '__LARAVEL_CONTEXT' => json_encode(Context::dehydrate()),
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
                         serialize(new SerializableClosure($task))
                     ),

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -38,6 +38,7 @@ class ProcessDriver implements Driver
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
             foreach (Arr::wrap($tasks) as $key => $task) {
                 $process = $pool->as($key)->path(base_path())->env([
+                    /** @phpstan-ignore staticMethod.notFound */
                     '__LARAVEL_CONTEXT' => json_encode(Context::dehydrate()),
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
                         serialize(new SerializableClosure($task))
@@ -85,6 +86,7 @@ class ProcessDriver implements Driver
         return defer(function () use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {
                 $this->processFactory->path(base_path())->env([
+                    /** @phpstan-ignore staticMethod.notFound */
                     '__LARAVEL_CONTEXT' => json_encode(Context::dehydrate()),
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
                         serialize(new SerializableClosure($task))

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -8,6 +8,7 @@ use Illuminate\Concurrency\SyncDriver;
 use Illuminate\Foundation\Application;
 use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\Context;
 use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -175,6 +176,34 @@ PHP);
             'false' => [false],
             'empty string' => [''],
         ];
+    }
+
+    public function testContextIsPropagatedToConcurrentProcesses()
+    {
+        Context::add('task', 'concurrency');
+        Context::addHidden('token', 'secret');
+
+        [$task, $token] = Concurrency::driver('process')->run([
+            fn () => Context::get('task'),
+            fn () => Context::getHidden('token'),
+        ]);
+
+        $this->assertSame('concurrency', $task);
+        $this->assertSame('secret', $token);
+    }
+
+    public function testContextIsPropagatedToDeferredConcurrentProcesses()
+    {
+        $this->withoutDefer();
+
+        Context::add('task', 'concurrency');
+
+        $factory = $this->app->make(ProcessFactory::class);
+        $factory->fake();
+
+        (new ProcessDriver($factory))->defer([fn () => 'result']);
+
+        $factory->assertRan(fn ($process) => ($process->environment['__LARAVEL_CONTEXT'] ?? null) === json_encode(Context::dehydrate()));
     }
 
     public static function getConcurrencyDrivers(): array


### PR DESCRIPTION
### Introduction
This PR ensures that the application context is propagated to concurrent processes.

`Concurrency::run()` and `Concurrency::defer()` spawn child processes that don't inherit the application's context, so anything stored in Context disappears inside the tasks.

```php
Context::add('tenantId', $id);

Concurrency::run(fn () => Context::get('tenantId')); // null
```

This makes context unreliable for exactly the kind of things it was meant to solve: request IDs, trace IDs, tenant context, etc. 

### How I caught this
Queued jobs carry the context in their payload, which automatically gets hydrated when processing the job. However, this behaviour breaks on the `background` queue connection, since the underlying process never inherits that context.

We dispatched background jobs that needed that context while executing, but the jobs didn't get that context and ended up behaving weirdly.

### The fix
Every other place the framework hands work to another process already propagates context; [the scheduler already passes it](https://github.com/laravel/framework/blob/5ba4bc549544a1bbe7dfff45094a2a0befeff3fc/src/Illuminate/Console/Scheduling/Event.php#L214) to background commands via the `__LARAVEL_CONTEXT` environment variable, and the receiving half already exists in [ContextServiceProvider](https://github.com/laravel/framework/blob/5ba4bc549544a1bbe7dfff45094a2a0befeff3fc/src/Illuminate/Log/Context/ContextServiceProvider.php#L25).

So this PR just sets that variable on the processes the `ProcessDriver` starts.

I don't see this as a breaking change, since apps relying on the Context are probably already broken.

Now,
```php
Context::add('tenantId', $id);

Concurrency::run(fn () => Context::get('tenantId')); // $id
```

Thanks!