### PR TITLE
[13.x] Memory leak fix in Http Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -272,7 +272,7 @@ class PendingRequest
             'timeout' => 30,
         ];
 
-        $this->beforeSendingCallbacks = new Collection([function (Request $request, array $options, PendingRequest $pendingRequest) {
+        $this->beforeSendingCallbacks = new Collection([static function (Request $request, array $options, PendingRequest $pendingRequest) {
             $pendingRequest->request = $request;
             $pendingRequest->cookies = $options['cookies'];
 


### PR DESCRIPTION
Making a lot of requests in a while/for loop may cause an out of memory error.

## Description
There is a temporary memory leak with Illuminate\Http\Client\PendingRequest caused by a reference cycle between `beforeSendingCallbacks` closure and PendingRequest object.
```php
// There is no "static" keyword, so the function stores a reference on a PendingRequest object as $this
// and $this (binding) is not really needed here since the request is provided as a parameter $pendingRequest
$this->beforeSendingCallbacks = new Collection([function (Request $request, array $options, PendingRequest $pendingRequest) {
``` 

While not so severe on its own, in `sendReqest` we have a callback that saves a reference to an object that references the whole guzzle response
```php
$onStats = function ($transferStats) {
    if (($callback = ($this->options['on_stats'] ?? false)) instanceof Closure) {
        $transferStats = $callback($transferStats) ?: $transferStats;
    }

    // Guzzle gives us the response and request here, so we keep them in memory while PendingRequest object exists 
    $this->transferStats = $transferStats;
};
```
In GuzzleHttp
```php
    private static function invokeStats(EasyHandle $easy): void
    {
        $curlStats = \curl_getinfo($easy->handle);
        $curlStats['appconnect_time'] = \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME);
        $stats = new TransferStats(
            $easy->request,
            $easy->response,
            $curlStats['total_time'],
            $easy->errno,
            $curlStats
        );
        ($easy->options['on_stats'])($stats);
    }
```

## Motivation
So in a scenario where we get a bunch of images, we will accamulate PendingRequests that inderectly hold references to the bodies of every large image response. This may lead to out-of-memory failure of jobs etc.
Adding the fix will also optimize peak of used memory
```php
use Illuminate\Support\Facades\Http;

$urls = [/* around 100 of 1MB image URLs */];

foreach ($urls as $url) {
    $response = Http::timeout(20)->get($url);
    $body = $response->body();
    unset($body, $response);
    // memory_get_usage(false) will constantly grow until gc decides to kick in but with a high chance will OOM before that
}
```

Adding the `static` keyword will prevent reference cycle instantly freeing the memory once PendingRequest is not referenced from anywhere outside
```php
// There is no "static" keyword, so the function stores a reference to the PendingRequest object as $this
$this->beforeSendingCallbacks = new Collection([static function (Request $request, array $options, PendingRequest $pendingRequest) {
``` 

## Reproduction
A test like this proves that PendingRequest leaks on 13.x and does not on this PR's branch
Was tested on PHP 8.5.10
```php
<?php

namespace Illuminate\Tests\Http;

use Illuminate\Http\Client\Factory;
use Illuminate\Http\Client\PendingRequest;
use PHPUnit\Framework\TestCase;
use WeakReference;

class HttpClientMemoryLeakTest extends TestCase
{
    public function testPendingRequestsAreFreedOnceUnset(): void
    {
        $references = [];
        $iterations = 0;

        while ($iterations++ < 100) {
            $references[] = $this->sendRequest();
        }

        $held = array_filter($references, static fn (WeakReference $reference) => $reference->get() !== null);

        $errMsg = sprintf(
            '%d of %d PendingRequest instances were still held in memory after being unset.',
            count($held),
            count($references)
        );

        $this->assertSame(0, count($held), $errMsg);
    }

    protected function sendRequest(): WeakReference
    {
        $request = (new PendingRequest)->stub([static fn () => Factory::response('ok')]);

        $reference = WeakReference::create($request);

        $response = $request->post('http://localhost/leak');

        unset($request, $response);

        return $reference;
    }
}
```
## Notes
Personally I would love it to be included in Laravel 12 too if possible