### PR TITLE
[14.x] fix: prune soft-deleted mass prunable models

### DIFF
--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -9,21 +9,17 @@ trait MassPrunable
 {
     /**
      * Prune all prunable models in the database.
-     *
-     * @param  int  $chunkSize
-     * @return int
      */
-    public function pruneAll(int $chunkSize = 1000)
+    public function pruneAll(int $chunkSize = 1000): int
     {
-        $query = tap($this->prunable(), function ($query) use ($chunkSize) {
-            $query->when(! $query->getQuery()->limit, function ($query) use ($chunkSize) {
-                $query->limit($chunkSize);
-            });
+        $softDeletable = static::isSoftDeletable();
+
+        $query = tap($this->prunable(), function ($query) use ($chunkSize, $softDeletable) {
+            $query->when($softDeletable, fn ($query) => $query->withTrashed())
+                ->when(! $query->getQuery()->limit, fn ($query) => $query->limit($chunkSize));
         });
 
         $total = 0;
-
-        $softDeletable = static::isSoftDeletable();
 
         do {
             $total += $count = $softDeletable

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -88,6 +88,24 @@ class EloquentMassPrunableTest extends DatabaseTestCase
         $this->assertEquals(0, MassPrunableSoftDeleteTestModel::count());
         $this->assertEquals(2000, MassPrunableSoftDeleteTestModel::withTrashed()->count());
     }
+
+    public function testPrunesActiveAndSoftDeletedRecords()
+    {
+        app('events')
+            ->expects('dispatch')
+            ->times(1)
+            ->with(Mockery::type(ModelsPruned::class));
+
+        MassPrunableSoftDeleteTestModel::insert([
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        ]);
+
+        $count = (new MassPrunableSoftDeleteTestModel)->pruneAll();
+
+        $this->assertEquals(2, $count);
+        $this->assertEquals(0, MassPrunableSoftDeleteTestModel::withTrashed()->count());
+    }
 }
 
 class MassPrunableTestModel extends Model


### PR DESCRIPTION
Hello!

It appears that the `Prunable` trait will automatically detect if the model is soft deletable and, if so, it will add the `->withTrashed()` method to the prunable query automatically. The `MassPrunable` trait does not currently do this, so there's a bit of an inconsistency that bit us


Targeting 14 so that there's no surprises for folks used to the existing behaviour.

Thanks!