### PR TITLE
[13.x] Resolve the `UsePolicy` attribute from parent classes

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -681,25 +681,38 @@ class Gate implements GateContract
                 return $this->resolvePolicy($policy);
             }
         }
+
+        $policy = $this->getPolicyFromAttribute($class, includeParents: true);
+
+        if (! is_null($policy)) {
+            return $this->resolvePolicy($policy);
+        }
     }
 
     /**
      * Get the policy class from the class attribute.
      *
      * @param  class-string<*>  $class
+     * @param  bool  $includeParents
      * @return class-string<*>|null
      */
-    protected function getPolicyFromAttribute(string $class): ?string
+    protected function getPolicyFromAttribute(string $class, bool $includeParents = false): ?string
     {
         if (! class_exists($class)) {
             return null;
         }
 
-        $attributes = (new ReflectionClass($class))->getAttributes(UsePolicy::class);
+        $reflection = new ReflectionClass($class);
 
-        return $attributes !== []
-            ? $attributes[0]->newInstance()->class
-            : null;
+        do {
+            $attributes = $reflection->getAttributes(UsePolicy::class);
+
+            if ($attributes !== []) {
+                return $attributes[0]->newInstance()->class;
+            }
+        } while ($includeParents && $reflection = $reflection->getParentClass());
+
+        return null;
     }
 
     /**

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -87,6 +87,31 @@ class GatePolicyResolutionTest extends TestCase
 
         $this->assertInstanceOf(PostPolicy::class, Gate::getPolicyFor(Post::class));
     }
+
+    public function testPolicyGivenByAttributeIsInheritedByChildClasses(): void
+    {
+        $this->assertInstanceOf(PostPolicy::class, Gate::getPolicyFor(ChildPost::class));
+        $this->assertInstanceOf(PostPolicy::class, Gate::getPolicyFor(GrandchildPost::class));
+    }
+
+    public function testPolicyGivenByAttributeOnChildClassOverridesParentAttribute(): void
+    {
+        $this->assertInstanceOf(AudioPostPolicy::class, Gate::getPolicyFor(AudioPost::class));
+    }
+
+    public function testRegisteredPolicyTakesPrecedenceOverInheritedAttribute(): void
+    {
+        Gate::policy(ChildPost::class, AudioPostPolicy::class);
+
+        $this->assertInstanceOf(AudioPostPolicy::class, Gate::getPolicyFor(ChildPost::class));
+    }
+
+    public function testGuessedPolicyTakesPrecedenceOverInheritedAttribute(): void
+    {
+        Gate::guessPolicyNamesUsing(fn () => [AuthenticationTestUserPolicy::class]);
+
+        $this->assertInstanceOf(AuthenticationTestUserPolicy::class, Gate::getPolicyFor(ChildPost::class));
+    }
 }
 
 #[UsePolicy(PostPolicy::class)]
@@ -94,6 +119,23 @@ class Post extends Model
 {
 }
 
+class ChildPost extends Post
+{
+}
+
+class GrandchildPost extends ChildPost
+{
+}
+
+#[UsePolicy(AudioPostPolicy::class)]
+class AudioPost extends Post
+{
+}
+
 class PostPolicy
+{
+}
+
+class AudioPostPolicy
 {
 }


### PR DESCRIPTION
`#[UsePolicy]` is only read from the class it's declared on, so a model that extends a base class carrying the attribute resolves no policy at all:

```php
#[UsePolicy(DocumentPolicy::class)]
abstract class Document extends Model
{
}

class Invoice extends Document
{
}

Gate::getPolicyFor(Document::class);   // DocumentPolicy
Gate::getPolicyFor(Invoice::class);   // null
Gate::allows('view', $invoice);       // false — even for an admin