### PR TITLE
[13.x] Fix `assertJsonMissingPath()` ignoring wildcards

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -223,7 +223,22 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertMissingPath($path)
     {
-        PHPUnit::assertFalse(Arr::has($this->json(), $path));
+        if (! str_contains($path, '*')) {
+            PHPUnit::assertFalse(Arr::has($this->json(), $path));
+
+            return $this;
+        }
+
+        $pattern = '#^'.(new Collection(explode('.', $path)))
+            ->map(fn ($segment) => $segment === '*' ? '[^.]+' : preg_quote($segment, '#'))
+            ->implode('\.').'(\.|$)#';
+
+        PHPUnit::assertFalse(
+            (new Collection(Arr::dot((array) $this->json())))
+                ->keys()
+                ->contains(fn ($key) => preg_match($pattern, $key) === 1),
+            "Found unexpected path [{$path}] within the response JSON."
+        );
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1862,6 +1862,44 @@ EOT
         $response->assertJsonMissingPath('numeric_keys.3');
     }
 
+    public function testAssertJsonMissingPathWithWildcard(): void
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('bars.*.missing');
+        $response->assertJsonMissingPath('missing.*.bar');
+
+        // A wildcard matches a single segment, so this must not match "barfoo.*.bar.foo"...
+        $response->assertJsonMissingPath('barfoo.*.foo');
+    }
+
+    public function testAssertJsonMissingPathWithTrailingWildcardCanFail(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('bars.*');
+    }
+
+    public function testAssertJsonMissingPathWithWildcardCanFail(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('bars.*.bar');
+    }
+
+    public function testAssertJsonMissingPathWithWildcardCanFailWhenPresentOnSomeItems(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('barfoo.*.bar.foo');
+    }
+
     public function testAssertJsonMissingPaths(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
`assertJsonPath()` supports wildcards, since it resolves the path with `data_get()`. `assertJsonMissingPath()` uses `Arr::has()`, which doesn't, so it treats the `*` as a literal key name, the lookup fails at that segment, and the assertion passes no matter what the response holds:

```php
// {"data": [{"id": 1, "token": "..."}, {"id": 2, "token": "..."}]}

$response->assertJsonPath('data.*.id', [1, 2]);   // passes, wildcard resolved
$response->assertJsonMissingPath('data.*.token'); // also passes, token is right there
```