### PR TITLE
[12.x] Fix TypeError in userFromRecaller() when the user has no password

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -231,7 +231,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return;
         }
 
-        $userPassword = $user->getAuthPassword();
+        if (is_null($userPassword = $user->getAuthPassword())) {
+            return $user;
+        }
 
         $recallerHash = $recaller->hash();
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -611,6 +611,23 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->viaRemember());
     }
 
+    public function testUserUsesRememberCookieWhenUserHasNoPassword()
+    {
+        $guard = $this->getGuard();
+        [$session, $provider, $request, $cookie] = $this->getMocks();
+        $request = Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
+        $guard = new SessionGuard('default', $provider, $session, $request);
+        $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
+        $user = m::mock(Authenticatable::class);
+        $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
+        $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
+        $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
+        $session->shouldReceive('regenerate')->once();
+        $this->assertSame($user, $guard->user());
+        $this->assertTrue($guard->viaRemember());
+    }
+
     public function testUserReturnsNullWhenRememberCookieTokenDoesNotMatchAnyUser()
     {
         $guard = $this->getGuard();


### PR DESCRIPTION
Follow up to #61386 / #61397. Same TypeError, different path: the remember token matches a user, but that user has no password (socialite style apps with a nullable `password` column). `getAuthPassword()` is null, the first `hash_equals()` doesn't match, and the second one throws.

To hit it the cookie hash has to differ from the empty password hash, so either the password was cleared after the cookie was set, or the cookie is from before 12.45 (raw hash in the cookie, so for these users the third segment is just empty).

Repro on a fresh app (I used 13.30.1, the 12.x lines are the same):

1. make `users.password` nullable
2. `Auth::login($user, remember: true)`
3. set that user's `password` to null
4. delete the session cookie, keep `remember_web_*`, load any route that calls `Auth::check()`

500 on every request until the cookie expires. 12.68 logs the user in.

The fix skips the hash check when there is no password, which is what `AuthenticateSession` already does for these users. The token is still checked by `retrieveByToken()`, a wrong token still gets a guest.
