### PR TITLE
[13.x] Add a forEach method to model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -104,6 +104,13 @@ abstract class Factory
     protected $excludeRelationships = [];
 
     /**
+     * The sequence of items and the callback that configures the factory for each of them.
+     *
+     * @var array{sequence: \Illuminate\Database\Eloquent\Factories\Sequence, callback: \Closure(static, mixed, non-negative-int): static}|null
+     */
+    protected $forEach;
+
+    /**
      * The name of the database connection that will be used to create the models.
      *
      * @var \UnitEnum|string|null
@@ -172,6 +179,7 @@ abstract class Factory
      * @param  \Illuminate\Support\Collection|null  $recycle
      * @param  bool|null  $expandRelationships
      * @param  array  $excludeRelationships
+     * @param  array{sequence: \Illuminate\Database\Eloquent\Factories\Sequence, callback: \Closure(static, mixed, non-negative-int): static}|null  $forEach
      */
     public function __construct(
         $count = null,
@@ -184,6 +192,7 @@ abstract class Factory
         ?Collection $recycle = null,
         ?bool $expandRelationships = null,
         array $excludeRelationships = [],
+        ?array $forEach = null,
     ) {
         $this->count = $count;
         $this->states = $states ?? new Collection;
@@ -196,6 +205,7 @@ abstract class Factory
         $this->faker = $this->withFaker();
         $this->expandRelationships = $expandRelationships ?? self::$expandRelationshipsByDefault;
         $this->excludeRelationships = $excludeRelationships;
+        $this->forEach = $forEach;
     }
 
     /**
@@ -295,7 +305,7 @@ abstract class Factory
 
         return new EloquentCollection(
             (new Collection($records))->map(function ($record) {
-                return $this->state($record)->create();
+                return $this->create($record);
             })
         );
     }
@@ -320,6 +330,10 @@ abstract class Factory
      */
     public function create($attributes = [], ?Model $parent = null)
     {
+        if ($this->forEach) {
+            return $this->buildForEach(fn ($factory) => $factory->create($attributes, $parent));
+        }
+
         if (! empty($attributes)) {
             return $this->state($attributes)->create([], $parent);
         }
@@ -423,6 +437,10 @@ abstract class Factory
      */
     public function make($attributes = [], ?Model $parent = null)
     {
+        if ($this->forEach) {
+            return $this->buildForEach(fn ($factory) => $factory->make($attributes, $parent));
+        }
+
         $autoEagerLoadingEnabled = Model::isAutomaticallyEagerLoadingRelationships();
 
         if ($autoEagerLoadingEnabled) {
@@ -474,7 +492,7 @@ abstract class Factory
 
         return new EloquentCollection(
             (new Collection($records))->map(function ($record) {
-                return $this->state($record)->make();
+                return $this->make($record);
             })
         );
     }
@@ -676,6 +694,50 @@ abstract class Factory
     public function forEachSequence(...$sequence)
     {
         return $this->state(new Sequence(...$sequence))->count(count($sequence));
+    }
+
+    /**
+     * Build a model for each of the given items using the factory returned by the callback.
+     *
+     * @param  iterable<mixed>  $items
+     * @param  \Closure(static, mixed, non-negative-int): static  $callback
+     * @return static
+     */
+    public function forEach(iterable $items, Closure $callback)
+    {
+        $items = (new Collection($items))->values()->all();
+
+        return $this->newInstance(['forEach' => [
+            'sequence' => new Sequence(...$items),
+            'callback' => $callback,
+        ]])->count(count($items));
+    }
+
+    /**
+     * Build a model for each of the "for each" items using the given callback.
+     *
+     * @param  \Closure(static): TModel  $build
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|TModel
+     */
+    protected function buildForEach(Closure $build)
+    {
+        ['sequence' => $sequence, 'callback' => $callback] = $this->forEach;
+
+        $factory = $this->newInstance(['forEach' => null, 'count' => null]);
+
+        $buildNext = fn ($index) => $build($callback($factory, $sequence(), $index));
+
+        if ($this->count === null) {
+            return $buildNext(0);
+        }
+
+        if ($this->count < 1) {
+            return $this->newModel()->newCollection();
+        }
+
+        return $this->newModel()->newCollection(
+            array_map($buildNext, range(0, $this->count - 1))
+        );
     }
 
     /**
@@ -933,6 +995,7 @@ abstract class Factory
             'recycle' => $this->recycle,
             'expandRelationships' => $this->expandRelationships,
             'excludeRelationships' => $this->excludeRelationships,
+            'forEach' => $this->forEach,
         ], $arguments)));
     }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -630,6 +630,174 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(3, $value);
     }
 
+    public function test_for_each_builds_a_model_per_item_using_the_configured_factory()
+    {
+        [$taylor, $abigail] = FactoryTestUserFactory::new()->forEachSequence(
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Abigail Otwell'],
+        )->create();
+
+        $posts = FactoryTestPostFactory::new()
+            ->state(['title' => 'Announcement'])
+            ->forEach(
+                [$taylor, $abigail],
+                fn ($factory, $user) => $factory->for($user, 'user'),
+            )
+            ->create();
+
+        $this->assertInstanceOf(Collection::class, $posts);
+        $this->assertCount(2, $posts);
+        $this->assertSame($taylor->id, $posts[0]->user_id);
+        $this->assertSame($abigail->id, $posts[1]->user_id);
+        $this->assertSame(['Announcement', 'Announcement'], $posts->pluck('title')->all());
+        $this->assertCount(2, FactoryTestPost::all());
+    }
+
+    public function test_for_each_passes_the_index_of_the_item_to_the_callback()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second', 'Third'],
+                fn ($factory, $title, $index) => $factory->state(['title' => $index.'. '.$title]),
+            )
+            ->create();
+
+        $this->assertSame(['0. First', '1. Second', '2. Third'], $posts->pluck('title')->all());
+    }
+
+    public function test_for_each_may_vary_a_morph_to_relationship_per_item()
+    {
+        $posts = FactoryTestPostFactory::new()->count(2)->create();
+
+        $comments = FactoryTestCommentFactory::new()
+            ->forEach(
+                $posts,
+                fn ($factory, $post) => $factory->for($post, 'commentable'),
+            )
+            ->create();
+
+        $this->assertCount(2, $comments);
+        $this->assertSame($posts[0]->id, $comments[0]->commentable_id);
+        $this->assertSame($posts[1]->id, $comments[1]->commentable_id);
+        $this->assertSame(FactoryTestPost::class, $comments[0]->commentable_type);
+    }
+
+    public function test_for_each_keeps_its_items_when_the_factory_is_configured_further()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->for(FactoryTestUserFactory::new()->state(['name' => 'Taylor Otwell']), 'user')
+            ->create();
+
+        $this->assertCount(2, $posts);
+        $this->assertSame(['First', 'Second'], $posts->pluck('title')->all());
+        $this->assertSame('Taylor Otwell', $posts[0]->user->name);
+        $this->assertSame($posts[0]->user_id, $posts[1]->user_id);
+    }
+
+    public function test_for_each_cycles_through_its_items_when_a_larger_count_is_set()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->count(3)
+            ->create();
+
+        $this->assertCount(3, $posts);
+        $this->assertSame(['First', 'Second', 'First'], $posts->pluck('title')->all());
+    }
+
+    public function test_for_each_builds_a_single_model_when_the_count_is_cleared()
+    {
+        $post = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->createOne();
+
+        $this->assertInstanceOf(FactoryTestPost::class, $post);
+        $this->assertSame('First', $post->title);
+    }
+
+    public function test_for_each_can_make_models_without_persisting_them()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->make();
+
+        $this->assertCount(2, $posts);
+        $this->assertSame(['First', 'Second'], $posts->pluck('title')->all());
+        $this->assertCount(0, FactoryTestPost::all());
+    }
+
+    public function test_for_each_can_create_many_models()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->createMany();
+
+        $this->assertCount(2, $posts);
+        $this->assertInstanceOf(FactoryTestPost::class, $posts[0]);
+        $this->assertSame(['First', 'Second'], $posts->pluck('title')->all());
+
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->createMany(3);
+
+        $this->assertCount(3, $posts);
+        $this->assertSame(['First', 'Second', 'First'], $posts->pluck('title')->all());
+    }
+
+    public function test_for_each_can_make_many_models()
+    {
+        $posts = FactoryTestPostFactory::new()
+            ->forEach(
+                ['First', 'Second'],
+                fn ($factory, $title) => $factory->state(['title' => $title]),
+            )
+            ->makeMany();
+
+        $this->assertCount(2, $posts);
+        $this->assertInstanceOf(FactoryTestPost::class, $posts[0]);
+        $this->assertSame(['First', 'Second'], $posts->pluck('title')->all());
+        $this->assertCount(0, FactoryTestPost::all());
+    }
+
+    public function test_for_each_gives_precedence_to_the_attributes_it_is_built_with()
+    {
+        $factory = FactoryTestPostFactory::new()->forEach(
+            ['First', 'Second'],
+            fn ($factory, $title) => $factory->state(['title' => $title]),
+        );
+
+        $posts = $factory->create(['title' => 'Announcement']);
+
+        $this->assertSame(['Announcement', 'Announcement'], $posts->pluck('title')->all());
+
+        $posts = $factory->createMany([
+            ['title' => 'Announcement'],
+            ['title' => 'Retraction'],
+        ]);
+
+        $this->assertCount(2, $posts);
+        $this->assertSame(['Announcement', 'Retraction'], $posts->pluck('title')->all());
+    }
+
     public function test_sequence_with_has_many_relationship()
     {
         $users = FactoryTestUserFactory::times(2)


### PR DESCRIPTION
`forEachSequence()` varies the attributes of each created model. This PR adds `forEach()`, which varies the factory instead, so every model can get its own relationships and states.

It comes up whenever a few models share most of their setup and differ in one relationship. Right now that means repeating the whole chain:

### Before:

```php
Message::factory()
    ->for($conversation)
    ->for($author)
    ->for($mailbox)
    ->for($team)
    ->for($emailChannel)
    ->create();

Message::factory()
    ->for($conversation)
    ->for($author)
    ->for($mailbox)
    ->for($team)
    ->for($chatChannel)
    ->create();
```

### After:

With `forEach()` the shared part is written once and only the difference is repeated:

```php
Message::factory()
    ->for($conversation)
    ->for($author)
    ->for($mailbox)
    ->for($team)
    ->forEach(
        [$emailChannel, $chatChannel],
        fn (Factory $factory, Channel $channel) => $factory->for($channel),
    )
    ->create();
```

The closure receives the factory, the current item and its index, and returns the factory it configured. Anything set outside the closure applies to every model.

A sequence can't do this because it only merges attributes. It has no way to hand a model to `for()`, or to set a `morphTo` parent, which needs both the id and the type column:

```php
Comment::factory()
    ->forEach(
        [$post, $video],
        fn (Factory $factory, Post|Video $commentable) => $factory->for($commentable, 'commentable'),
    )
    ->create();
```

Under the hood the items are drawn through a `Sequence`, and `forEach()` sets the pending count to the number of items, so it behaves the way `forEachSequence()` does: `create()` builds one model per item, `createOne()` takes the next item, `createMany()` draws one item per record, and a larger count cycles back through the items. As with `forEachSequence()`, calling `count()` yourself is redundant: the number of items already sets it.

One existing behavior changed. `createMany()` and `makeMany()` now build each record through `create($record)` and `make($record)` instead of `state($record)->create()`. For a factory that isn't using `forEach()` these are equivalent, since `create()` applies non-empty attributes through `state()` itself. For `forEach()` it means attributes passed to `createMany()` win over the states applied in the closure, matching what `create($attributes)` already does.
