### PR TITLE
[13.x] Fix callbacks deferred from within a deferred callback

### DIFF
--- a/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
@@ -55,6 +55,10 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
 
             unset($this->callbacks[$index]);
         }
+
+        if (! empty($this->callbacks)) {
+            $this->invokeWhen($when);
+        }
     }
 
     /**

--- a/tests/Integration/Support/DeferredCallbackTest.php
+++ b/tests/Integration/Support/DeferredCallbackTest.php
@@ -29,6 +29,25 @@ class DeferredCallbackTest extends TestCase
 
         $this->assertTrue($executed);
     }
+
+    public function test_callbacks_deferred_within_a_deferred_callback_are_invoked()
+    {
+        $result = [];
+
+        Route::get('/test', function () use (&$result) {
+            defer(function () use (&$result) {
+                $result[] = 'first';
+
+                defer(function () use (&$result) {
+                    $result[] = 'second';
+                });
+            });
+        });
+
+        $this->get('/test');
+
+        $this->assertSame(['first', 'second'], $result);
+    }
 }
 
 class TestSyncJob implements ShouldQueue


### PR DESCRIPTION
## Introduction

This PR ensures deferred callbacks are run recursively until there genuinely aren't any callbacks left. Currently, callbacks deferred while the deferred callbacks are being invoked are silently dropped:

```php
defer(function () {
    info('A');

    defer(fn () => info('B')); // never runs
});
```

In practice the nesting is almost never this visible. `defer()` is a global helper, so the inner call usually lives somewhere else entirely. Nothing tells you you're already inside a deferred callback, and you shouldn't have to trace the execution path or count how many layers deep you are before deciding whether `defer()` is safe to call.

## How I caught this
Dispatching a job from within a job is very common and works on every other connection. However, on the `deferred` connection, the inner job disappears without a trace.

```php
class ProcessPodcast implements ShouldQueue
{
    public function handle()
    {
        // ...
        ProcessTranscript::dispatch(); // never runs
    }
}
```

This easily means job chaining doesn't work, since the chain dispatches the next job from inside the current one, so every job after the first is a nested defer.

```php
Bus::chain([
    new ChainA, // only this job runs
    new ChainB, 
    new ChainC
])->dispatch();
```

That's a lot of surprise for someone who only changed `QUEUE_CONNECTION` from `database` to `deferred`.

## The fix
`DeferredCallbackCollection::invokeWhen()` iterates with foreach, which walks the array as it was when the loop started. Anything appended while executing the initial callbacks is never visited nor discarded; it just sits in the collection.

Now: after the loop, this PR recursively checks and drains whatever got added while it was running.
A bonus here is that this fixes the `background` queue connection, since that also depends on `defer()`.

Every other behaviour is unchanged.

Thanks!