### PR TITLE
Adding HTTP method for scheduler ping methods

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -616,7 +616,6 @@ class Event
                 $container->make(ExceptionHandler::class)->report($e);
             }
         };
-
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -633,7 +633,7 @@ class Event
                 'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
                 'timeout' => 30,
             ],
-            $options
+            is_array($options) ? $options : []
         );
 
         return match (true) {

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -493,11 +493,12 @@ class Event
      * Register a callback to ping a given URL before the job runs.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingBefore($url)
+    public function pingBefore($url, $method = 'GET')
     {
-        return $this->before($this->pingCallback($url));
+        return $this->before($this->pingCallback($url, $method));
     }
 
     /**
@@ -505,22 +506,24 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingBeforeIf($value, $url)
+    public function pingBeforeIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->pingBefore($url) : $this;
+        return $value ? $this->pingBefore($url, $method) : $this;
     }
 
     /**
      * Register a callback to ping a given URL after the job runs.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function thenPing($url)
+    public function thenPing($url, $method = 'GET')
     {
-        return $this->then($this->pingCallback($url));
+        return $this->then($this->pingCallback($url, $method));
     }
 
     /**
@@ -528,22 +531,24 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function thenPingIf($value, $url)
+    public function thenPingIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->thenPing($url) : $this;
+        return $value ? $this->thenPing($url, $method) : $this;
     }
 
     /**
      * Register a callback to ping a given URL if the operation succeeds.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingOnSuccess($url)
+    public function pingOnSuccess($url, $method = 'GET')
     {
-        return $this->onSuccess($this->pingCallback($url));
+        return $this->onSuccess($this->pingCallback($url, $method));
     }
 
     /**
@@ -551,22 +556,24 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingOnSuccessIf($value, $url)
+    public function pingOnSuccessIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->onSuccess($this->pingCallback($url)) : $this;
+        return $value ? $this->onSuccess($this->pingCallback($url, $method)) : $this;
     }
 
     /**
      * Register a callback to ping a given URL if the operation fails.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingOnFailure($url)
+    public function pingOnFailure($url, $method = 'GET')
     {
-        return $this->onFailure($this->pingCallback($url));
+        return $this->onFailure($this->pingCallback($url, $method));
     }
 
     /**
@@ -574,11 +581,12 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingOnFailureIf($value, $url)
+    public function pingOnFailureIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->onFailure($this->pingCallback($url)) : $this;
+        return $value ? $this->onFailure($this->pingCallback($url, $method)) : $this;
     }
 
     /**
@@ -587,11 +595,13 @@ class Event
      * @param  string  $url
      * @return \Closure
      */
-    protected function pingCallback($url)
+    protected function pingCallback($url, $method = 'GET')
     {
-        return function (Container $container) use ($url) {
+        $method = in_array($method, ['GET', 'POST', 'HEAD']) ? strtoupper($method) : 'GET';
+
+        return function (Container $container) use ($url, $method) {
             try {
-                $this->getHttpClient($container)->request('GET', $url);
+                $this->getHttpClient($container)->request($method, $url);
             } catch (ClientExceptionInterface|TransferException $e) {
                 $container->make(ExceptionHandler::class)->report($e);
             }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -494,11 +494,12 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingBefore($url, $method = 'GET')
+    public function pingBefore($url, $method = 'GET', $options = [])
     {
-        return $this->before($this->pingCallback($url, $method));
+        return $this->before($this->pingCallback($url, $method, $options));
     }
 
     /**
@@ -507,9 +508,10 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingBeforeIf($value, $url, $method = 'GET')
+    public function pingBeforeIf($value, $url, $method = 'GET', $options = [])
     {
         return $value ? $this->pingBefore($url, $method) : $this;
     }
@@ -519,11 +521,12 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function thenPing($url, $method = 'GET')
+    public function thenPing($url, $method = 'GET', $options = [])
     {
-        return $this->then($this->pingCallback($url, $method));
+        return $this->then($this->pingCallback($url, $method, $options));
     }
 
     /**
@@ -532,11 +535,12 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function thenPingIf($value, $url, $method = 'GET')
+    public function thenPingIf($value, $url, $method = 'GET', $options = [])
     {
-        return $value ? $this->thenPing($url, $method) : $this;
+        return $value ? $this->thenPing($url, $method, $options) : $this;
     }
 
     /**
@@ -544,11 +548,12 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingOnSuccess($url, $method = 'GET')
+    public function pingOnSuccess($url, $method = 'GET', $options = [])
     {
-        return $this->onSuccess($this->pingCallback($url, $method));
+        return $this->onSuccess($this->pingCallback($url, $method, $options));
     }
 
     /**
@@ -557,11 +562,12 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingOnSuccessIf($value, $url, $method = 'GET')
+    public function pingOnSuccessIf($value, $url, $method = 'GET', $options = [])
     {
-        return $value ? $this->onSuccess($this->pingCallback($url, $method)) : $this;
+        return $value ? $this->onSuccess($this->pingCallback($url, $method, $options)) : $this;
     }
 
     /**
@@ -569,11 +575,12 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingOnFailure($url, $method = 'GET')
+    public function pingOnFailure($url, $method = 'GET', $options = [])
     {
-        return $this->onFailure($this->pingCallback($url, $method));
+        return $this->onFailure($this->pingCallback($url, $method, $options));
     }
 
     /**
@@ -582,9 +589,10 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
+     * @param  array   $options
      * @return $this
      */
-    public function pingOnFailureIf($value, $url, $method = 'GET')
+    public function pingOnFailureIf($value, $url, $method = 'GET', $options = [])
     {
         return $value ? $this->onFailure($this->pingCallback($url, $method)) : $this;
     }
@@ -593,37 +601,45 @@ class Event
      * Get the callback that pings the given URL.
      *
      * @param  string  $url
+     * @param  string  $method
+     * @param  array   $options
      * @return \Closure
      */
-    protected function pingCallback($url, $method = 'GET')
+    protected function pingCallback($url, $method = 'GET', $options = [])
     {
         $method = in_array($method, ['GET', 'POST', 'HEAD']) ? strtoupper($method) : 'GET';
-
-        return function (Container $container) use ($url, $method) {
+        return function (Container $container) use ($url, $method, $options) {
             try {
-                $this->getHttpClient($container)->request($method, $url);
+                $this->getHttpClient($container, $options)->request($method, $url);
             } catch (ClientExceptionInterface|TransferException $e) {
                 $container->make(ExceptionHandler::class)->report($e);
             }
         };
+
     }
 
     /**
      * Get the Guzzle HTTP client to use to send pings.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  string  $method
      * @return \GuzzleHttp\ClientInterface
      */
-    protected function getHttpClient(Container $container)
+    protected function getHttpClient(Container $container, $options)
     {
-        return match (true) {
-            $container->bound(HttpClientInterface::class) => $container->make(HttpClientInterface::class),
-            $container->bound(HttpClient::class) => $container->make(HttpClient::class),
-            default => new HttpClient([
+        $options = array_merge(
+            [
                 'connect_timeout' => 10,
                 'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
                 'timeout' => 30,
-            ]),
+            ],
+            $options
+        );
+
+        return match (true) {
+            $container->bound(HttpClientInterface::class) => $container->make(HttpClientInterface::class),
+            $container->bound(HttpClient::class) => $container->make(HttpClient::class),
+            default => new HttpClient($options),
         };
     }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -494,7 +494,7 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingBefore($url, $method = 'GET', $options = [])
@@ -508,7 +508,7 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingBeforeIf($value, $url, $method = 'GET', $options = [])
@@ -521,7 +521,7 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function thenPing($url, $method = 'GET', $options = [])
@@ -535,7 +535,7 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function thenPingIf($value, $url, $method = 'GET', $options = [])
@@ -548,7 +548,7 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingOnSuccess($url, $method = 'GET', $options = [])
@@ -562,7 +562,7 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingOnSuccessIf($value, $url, $method = 'GET', $options = [])
@@ -575,7 +575,7 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingOnFailure($url, $method = 'GET', $options = [])
@@ -589,7 +589,7 @@ class Event
      * @param  bool  $value
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function pingOnFailureIf($value, $url, $method = 'GET', $options = [])
@@ -602,7 +602,7 @@ class Event
      *
      * @param  string  $url
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return \Closure
      */
     protected function pingCallback($url, $method = 'GET', $options = [])

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -608,6 +608,7 @@ class Event
     protected function pingCallback($url, $method = 'GET', $options = [])
     {
         $method = in_array($method, ['GET', 'POST', 'HEAD']) ? strtoupper($method) : 'GET';
+
         return function (Container $container) use ($url, $method, $options) {
             try {
                 $this->getHttpClient($container, $options)->request($method, $url);


### PR DESCRIPTION
## Currently

Laravel scheduler ping methods allow only GET URL requests. 

## Changing 

User can now choose to send GET, POST or HEAD ping requests

Example: 
```
$schedule->command('myapp:run-command')->everyMinute()->thenPing('https://uptime.xxx.com', 'POST');