### PR TITLE
[13.x] Remove the unused Request import from the JSON:API resource stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/resource-json-api.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-json-api.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
 class {{ class }} extends JsonApiResource

--- a/tests/Integration/Generators/ResourceMakeCommandTest.php
+++ b/tests/Integration/Generators/ResourceMakeCommandTest.php
@@ -32,4 +32,20 @@ class ResourceMakeCommandTest extends TestCase
             'class FooResourceCollection extends ResourceCollection',
         ], 'app/Http/Resources/FooResourceCollection.php');
     }
+
+    public function testItCanGenerateJsonApiResourceFile()
+    {
+        $this->artisan('make:resource', ['name' => 'FooResource', '--json-api' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Http\Resources;',
+            'use Illuminate\Http\Resources\JsonApi\JsonApiResource;',
+            'class FooResource extends JsonApiResource',
+        ], 'app/Http/Resources/FooResource.php');
+
+        $this->assertFileNotContains([
+            'use Illuminate\Http\Request;',
+        ], 'app/Http/Resources/FooResource.php');
+    }
 }


### PR DESCRIPTION
`make:resource --json-api` generates a class that imports `Illuminate\Http\Request` and never uses it. The stub has no `toArray()`, only the `$attributes` and `$relationships` properties, so nothing in the generated file refers to `Request` at all. With Pint in CI that file fails `no_unused_imports` immediately after generation, before anyone has written a line into it — the rule is on in the default `laravel` preset. The framework's own style pass does not reach it, which is presumably how it survived: `pint.json` here turns `no_unused_imports` on as well, but Pint walks `*.php`, and all sixty-one files in that stubs directory end in `.stub`.

The import looks like it came along for the ride: `resource.stub` and `resource-collection.stub` next to it both declare `public function toArray(Request $request): array`, and the JSON:API stub was given the same header without the method that needed it. The file has not changed since #57571 added it.

The other way to fix this would be to give the stub a body instead, so the import earns its place. I don't think that is the right one here: `JsonApiResource` does not declare `toArray()` — it resolves through `resolve()` and reads the `$attributes` and `$relationships` properties, and the per-resource hooks it does declare are `toAttributes()`, `toRelationships()`, `toId()`, `toType()`, `toLinks()` and `toMeta()`. A generated `toArray()` would point people at the wrong extension point, and the properties already in the stub are the intended one. So this is a one-line removal.

There were no generator tests covering `--json-api`, so I added one alongside the two that were already there. It asserts the generated class extends `JsonApiResource` and that the `Request` import is not in it, which is what would have caught this in the first place.
