### PR TITLE
[13.x] Optimize HTTP batch result ordering

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -332,13 +332,18 @@ class Batch
                 ->wait();
         }
 
-        // Before returning the results, we must ensure that the results are sorted
+        // Before returning the results, we must ensure that the results are ordered
         // in the same order as the requests were defined, respecting any custom
         // key names that were assigned to this request using the "as" method.
-        uksort($results, function ($key1, $key2) {
-            return array_search($key1, array_keys($this->requests), true) <=>
-                   array_search($key2, array_keys($this->requests), true);
-        });
+        $orderedResults = [];
+
+        foreach ($this->requests as $key => $request) {
+            if (array_key_exists($key, $results)) {
+                $orderedResults[$key] = $results[$key];
+            }
+        }
+
+        $results = $orderedResults;
 
         if (! $this->hasFailures() && $this->thenCallback !== null) {
             call_user_func($this->thenCallback, $this, $results);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\NoSeekStream;
@@ -4604,6 +4605,68 @@ class HttpClientTest extends TestCase
         $this->assertSame(1, $batch->failedRequests);
         $this->assertTrue($batch->hasFailures());
         $this->assertTrue($batch->finished());
+    }
+
+    public function testBatchResultsAreReturnedInRequestOrderWhenTheyCompleteOutOfOrder(): void
+    {
+        $promises = [];
+        $resolved = false;
+        $wait = function (bool $unwrap = true) use (&$promises, &$resolved) {
+            if ($resolved) {
+                return;
+            }
+
+            $resolved = true;
+
+            foreach (array_reverse($promises, true) as $key => $promise) {
+                $promise->resolve(new Response(new Psr7Response(200, [], "response-{$key}")));
+            }
+        };
+
+        for ($i = 0; $i < 4; $i++) {
+            $promises[] = new Promise($wait);
+        }
+
+        $batch = new class($promises) extends Batch
+        {
+            public function __construct(protected array $stubbedRequests)
+            {
+                parent::__construct();
+            }
+
+            protected function asyncRequest()
+            {
+                return array_shift($this->stubbedRequests);
+            }
+        };
+
+        $batch->as('first');
+        $batch->newRequest();
+        $batch->as('third');
+        $batch->newRequest();
+
+        $completionOrder = [];
+        $thenResults = [];
+        $finallyResults = [];
+
+        $results = $batch->progress(function (Batch $batch, int|string $key) use (&$completionOrder) {
+            $completionOrder[] = $key;
+        })->then(function (Batch $batch, array $results) use (&$thenResults) {
+            $thenResults = $results;
+        })->finally(function (Batch $batch, array $results) use (&$finallyResults) {
+            $finallyResults = $results;
+        })->send();
+
+        $this->assertSame([1, 'third', 0, 'first'], $completionOrder);
+        $this->assertSame(['first', 0, 'third', 1], array_keys($results));
+        $this->assertSame([
+            'first' => 'response-0',
+            0 => 'response-1',
+            'third' => 'response-2',
+            1 => 'response-3',
+        ], array_map(fn (Response $response) => $response->body(), $results));
+        $this->assertSame($results, $thenResults);
+        $this->assertSame($results, $finallyResults);
     }
 
     public function testBatchDefer(): void


### PR DESCRIPTION
This pull request improves the performance of restoring HTTP batch results to their request definition order.

The ordering introduced in #57483 is currently performed with:

```php
uksort($results, function ($key1, $key2) {
    return array_search($key1, array_keys($this->requests), true) <=>
           array_search($key2, array_keys($this->requests), true);
});
```

Let `R` be the number of requests and `F` the number of fulfilled results. `uksort` performs approximately O(F log F) comparisons. Each comparison rebuilds the complete request key array twice and then searches both arrays, making the ordering step approximately O(R × F log F). When most requests are fulfilled, R ≈ F ≈ N, this becomes O(N² log N).

The results can instead be rebuilt directly from the request insertion order:

```php
$orderedResults = [];

foreach ($this->requests as $key => $request) {
    if (array_key_exists($key, $results)) {
        $orderedResults[$key] = $results[$key];
    }
}

$results = $orderedResults;
```

This reduces the ordering step to O(R + F) while preserving the existing behavior:

- String, numeric, and mixed request keys retain their definition order.
- Response values remain associated with their original keys.
- Rejected promises remain absent because only keys present in `$results` are copied.
- Fulfilled `null` values are retained through `array_key_exists`.
- The `then` and `finally` callbacks continue to receive the ordered results.

The regression test uses controlled Guzzle promises with a shared wait callback. On the first wait, all promises are resolved in reverse order without making external HTTP requests. The test records the actual completion order and verifies the returned key order, response-to-key mapping, and the results passed to `then` and `finally`.

Benchmarked using the real `Batch::send()` path on an Apple M4 with PHP 8.5.8. Promises were created before timing and each value is the median of three runs:

| Requests | Before | After | Improvement |
| ---: | ---: | ---: | ---: |
| 1,000 | 96.976 ms | 1.488 ms | 65.2× |
| 2,000 | 489.422 ms | 4.551 ms | 107.5× |
| 5,000 | 3.365723 s | 17.519 ms | 192.1× |
