### PR TITLE
[14.x] Adjust `chunk()` mutating the builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -38,10 +38,12 @@ trait BuildsQueries
      */
     public function chunk($count, callable $callback)
     {
-        $this->enforceOrderBy();
+        $clone = clone $this;
 
-        $skip = $this->getOffset();
-        $remaining = $this->getLimit();
+        $clone->enforceOrderBy();
+
+        $skip = $clone->getOffset();
+        $remaining = $clone->getLimit();
 
         $page = 1;
 
@@ -54,7 +56,7 @@ trait BuildsQueries
                 break;
             }
 
-            $results = $this->offset($offset)->limit($limit)->get();
+            $results = $clone->offset($offset)->limit($limit)->get();
 
             $countResults = $results->count();
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -545,6 +545,35 @@ class DatabaseEloquentBuilderTest extends TestCase
         }, 'someIdField');
     }
 
+    public function testChunkDoesNotMutateTheOriginalBuilder()
+    {
+        $model = new EloquentBuilderTestStub;
+
+        $connection = $this->mockConnectionForModel($model, '');
+        $connection->shouldReceive('getName')->andReturn('default');
+        $connection->shouldReceive('select')->andReturn(
+            [(object) ['id' => 1], (object) ['id' => 2]],
+            [(object) ['id' => 3]],
+            [(object) ['id' => 1], (object) ['id' => 2]],
+            [(object) ['id' => 3]],
+        );
+
+        $builder = $model->newQuery();
+
+        $builder->chunk(2, fn ($results) => true);
+
+        $this->assertNull($builder->getQuery()->offset);
+        $this->assertNull($builder->getQuery()->limit);
+        $this->assertEmpty($builder->getQuery()->orders);
+
+        $results = [];
+        $builder->chunk(2, function ($chunk) use (&$results) {
+            $results = array_merge($results, $chunk->pluck('id')->all());
+        });
+
+        $this->assertEquals([1, 2, 3], $results);
+    }
+
     public function testLazyWithLastChunkComplete()
     {
         $builder = Mockery::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/61411 

Since I did lazy I noticed this and it didn't sit right with me to just ignore it..

Today this fails:
```php
public function testChunkIsCrazy()
    {
        EloquentTestUser::insert([
            ['id' => 1, 'email' => 'jack@gmail.com'],
            ['id' => 2, 'email' => 'taylor@gmail.com'],
            ['id' => 3, 'email' => 'baz@gmail.com'],
        ]);

        $query = EloquentTestUser::query();

        $query->chunk(2, function(){
          // some stuff
        });

         // Later on reuse the same builder... it says 0
        $this->assertSame(3, $query->count());
    }
```   

This PR ensures it's not mutated  

Targets 14.x same as the lazy PR

Not sure if they both need backporting, but also a bit scared of breaking millions of apps.. 🌚 