### PR TITLE
[14.x] Add opt-in jitter to queue backoff

### DIFF
--- a/src/Illuminate/Queue/Attributes/BackoffJitter.php
+++ b/src/Illuminate/Queue/Attributes/BackoffJitter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class BackoffJitter
+{
+    /**
+     * The default proportion the backoff may be adjusted by.
+     */
+    public const DEFAULT_RATIO = 0.25;
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  float  $ratio  Proportion of the backoff the delay may vary by, between 0 and 1.
+     */
+    public function __construct(public float $ratio = self::DEFAULT_RATIO)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -327,6 +327,16 @@ abstract class Job
     }
 
     /**
+     * Get the proportion the job's backoff may be adjusted by.
+     *
+     * @return float|null
+     */
+    public function backoffJitter()
+    {
+        return $this->payload()['backoffJitter'] ?? null;
+    }
+
+    /**
      * Get the number of seconds the job can run.
      *
      * @return int|null

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
+use Illuminate\Queue\Attributes\BackoffJitter;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -181,6 +182,7 @@ abstract class Queue
             'maxExceptions' => $this->getAttributeValue($job, MaxExceptions::class, 'maxExceptions'),
             'failOnTimeout' => $this->getAttributeValue($job, FailOnTimeout::class, 'failOnTimeout') ?? false,
             'backoff' => $this->getJobBackoff($job),
+            'backoffJitter' => $this->getJobBackoffJitter($job),
             'timeout' => $this->getAttributeValue($job, Timeout::class, 'timeout'),
             'retryUntil' => $this->getJobExpiration($job),
             'deleteWhenMissingModels' => $this->getAttributeValue($job, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? false,
@@ -266,6 +268,27 @@ abstract class Queue
     }
 
     /**
+     * Get the backoff jitter ratio for an object-based queue handler.
+     *
+     * @param  mixed  $job
+     * @return float|null
+     */
+    public function getJobBackoffJitter($job)
+    {
+        $jitter = $this->getAttributeValue($job, BackoffJitter::class, 'backoffJitter');
+
+        if (method_exists($job, 'backoffJitter')) {
+            $jitter = $job->backoffJitter();
+        }
+
+        if (is_null($jitter) || $jitter === false) {
+            return;
+        }
+
+        return $jitter === true ? BackoffJitter::DEFAULT_RATIO : (float) $jitter;
+    }
+
+    /**
      * Get the expiration timestamp for an object-based queue handler.
      *
      * @param  mixed  $job
@@ -317,6 +340,7 @@ abstract class Queue
             'maxExceptions' => null,
             'failOnTimeout' => false,
             'backoff' => null,
+            'backoffJitter' => null,
             'timeout' => null,
             'data' => $data,
             'createdAt' => Carbon::now()->getTimestamp(),

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -799,7 +799,38 @@ class Worker
                 : $options->backoff
         );
 
-        return (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+        return $this->applyBackoffJitter(
+            $job, (int) ($backoff[$job->attempts() - 1] ?? last($backoff))
+        );
+    }
+
+    /**
+     * Apply the job's jitter, if any, to the calculated backoff.
+     *
+     * Jitter spreads the retries of jobs that failed together, so that they do
+     * not all hit a struggling dependency again at the same moment.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  int  $backoff
+     * @return int
+     */
+    protected function applyBackoffJitter($job, $backoff)
+    {
+        if ($backoff <= 0 || ! method_exists($job, 'backoffJitter')) {
+            return $backoff;
+        }
+
+        $ratio = $job->backoffJitter();
+
+        if (is_null($ratio)) {
+            return $backoff;
+        }
+
+        $delta = (int) round($backoff * max(0, min(1, (float) $ratio)));
+
+        return $delta === 0
+            ? $backoff
+            : random_int($backoff - $delta, $backoff + $delta);
     }
 
     /**

--- a/tests/Queue/QueueAttributesTest.php
+++ b/tests/Queue/QueueAttributesTest.php
@@ -2,12 +2,27 @@
 
 namespace Illuminate\Tests\Queue;
 
+use Illuminate\Queue\Attributes\BackoffJitter;
 use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\Queue;
 use PHPUnit\Framework\TestCase;
 
 class QueueAttributesTest extends TestCase
 {
+    public function test_backoff_jitter_attribute_defaults_to_the_default_ratio()
+    {
+        $attribute = new BackoffJitter;
+
+        $this->assertSame(BackoffJitter::DEFAULT_RATIO, $attribute->ratio);
+    }
+
+    public function test_backoff_jitter_attribute_accepts_an_explicit_ratio()
+    {
+        $attribute = new BackoffJitter(0.5);
+
+        $this->assertSame(0.5, $attribute->ratio);
+    }
+
     public function test_queue_attribute_normalizes_backed_enum_to_string()
     {
         $attribute = new Queue(QueueAttributeBackedEnum::DEFAULT);

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -46,7 +46,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $pheanstalk = $this->queue->getPheanstalk();
         $pheanstalk->expects('useTube')->with(Mockery::type(TubeName::class));
         $pheanstalk->expects('useTube')->with(Mockery::type(TubeName::class));
-        $pheanstalk->expects('put')->times(2)->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]), 1024, 0, 60);
+        $pheanstalk->expects('put')->times(2)->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]), 1024, 0, 60);
 
         $this->queue->push('foo', ['data'], 'stack');
         $this->queue->push('foo', ['data']);
@@ -71,7 +71,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $pheanstalk = $this->queue->getPheanstalk();
         $pheanstalk->expects('useTube')->with(Mockery::type(TubeName::class));
         $pheanstalk->expects('useTube')->with(Mockery::type(TubeName::class));
-        $pheanstalk->expects('put')->times(2)->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 5]), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
+        $pheanstalk->expects('put')->times(2)->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 5]), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
 
         $this->queue->later(5, 'foo', ['data'], 'stack');
         $this->queue->later(5, 'foo', ['data']);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Queue\Attributes\Backoff;
+use Illuminate\Queue\Attributes\BackoffJitter;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -93,7 +94,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $database->expects('table')->with('table')->andReturn($query);
         $query->expects('insertGetId')->andReturnUsing(function ($array) use ($uuid, $time) {
             $this->assertSame('default', $array['queue']);
-            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 10]), $array['payload']);
+            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 10]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
@@ -156,6 +157,29 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->push(new ChildJobWithPropertiesOverridingParentAttributes, ['data']);
 
         $container->shouldHaveReceived('bound')->with('events')->twice();
+    }
+
+    public function testPushResolvesBackoffJitterFromAttributeAndProperty()
+    {
+        $payloads = [];
+
+        foreach ([new JobWithBackoffJitterAttribute, new JobWithBackoffJitterProperty, new JobWithoutBackoffJitter] as $job) {
+            $database = Mockery::mock(Connection::class);
+            $queue = new DatabaseQueue($database, 'table', 'default');
+            $container = Mockery::spy(Container::class);
+            $queue->setContainer($container);
+            $query = Mockery::mock(QueryBuilder::class);
+            $database->expects('table')->with('table')->andReturn($query);
+            $query->expects('insertGetId')->andReturnUsing(function ($array) use (&$payloads) {
+                $payloads[] = json_decode($array['payload'], true);
+            });
+
+            $queue->push($job, ['data']);
+        }
+
+        $this->assertSame(BackoffJitter::DEFAULT_RATIO, $payloads[0]['backoffJitter']);
+        $this->assertSame(0.5, $payloads[1]['backoffJitter']);
+        $this->assertNull($payloads[2]['backoffJitter']);
     }
 
     public function testPushStillUsesAttributesDeclaredOnSameClassOverDefaultProperties()
@@ -232,14 +256,14 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $query->expects('insert')->andReturnUsing(function ($records) use ($uuid, $time) {
             $this->assertEquals([[
                 'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
+                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
                 'attempts' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',
             ], [
                 'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'bar', 'job' => 'bar', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
+                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'bar', 'job' => 'bar', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
                 'attempts' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',
@@ -586,6 +610,20 @@ class AfterCommitJob implements ShouldQueue
 #[Timeout(40)]
 #[Tries(2)]
 abstract class ParentJobWithAttributes implements ShouldQueue
+{
+}
+
+#[BackoffJitter]
+class JobWithBackoffJitterAttribute implements ShouldQueue
+{
+}
+
+class JobWithBackoffJitterProperty implements ShouldQueue
+{
+    public $backoffJitter = 0.5;
+}
+
+class JobWithoutBackoffJitter implements ShouldQueue
 {
 }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -35,7 +35,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container);
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->expects('isCluster')->andReturn(false);
-        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
@@ -62,7 +62,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container);
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->expects('isCluster')->andReturn(false);
-        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -95,7 +95,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container);
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->expects('isCluster')->andReturn(false);
-        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->expects('eval')->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -139,7 +139,7 @@ class QueueRedisQueueTest extends TestCase
             1,
             'queues:default:delayed',
             2,
-            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 1])
+            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 1])
         );
 
         $id = $queue->later(1, 'foo', ['data']);
@@ -173,7 +173,7 @@ class QueueRedisQueueTest extends TestCase
             1,
             'queues:default:delayed',
             5,
-            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 5])
+            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'backoffJitter' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 5])
         );
 
         $queue->later($date->addSeconds(5), 'foo', ['data']);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -419,6 +419,83 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(10, $job->releaseAfter);
     }
 
+    public function testBackoffIsNotJitteredByDefault()
+    {
+        foreach (range(1, 25) as $ignored) {
+            $job = new WorkerFakeJob(function ($job) {
+                throw new Exception('Something went wrong.');
+            });
+
+            $job->attempts = 1;
+            $job->backoff = 100;
+
+            $worker = $this->getWorker('default', ['queue' => [$job]]);
+            $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+            $this->assertSame(100, $job->releaseAfter);
+        }
+    }
+
+    public function testBackoffJitterKeepsTheDelayWithinTheConfiguredRatio()
+    {
+        $delays = [];
+
+        foreach (range(1, 50) as $ignored) {
+            $job = new WorkerFakeJob(function ($job) {
+                throw new Exception('Something went wrong.');
+            });
+
+            $job->attempts = 1;
+            $job->backoff = 100;
+            $job->backoffJitter = 0.25;
+
+            $worker = $this->getWorker('default', ['queue' => [$job]]);
+            $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+            $delays[] = $job->releaseAfter;
+
+            $this->assertGreaterThanOrEqual(75, $job->releaseAfter);
+            $this->assertLessThanOrEqual(125, $job->releaseAfter);
+        }
+
+        $this->assertGreaterThan(1, count(array_unique($delays)));
+    }
+
+    public function testBackoffJitterLeavesAZeroBackoffAlone()
+    {
+        $job = new WorkerFakeJob(function ($job) {
+            throw new Exception('Something went wrong.');
+        });
+
+        $job->attempts = 1;
+        $job->backoff = 0;
+        $job->backoffJitter = 0.5;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+        $this->assertSame(0, $job->releaseAfter);
+    }
+
+    public function testBackoffJitterRatioIsClampedAndNeverYieldsANegativeDelay()
+    {
+        foreach (range(1, 25) as $ignored) {
+            $job = new WorkerFakeJob(function ($job) {
+                throw new Exception('Something went wrong.');
+            });
+
+            $job->attempts = 1;
+            $job->backoff = 10;
+            $job->backoffJitter = 5.0;
+
+            $worker = $this->getWorker('default', ['queue' => [$job]]);
+            $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 0]));
+
+            $this->assertGreaterThanOrEqual(0, $job->releaseAfter);
+            $this->assertLessThanOrEqual(20, $job->releaseAfter);
+        }
+    }
+
     public function testJobRunsIfAppIsNotInMaintenanceMode()
     {
         $firstJob = new WorkerFakeJob(function ($job) {
@@ -861,6 +938,7 @@ class WorkerFakeJob implements QueueJobContract
     public $shouldFailOnTimeout = false;
     public $uuid;
     public $backoff;
+    public $backoffJitter;
     public $retryUntil;
     public $attempts = 0;
     public $failedWith;
@@ -916,6 +994,11 @@ class WorkerFakeJob implements QueueJobContract
     public function backoff()
     {
         return $this->backoff;
+    }
+
+    public function backoffJitter()
+    {
+        return $this->backoffJitter;
     }
 
     public function retryUntil()


### PR DESCRIPTION
Backoff delays are currently deterministic. Every job that fails at the same moment against the same dependency computes the same delay and retries in lockstep, so a rate-limited or briefly-degraded API gets hit by the whole batch again simultaneously.

This adds an opt-in jitter ratio that spreads those retries over a bounded window around the configured backoff.

```php
use Illuminate\Queue\Attributes\Backoff;
use Illuminate\Queue\Attributes\BackoffJitter;

#[Backoff(60)]
#[BackoffJitter]        // 0.25 by default, so 45-75s
class SyncInventory implements ShouldQueue
{
    //
}
```

The ratio is configurable, and the property form works too, matching how the other queue options are already expressed:

```php
#[BackoffJitter(0.5)]   // 30-90s

public $backoffJitter = 0.5;
```

### Notes

- **Off by default.** With no attribute or property, `calculateBackoff()` returns exactly what it returned before, so existing retry timing is unchanged.
- Resolution goes through the existing `getAttributeValue()` helper, so attribute, property, inheritance, and property-overrides-attribute all behave the same way `backoff` already does. No new resolution path.
- A backoff of `0` is left alone, so opting in never introduces a delay where there wasn't one.
- The ratio is clamped to `0..1`, so the delay can't go negative.
- Jitter is proportional (±ratio) rather than AWS-style full jitter (`random(0, backoff)`). Full jitter spreads more aggressively but can collapse a deliberately-tuned 300s backoff to near zero; proportional keeps the configured value meaningful. Happy to switch if you'd prefer the other shape.

### Tests

`tests/Queue` 311 passing, `tests/Bus` and `tests/Integration/Queue` 378 passing, `pint` clean. The payload-shape assertions in the Redis, Beanstalkd and Database queue tests were updated for the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
