### PR TITLE
[13.x] Default `memoryExceededExitCode` for Cloud

### DIFF
--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -102,6 +102,7 @@ class QueueConnector implements ConnectorInterface
     {
         Worker::$restartable = false;
         Worker::$pausable = false;
+        Worker::$memoryExceededExitCode = Worker::EXIT_MEMORY_LIMIT;
 
         // Exit the worker (and restart the pod) when the agent socket is unreachable...
         $this->app->extend(

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -102,7 +102,7 @@ class QueueConnector implements ConnectorInterface
     {
         Worker::$restartable = false;
         Worker::$pausable = false;
-        Worker::$memoryExceededExitCode = Worker::EXIT_MEMORY_LIMIT;
+        Worker::$memoryExceededExitCode = null;
 
         // Exit the worker (and restart the pod) when the agent socket is unreachable...
         $this->app->extend(

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -143,7 +143,7 @@ class QueueTest extends TestCase
         }
     }
 
-    public function testItRestoresTheMemoryExceededExitCodeForManagedQueues()
+    public function testItDefaultsTheMemoryExceededExitCodeForManagedQueues()
     {
         $argv = $_SERVER['argv'];
         $_SERVER['argv'] = ['artisan', 'queue:work'];

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -153,9 +153,10 @@ class QueueTest extends TestCase
             CloudBootstrapper::bootManagedQueues($this->app);
 
             Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;
+            $this->assertSame(Worker::EXIT_SUCCESS, Worker::$memoryExceededExitCode);
 
             $this->app['queue']->connection('cloud');
-            $this->assertSame(Worker::EXIT_MEMORY_LIMIT, Worker::$memoryExceededExitCode);
+            $this->assertNull(Worker::$memoryExceededExitCode);
         } finally {
             $_SERVER['argv'] = $argv;
         }

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -74,6 +74,7 @@ class QueueTest extends TestCase
 
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
         $_SERVER['LARAVEL_CLOUD'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
@@ -105,6 +106,7 @@ class QueueTest extends TestCase
         unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
     }
 
     public function testItDisablesQueueRestartPollingForManagedQueues()
@@ -136,6 +138,24 @@ class QueueTest extends TestCase
 
             $this->app['queue']->connection('cloud');
             $this->assertFalse(Worker::$pausable);
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+    }
+
+    public function testItRestoresTheMemoryExceededExitCodeForManagedQueues()
+    {
+        $argv = $_SERVER['argv'];
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        try {
+            CloudBootstrapper::registerEvents($this->app);
+            CloudBootstrapper::bootManagedQueues($this->app);
+
+            Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;
+
+            $this->app['queue']->connection('cloud');
+            $this->assertSame(Worker::EXIT_MEMORY_LIMIT, Worker::$memoryExceededExitCode);
         } finally {
             $_SERVER['argv'] = $argv;
         }


### PR DESCRIPTION
We override this by default in our application due to our current production env elsewhere, and found we wouldn't get some notifications when set. 

We listen to the WorkerStopping events, so we could see some memory exhaustion basically, but wasnt getting notifications.

This should probably be backported to 12.x seeing as that also has the `memoryExceededExitCode` property.. 

I would also suggest maybe doing this for all the static overrides? But i am but one external operating man