### PR TITLE
[12.x] Default memoryExceededExitCode for Cloud

### DIFF
--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -102,6 +102,7 @@ class QueueConnector implements ConnectorInterface
     {
         Worker::$restartable = false;
         Worker::$pausable = false;
+        Worker::$memoryExceededExitCode = null;
 
         // Exit the worker (and restart the pod) when the agent socket is unreachable...
         $this->app->extend(

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -144,8 +144,8 @@ class QueueTest extends TestCase
         $_SERVER['argv'] = ['artisan', 'queue:work'];
 
         try {
-            CloudBootstrapper::registerEvents($this->app);
-            CloudBootstrapper::bootManagedQueues($this->app);
+            Cloud::registerEvents($this->app);
+            Cloud::bootManagedQueues($this->app);
 
             Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;
             $this->assertSame(Worker::EXIT_SUCCESS, Worker::$memoryExceededExitCode);

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -144,7 +144,6 @@ class QueueTest extends TestCase
         $_SERVER['argv'] = ['artisan', 'queue:work'];
 
         try {
-            Cloud::registerEvents($this->app);
             Cloud::bootManagedQueues($this->app);
 
             Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -71,6 +71,7 @@ class QueueTest extends TestCase
 
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
         $_SERVER['LARAVEL_CLOUD'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
@@ -102,6 +103,7 @@ class QueueTest extends TestCase
         unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
     }
 
     public function testItDisablesQueueRestartPollingForManagedQueues()
@@ -131,6 +133,25 @@ class QueueTest extends TestCase
 
             $this->app['queue']->connection('cloud');
             $this->assertFalse(Worker::$pausable);
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+    }
+
+    public function testItDefaultsTheMemoryExceededExitCodeForManagedQueues()
+    {
+        $argv = $_SERVER['argv'];
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        try {
+            CloudBootstrapper::registerEvents($this->app);
+            CloudBootstrapper::bootManagedQueues($this->app);
+
+            Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;
+            $this->assertSame(Worker::EXIT_SUCCESS, Worker::$memoryExceededExitCode);
+
+            $this->app['queue']->connection('cloud');
+            $this->assertNull(Worker::$memoryExceededExitCode);
         } finally {
             $_SERVER['argv'] = $argv;
         }


### PR DESCRIPTION
Backport of https://github.com/laravel/framework/pull/61430 

with slightly adjusted test to fit 12.x version 
 
 One of the tests timed out, so not failed https://github.com/laravel/framework/actions/runs/33816268256/job/100848992028?pr=61432