### PR TITLE
[13.x] Resolve the `UseEloquentBuilder` attribute from parent classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1946,12 +1946,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function resolveCustomBuilderClass()
     {
-        $attributes = (new ReflectionClass($this))
-            ->getAttributes(UseEloquentBuilder::class);
-
-        return ! empty($attributes)
-            ? $attributes[0]->newInstance()->builderClass
-            : false;
+        return static::resolveClassAttribute(UseEloquentBuilder::class, 'builderClass') ?? false;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -4021,6 +4021,24 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomBuilder::class, $eloquentBuilder);
     }
 
+    public function testUseEloquentBuilderAttributeIsInherited()
+    {
+        $model = new EloquentModelInheritingBuilderStub();
+
+        $query = $this->createStub(\Illuminate\Database\Query\Builder::class);
+
+        $this->assertInstanceOf(CustomBuilder::class, $model->newEloquentBuilder($query));
+    }
+
+    public function testUseEloquentBuilderAttributeOnChildClassOverridesParentAttribute()
+    {
+        $model = new EloquentModelOverridingBuilderStub();
+
+        $query = $this->createStub(\Illuminate\Database\Query\Builder::class);
+
+        $this->assertInstanceOf(ChildCustomBuilder::class, $model->newEloquentBuilder($query));
+    }
+
     public function testDefaultBuilderIsUsedWhenUseEloquentBuilderAttributeIsNotPresent()
     {
         $model = new EloquentModelWithoutUseEloquentBuilderAttributeStub();
@@ -4050,8 +4068,21 @@ class CustomBuilder extends Builder
 {
 }
 
+class ChildCustomBuilder extends Builder
+{
+}
+
 #[\Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder(CustomBuilder::class)]
 class EloquentModelWithUseEloquentBuilderAttributeStub extends Model
+{
+}
+
+class EloquentModelInheritingBuilderStub extends EloquentModelWithUseEloquentBuilderAttributeStub
+{
+}
+
+#[\Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder(ChildCustomBuilder::class)]
+class EloquentModelOverridingBuilderStub extends EloquentModelWithUseEloquentBuilderAttributeStub
 {
 }
 


### PR DESCRIPTION
Follow-up to #61439

  `#[UseEloquentBuilder]` is only read from the class it's declared on, and PHP doesn't inherit attributes, so putting it on a shared base model does nothing for the models that actually extend it:                      
                                                                                                                                                                                                                           
  ```php                                                                                                                                                                                                                   
  class AppBuilder extends Builder                                                                                                                                                                                         
  {                                                                                                                                                                                                                        
      public function recent(int $days = 30): static                                                                                                                                                                       
      {                                                                                                                                                                                                                    
          return $this->where('created_at', '>=', now()->subDays($days));                                                                                                                                                  
      }                                                                                                                                                                                                                    
  }                                                                                                                                                                                                                        
                                                                                                                                                                                                                           
  #[UseEloquentBuilder(AppBuilder::class)]                                                                                                                                                                                 
  abstract class BaseModel extends Model                                                                                                                                                                                   
  {                                                                                                                                                                                                                        
  }                                                                                                                                                                                                                        
                                                                                                                                                                                                                           
  class Order extends BaseModel                                                                                                                                                                                            
  {                                                                                                                                                                                                                        
  }                                                                                                                                                                                                                        
                                                                                                                                                                                                                           
  Order::query()->recent(); // BadMethodCallException