### PR TITLE
[13.x] Count crashed worker attempts towards job maxExceptions

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -593,10 +593,14 @@ class Worker
                 return $this->raiseAfterJobEvent($connectionName, $job);
             }
 
+            $this->markJobAsFailedIfAlreadyExceedsMaxExceptions($connectionName, $job);
+
             // Here we will fire off the job and let it process. We will catch any exceptions, so
             // they can be reported to the developer's logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has completed.
             $job->fire();
+
+            $this->decrementExceptionCount($job);
 
             $this->raiseAfterJobEvent($connectionName, $job);
 
@@ -700,6 +704,57 @@ class Worker
     }
 
     /**
+     * Mark the given job as failed if it has already exceeded the maximum allowed exceptions.
+     *
+     * The exception count is optimistically incremented before the job is processed so that
+     * jobs which crash the worker process without throwing an exception, such as when the
+     * PHP memory limit is exceeded, are still counted towards the allowed exceptions.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     *
+     * @throws \Illuminate\Queue\MaxAttemptsExceededException
+     */
+    protected function markJobAsFailedIfAlreadyExceedsMaxExceptions($connectionName, $job)
+    {
+        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+            is_null($maxExceptions = $job->maxExceptions())) {
+            return;
+        }
+
+        if (! $this->cache->get('job-exceptions:'.$uuid)) {
+            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
+        }
+
+        if ($maxExceptions > 0 && $maxExceptions < $this->cache->increment('job-exceptions:'.$uuid)) {
+            $this->cache->forget('job-exceptions:'.$uuid);
+
+            $this->failJob($job, $e = $this->maxAttemptsExceededException($job));
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Roll back the optimistic exception count increment for the job.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function decrementExceptionCount($job)
+    {
+        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+            is_null($maxExceptions = $job->maxExceptions())) {
+            return;
+        }
+
+        if ($this->cache->decrement('job-exceptions:'.$uuid) <= 0) {
+            $this->cache->forget('job-exceptions:'.$uuid);
+        }
+    }
+
+    /**
      * Mark the given job as failed if it has exceeded the maximum allowed attempts.
      *
      * @param  string  $connectionName
@@ -736,11 +791,15 @@ class Worker
             return;
         }
 
-        if (! $this->cache->get('job-exceptions:'.$uuid)) {
+        $count = $this->cache->get('job-exceptions:'.$uuid);
+
+        if (! $count) {
             $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
+
+            return;
         }
 
-        if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
+        if ($maxExceptions <= $count) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
             $this->failJob($job, $e);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Interruptible;
@@ -343,6 +344,178 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+    }
+
+    public function testJobThatCrashedWorkerIsFailedOnceMaxExceptionsWouldBeExceeded()
+    {
+        $e = MaxAttemptsExceededException::class;
+
+        // Simulates the second pickup of a job whose first attempt crashed the worker
+        // process (e.g. PHP memory exhaustion): the exception counter was optimistically
+        // incremented before the job ran and never rolled back...
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+        $job->attempts = 2;
+
+        $cache = Mockery::mock(CacheRepository::class);
+        $cache->shouldReceive('get')->with('job-exceptions:test-uuid')->andReturn(1)->once();
+        $cache->shouldReceive('increment')->with('job-exceptions:test-uuid')->andReturn(2)->once();
+        $cache->shouldReceive('forget')->with('job-exceptions:test-uuid')->once();
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        Worker::$pausable = false;
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+        $this->assertFalse($job->fired);
+        $this->assertNull($job->releaseAfter);
+        $this->assertTrue($job->deleted);
+        $this->assertTrue($job->failed);
+        $this->assertInstanceOf($e, $job->failedWith);
+
+        Worker::$pausable = true;
+    }
+
+    public function testSuccessfulJobsDecrementExceptionCountAndForgetCacheKey()
+    {
+        Carbon::setTestNow($now = Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+
+        $cache = Mockery::mock(CacheRepository::class);
+        $cache->shouldReceive('get')->with('job-exceptions:test-uuid')->andReturn(false);
+        $cache->shouldReceive('put')->with('job-exceptions:test-uuid', 0, Mockery::on(function ($ttl) use ($now) {
+            return $ttl == $now->copy()->addDay();
+        }));
+        $cache->shouldReceive('increment')->with('job-exceptions:test-uuid')->andReturn(1);
+        $cache->shouldReceive('decrement')->with('job-exceptions:test-uuid')->andReturn(0)->once();
+        $cache->shouldReceive('forget')->with('job-exceptions:test-uuid')->once();
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        Worker::$pausable = false;
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->assertTrue($job->fired);
+        $this->assertNull($job->releaseAfter);
+        $this->assertFalse($job->deleted);
+        $this->assertFalse($job->failed);
+
+        Carbon::setTestNow();
+        Worker::$pausable = true;
+    }
+
+    public function testExceptionStillFailsJobWhenMaxExceptionsReached()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+
+        $cache = Mockery::mock(CacheRepository::class);
+        $cache->shouldReceive('get')->with('job-exceptions:test-uuid')->andReturn(false, 1)->twice();
+        $cache->shouldReceive('put')->with('job-exceptions:test-uuid', 0, Mockery::type(Carbon::class))->once();
+        $cache->shouldReceive('increment')->with('job-exceptions:test-uuid')->andReturn(1)->once();
+        $cache->shouldReceive('forget')->with('job-exceptions:test-uuid')->once();
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        Worker::$pausable = false;
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+        $this->assertNull($job->releaseAfter);
+        $this->assertTrue($job->deleted);
+        $this->assertTrue($job->failed);
+        $this->assertEquals($e, $job->failedWith);
+
+        Worker::$pausable = true;
+    }
+
+    public function testJobWithMaxExceptionsOfZeroRunsItsFirstAttempt()
+    {
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 0;
+
+        $cache = Mockery::mock(CacheRepository::class);
+        $cache->shouldReceive('get')->with('job-exceptions:test-uuid')->andReturn(false);
+        $cache->shouldReceive('put')->with('job-exceptions:test-uuid', 0, Mockery::type(Carbon::class));
+        $cache->shouldReceive('increment')->with('job-exceptions:test-uuid')->andReturn(1);
+        $cache->shouldReceive('decrement')->with('job-exceptions:test-uuid')->andReturn(0)->once();
+        $cache->shouldReceive('forget')->with('job-exceptions:test-uuid')->once();
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        Worker::$pausable = false;
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->assertTrue($job->fired);
+        $this->assertNull($job->releaseAfter);
+        $this->assertFalse($job->deleted);
+        $this->assertFalse($job->failed);
+
+        Worker::$pausable = true;
+    }
+
+    public function testMaxExceptionsOfTwoStillPermitsTwoGenuineExceptions()
+    {
+        $e = new RuntimeException;
+
+        $firstThrow = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+        $secondThrow = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+        $firstThrow->uuid = $secondThrow->uuid = 'test-uuid';
+        $firstThrow->maxExceptions = $secondThrow->maxExceptions = 2;
+        $secondThrow->attempts = 1;
+
+        // Two pickups of the same job (same uuid): get sequence across both is
+        // false (seed) → 1 (post-throw compare) → 1 (pre-fire check) → 2 (final compare).
+        $cache = Mockery::mock(CacheRepository::class);
+        $cache->shouldReceive('get')->with('job-exceptions:test-uuid')->andReturn(false, 1, 1, 2)->times(4);
+        $cache->shouldReceive('put')->with('job-exceptions:test-uuid', 0, Mockery::type(Carbon::class))->once();
+        $cache->shouldReceive('increment')->with('job-exceptions:test-uuid')->andReturn(1, 2)->twice();
+        $cache->shouldReceive('forget')->with('job-exceptions:test-uuid')->once();
+
+        $worker = $this->getWorker('default', ['queue' => [$firstThrow, $secondThrow]]);
+        $worker->setCache($cache);
+        Worker::$pausable = false;
+
+        $options = $this->workerOptions(['maxTries' => 0]);
+
+        $worker->runNextJob('default', 'queue', $options);
+        $worker->runNextJob('default', 'queue', $options);
+
+        // The first genuine exception is tolerated: job released, not failed, counter persists at 1.
+        $this->assertFalse($firstThrow->failed);
+        $this->assertEquals(0, $firstThrow->releaseAfter);
+        $this->assertFalse($firstThrow->deleted);
+
+        // The second genuine exception fails the job.
+        $this->assertTrue($secondThrow->failed);
+        $this->assertEquals($e, $secondThrow->failedWith);
+        $this->assertTrue($secondThrow->deleted);
+        $this->assertNull($secondThrow->releaseAfter);
+
+        Worker::$pausable = true;
     }
 
     public function testJobIsFailedIfItHasAlreadyExceededMaxAttempts()


### PR DESCRIPTION
## The problem

A job that crashes the worker process without throwing a catchable exception — most commonly PHP's `Allowed memory size exhausted` fatal error — never increments the `job-exceptions:{uuid}` counter. With ` = 0` (unlimited) and `` set, such jobs are retried forever because nothing ever observes the failure. Timeout-killed jobs work correctly via the SIGALRM handler; only hard process death is affected. Fixes #58207.

## The fix

- Before the job runs, the worker optimistically increments the per-job exception counter (`markJobAsFailedIfAlreadyExceedsMaxExceptions`) and fails the job pre-emptively when the count already exceeds `maxExceptions` — mirroring the existing `markJobAsFailedIfAlreadyExceedsMaxAttempts` handling of previously-timed-out jobs.
- After a job completes successfully, the increment is rolled back and the cache key forgotten (`decrementExceptionCount`), so successful jobs leave no 24h cache keys behind.
- `markJobAsFailedIfWillExceedMaxExceptions` now compares the pre-fired counter instead of incrementing again, so real exceptions are not double counted (verified: maxExceptions=2 still permits two genuine exceptions).
- A job that throws but hasn't yet reached `maxExceptions` is released with its counter persisting at the pre-fired value (e.g. `1`) — the key is deliberately *not* forgotten there, matching the old increment-then-compare semantics; it is cleaned up only when the job eventually fails (`forget`) or succeeds (decrement to 0, then `forget`).

`maxExceptions = 0` (fail on first exception) is unchanged: jobs always run their first attempt.

This supersedes #59329 and addresses its review: the `maxExceptions = 0` first-pickup edge case and the cache-key churn on successful jobs.

## Testing

Five new tests in `tests/Queue/QueueWorkerTest.php`: crashed-worker second pickup fails pre-run; successful jobs decrement and forget the counter; genuine exceptions still fail at maxExceptions; maxExceptions=2 still permits two genuine exceptions; maxExceptions=0 still runs the first attempt. Full `tests/Queue` suite passes.