### PR TITLE
[13.x] Keep Eloquent on the direct connection during migrations

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1479,7 +1479,14 @@ class Connection implements ConnectionInterface
      */
     public function getName()
     {
-        return $this->getConfig('name');
+        $name = $this->getConfig('name');
+
+        // The "direct" connection is a distinct connection instance with its own
+        // transactions, so its name has to keep the suffix in order to resolve
+        // back to it. Read and write connections still collapse to the base.
+        return $this->readWriteType === 'direct' && $name
+            ? $name.'::direct'
+            : $name;
     }
 
     /**
@@ -1489,7 +1496,7 @@ class Connection implements ConnectionInterface
      */
     public function getNameWithReadWriteType()
     {
-        $name = $this->getName().($this->readWriteType ? '::'.$this->readWriteType : '');
+        $name = $this->getConfig('name').($this->readWriteType ? '::'.$this->readWriteType : '');
 
         return empty($name) ? null : $name;
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1481,9 +1481,6 @@ class Connection implements ConnectionInterface
     {
         $name = $this->getConfig('name');
 
-        // The "direct" connection is a distinct connection instance with its own
-        // transactions, so its name has to keep the suffix in order to resolve
-        // back to it. Read and write connections still collapse to the base.
         return $this->readWriteType === 'direct' && $name
             ? $name.'::direct'
             : $name;

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -239,7 +239,12 @@ class MigrateCommand extends BaseCommand implements Isolatable
      */
     protected function createMissingMySqlOrPgsqlDatabase($connection)
     {
-        if ($this->laravel['config']->get("database.connections.{$connection->getName()}.database") !== $connection->getDatabaseName()) {
+        // The connection name may carry a routing suffix, such as "::direct", which is
+        // not part of the configuration key, so it has to be trimmed before the
+        // database name is read from and later written back to the config.
+        $configKey = 'database.connections.'.Str::before($connection->getName(), '::');
+
+        if ($this->laravel['config']->get("{$configKey}.database") !== $connection->getDatabaseName()) {
             return false;
         }
 
@@ -258,7 +263,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
         }
         try {
             $this->laravel['config']->set(
-                "database.connections.{$connection->getName()}.database",
+                "{$configKey}.database",
                 match ($connection->getDriverName()) {
                     'mysql', 'mariadb' => null,
                     'pgsql' => 'postgres',
@@ -278,7 +283,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 $this->laravel['db']->purge();
             });
         } finally {
-            $this->laravel['config']->set("database.connections.{$connection->getName()}.database", $connection->getDatabaseName());
+            $this->laravel['config']->set("{$configKey}.database", $connection->getDatabaseName());
         }
     }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -239,12 +239,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
      */
     protected function createMissingMySqlOrPgsqlDatabase($connection)
     {
-        // The connection name may carry a routing suffix, such as "::direct", which is
-        // not part of the configuration key, so it has to be trimmed before the
-        // database name is read from and later written back to the config.
         $configKey = 'database.connections.'.Str::before($connection->getName(), '::');
 
-        if ($this->laravel['config']->get("{$configKey}.database") !== $connection->getDatabaseName()) {
+        if ($this->laravel['config']->get("{$configKey}.database") !== 
+            $connection->getDatabaseName()) {
             return false;
         }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -873,6 +873,30 @@ class DatabaseConnectionTest extends TestCase
         $this->assertSame('pgsql::direct', $connection->getNameWithReadWriteType());
     }
 
+    public function testNameKeepsTheDirectRoutingType()
+    {
+        $connection = new Connection(new DatabaseConnectionTestMockPDO, 'database', '', [
+            'name' => 'pgsql',
+        ]);
+
+        $connection->setReadWriteType('direct');
+
+        $this->assertSame('pgsql::direct', $connection->getName());
+    }
+
+    public function testNameCollapsesTheReadAndWriteRoutingTypes()
+    {
+        $connection = new Connection(new DatabaseConnectionTestMockPDO, 'database', '', [
+            'name' => 'pgsql',
+        ]);
+
+        foreach ([null, 'read', 'write'] as $readWriteType) {
+            $connection->setReadWriteType($readWriteType);
+
+            $this->assertSame('pgsql', $connection->getName());
+        }
+    }
+
     public function testQueryExceptionContainsDirectConnectionDetailsWhenUsingDirectConnection()
     {
         $directPdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)

--- a/tests/Integration/Database/Postgres/DatabasePgsqlPooledConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePgsqlPooledConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\Postgres;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use PDO;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -41,6 +42,35 @@ class DatabasePgsqlPooledConnectionTest extends PostgresTestCase
         $this->assertIsBool(DB::connection('pgsql')->getSchemaBuilder()->hasTable('migrations'));
     }
 
+    public function testEloquentModelsStayOnTheDirectConnection()
+    {
+        $direct = DB::connection('pgsql::direct');
+        $schema = $direct->getSchemaBuilder();
+
+        $schema->dropIfExists('pooled_direct_models');
+
+        try {
+            $direct->transaction(function () use ($schema) {
+                $schema->create('pooled_direct_models', function ($table) {
+                    $table->id();
+                    $table->string('name');
+                });
+
+                // Every model the builder produces has to keep the routing, whether it is created
+                // or hydrated. The table only exists inside this transaction, so anything falling
+                // back to the pooled connection can neither write to it nor read it back.
+                $created = PooledDirectModel::on('pgsql::direct')->create(['name' => 'direct']);
+                $retrieved = PooledDirectModel::on('pgsql::direct')->first();
+
+                $this->assertSame('pgsql::direct', $created->getConnectionName());
+                $this->assertSame('pgsql::direct', $retrieved->getConnectionName());
+                $this->assertSame('direct', $retrieved->name);
+            });
+        } finally {
+            $schema->dropIfExists('pooled_direct_models');
+        }
+    }
+
     public function testPooledConnectionCanBindBooleansWithEmulatedPrepares()
     {
         $schema = DB::connection('pgsql::direct')->getSchemaBuilder();
@@ -63,4 +93,13 @@ class DatabasePgsqlPooledConnectionTest extends PostgresTestCase
             $schema->dropIfExists('pooled_boolean_bindings');
         }
     }
+}
+
+class PooledDirectModel extends Model
+{
+    protected $table = 'pooled_direct_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
 }


### PR DESCRIPTION
[#60425](https://github.com/laravel/framework/pull/60425) added the `::direct` routing type in 13.x. `Migrator::runMethod()` sets the default connection to `pgsql::direct` so migrations run outside the transaction pooler, but `Connection::getName()` strips the suffix. As a result, any Eloquent model that binds to a resolved connection falls back to `pgsql`, outside the migration's transaction.

```php
Schema::create('examples', function (Blueprint $table) {
    $table->id();
});

Example::create([]); // runs on "pgsql", not "pgsql::direct"
```

On a fresh database, `migrate:fresh` **fails** with `relation "examples" does not exist`.

On an existing database, the insert succeeds but is no longer part of the migration transaction.
A pooler is not required to reproduce the issue: pointing `direct` at the same host is enough, since `pgsql` and `pgsql::direct` are separate `Connection` instances with independent transactions.

`getName()` intentionally collapses `::read` and `::write` so a model loaded through a replica remains writable. `::direct` is different: it represents a distinct connection used to bypass the pooler, so removing the suffix changes where the query is executed.

This change preserves the `::direct` suffix. `getNameWithReadWriteType()` now reads the base name straight from the configuration, so its output is unchanged for every input.

The check matches `::direct` explicitly rather than excluding `::read` and `::write`. 
Discarted solution:
```php
  // Read and write connections collapse to the base name so a model read from
  // a replica may still be written. Any other routing type resolves to its
  // own connection instance, with its own transactions, so the name has
  // to keep the suffix in order to resolve back to that instance.
  return $name && $this->readWriteType && ! in_array($this->readWriteType, ['read', 'write'])
      ? $name.'::'.$this->readWriteType
      : $name;
```
An exclusion rule would preserve any future routing type for free, but `setReadWriteType()` is public: an unrecognised value would then produce a name that resolves to no connection at all, and the failure would surface far from its cause. 

`::direct` is not a Postgres concept in the core. `DatabaseManager::parseConnectionName()`, `DatabaseManager::setPdoForType()`, `Connection::$directPdo` and `Migrator::directConnectionName()` are all driver-agnostic; the only driver check is `ConfiguresPooledConnections::hasDirectConnection()`, which decides where a direct PDO is configured. This fix stays in that same driver-agnostic layer.

That covers `Builder::newModelInstance()`, `Factory::store()`, `Model::save()`, `Model::saveOrIgnore()`, and `MorphTo::createModelByType()` without modifying any of them directly.

`MigrateCommand::createMissingMySqlOrPgsqlDatabase()` builds a configuration key from the connection name, so it now strips any routing suffix before resolving the configuration.

Behaviour change: `getName()` returns `pgsql::direct` on that connection, so `QueryExecuted`, the connection events and `db:show` report it that way.

This builds directly on #61092  by @RobertoNegro 
The diagnosis, reproduction case, and integration test originated there. That PR was closed because of the amount of code it touched, so this is the same fix reduced to a single branch in an existing method.