### PR TITLE
[13.x] Apply eager load constraints to one-of-many subqueries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
+use Illuminate\Contracts\Database\Eloquent\SupportsPartialRelations;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
@@ -969,7 +970,11 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
-        $constraints($relation);
+        if ($relation instanceof SupportsPartialRelations && $relation->isOneOfMany()) {
+            $this->applyOneOfManyEagerConstraints($relation, $constraints);
+        } else {
+            $constraints($relation);
+        }
 
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays
@@ -978,6 +983,34 @@ class Builder implements BuilderContract
             $relation->initRelation($models, $name),
             $relation->getEager(), $name
         );
+    }
+
+    /**
+     * Apply the eager load constraints to a one of many relationship's query and its
+     * underlying aggregate subselect query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param  \Closure  $constraints
+     * @return void
+     */
+    protected function applyOneOfManyEagerConstraints($relation, Closure $constraints)
+    {
+        $query = $relation->getQuery()->getQuery();
+
+        $wheresCount = count($query->wheres);
+        $bindingsCount = count($query->bindings['where'] ?? []);
+
+        $constraints($relation);
+
+        if (! empty($newWheres = array_slice($query->wheres, $wheresCount))) {
+            $subQuery = $relation->getOneOfManySubQuery()->getQuery();
+
+            $subQuery->wheres = array_merge($subQuery->wheres, $newWheres);
+            $subQuery->bindings['where'] = array_merge(
+                $subQuery->bindings['where'] ?? [],
+                array_slice($query->bindings['where'] ?? [], $bindingsCount)
+            );
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -434,6 +434,42 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertSame($user2Price->id, $users[1]->price->id);
     }
 
+    public function testEagerLoadConstraintsAreAppliedToOneOfManySubQuery()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $user->states()->createMany([
+            ['type' => 'foo', 'state' => 'older_foo'],
+            ['type' => 'foo', 'state' => 'latest_foo'],
+            ['type' => 'bar', 'state' => 'latest_bar'],
+        ]);
+
+        $user = HasOneOfManyTestUser::with(['latest_state' => function ($query) {
+            $query->where('type', 'foo');
+        }])->first();
+
+        $this->assertNotNull($user->latest_state);
+        $this->assertSame('latest_foo', $user->latest_state->state);
+    }
+
+    public function testEagerLoadConstraintsAreAppliedToMultiColumnOneOfManySubQuery()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $user->states()->createMany([
+            ['type' => 'foo', 'state' => 'old_foo', 'updated_at' => '2021-01-01'],
+            ['type' => 'bar', 'state' => 'latest_bar', 'updated_at' => '2021-06-01'],
+            ['type' => 'foo', 'state' => 'latest_foo', 'updated_at' => '2021-03-01'],
+        ]);
+
+        $user = HasOneOfManyTestUser::with(['latest_updated_foo_state' => function ($query) {
+            $query->where('type', 'foo');
+        }])->first();
+
+        $this->assertNotNull($user->latest_updated_foo_state);
+        $this->assertSame('latest_foo', $user->latest_updated_foo_state->state);
+    }
+
     public function testWithExists()
     {
         $user = HasOneOfManyTestUser::create();
@@ -593,6 +629,19 @@ class HasOneOfManyTestUser extends Eloquent
     public function states()
     {
         return $this->hasMany(HasOneOfManyTestState::class, 'user_id');
+    }
+
+    public function latest_state()
+    {
+        return $this->hasOne(HasOneOfManyTestState::class, 'user_id')->latestOfMany();
+    }
+
+    public function latest_updated_foo_state()
+    {
+        return $this->hasOne(HasOneOfManyTestState::class, 'user_id')->ofMany([
+            'updated_at' => 'MAX',
+            'id' => 'MAX',
+        ]);
     }
 
     public function foo_state()


### PR DESCRIPTION
## The problem

When eager loading a `latestOfMany()`/`ofMany()` relation with constraints, the closure is applied to the outer query only; the aggregate subquery that decides which row is latest stays unscoped:

    User::with(['lastPayment' => fn ($q) => $q->where('store_id', $storeId)])

picks the globally-latest payment in the subquery, then the outer `store_id` filter discards it, silently returning `null` even when the user has matching payments at that store. Fixes #59318. This also restores the intent of #37451 (8.x), which moved constraints into the subquery for correctness and performance.

## The fix

Inside `Builder::eagerLoadRelation()`, for one-of-many relations the closure still runs against the relation (outer query unchanged for BC), and the wheres/bindings it added — isolated by counting `wheres` before/after — are mirrored into the relation's `oneOfManySubQuery`, the same query `addEagerConstraints()` already targets. Lazy loading and all other relation types take the exact previous path.

## Scope

- No existing tests are modified; two new eager-loading tests added (single-column `latestOfMany` and multi-column `ofMany([updated_at, id])`), freshly written and named for this PR.
- Alternative to open PR #59337, which routes all `where*` calls to the subquery and therefore changes documented lazy-load behavior (the existing `testItGetsWithConstraintsCorrectResults`, `testExists`, and `testGet` assertions).

## Prior attempts

- Builds on #60219 (same eager-only scope in `Builder::eagerLoadRelation()`, trimmed to a minimal diff here). That PR was closed as primarily AI-generated without careful human review, so to be explicit about this submission: the problem/mechanism/fix analysis above is my own, the two tests are newly written and named differently from #60219's, and I'll be actively answering review feedback.
- Also supersedes #59788 / #59333.

## Known limitations

- A top-level `orWhere` inside an eager closure is copied into the subquery as a bare or-boolean where appended after the subquery's `whereIn`; SQL precedence changes its semantics relative to the outer query. Wrapping the copied delta in a nested where group is the future fix.
- `join()` calls inside eager closures still don't propagate (the same limitation #60219 documented).
- `HasOneThrough`-of-many closures referencing intermediate-table columns would SQL-error when copied.