### PR TITLE
[13.x] Add `Runnable` trait

### DIFF
--- a/src/Illuminate/Foundation/Concerns/Runnable.php
+++ b/src/Illuminate/Foundation/Concerns/Runnable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Foundation\Concerns;
+
+use Closure;
+use Illuminate\Container\Container;
+use Mockery;
+use Mockery\MockInterface;
+
+trait Runnable
+{
+    /**
+     * Resolve the runnable from the container.
+     */
+    public static function make(array $parameters = []): static
+    {
+        return Container::getInstance()->make(static::class, $parameters);
+    }
+
+    /**
+     * Resolve and run the runnable.
+     */
+    public static function run(mixed ...$arguments): mixed
+    {
+        return static::make()->handle(...$arguments);
+    }
+
+    /**
+     * Replace the runnable with a fake.
+     *
+     * @return \Mockery\MockInterface&static
+     */
+    public static function fake(mixed $result = null): MockInterface
+    {
+        $fake = Mockery::mock(static::class);
+
+        $expectation = $fake->shouldReceive('handle');
+
+        if ($result instanceof Closure) {
+            $expectation->andReturnUsing($result);
+        } elseif (func_num_args() > 0) {
+            $expectation->andReturn($result);
+        }
+
+        Container::getInstance()->instance(static::class, $fake);
+
+        return $fake;
+    }
+}

--- a/src/Illuminate/Foundation/Concerns/Runnable.php
+++ b/src/Illuminate/Foundation/Concerns/Runnable.php
@@ -10,19 +10,11 @@ use Mockery\MockInterface;
 trait Runnable
 {
     /**
-     * Resolve the runnable from the container.
-     */
-    public static function make(array $parameters = []): static
-    {
-        return Container::getInstance()->make(static::class, $parameters);
-    }
-
-    /**
      * Resolve and run the runnable.
      */
     public static function run(mixed ...$arguments): mixed
     {
-        return static::make()->handle(...$arguments);
+        return Container::getInstance()->make(static::class)->handle(...$arguments);
     }
 
     /**

--- a/tests/Foundation/Concerns/RunnableTest.php
+++ b/tests/Foundation/Concerns/RunnableTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Concerns;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Concerns\Runnable;
+use PHPUnit\Framework\TestCase;
+
+class RunnableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::setInstance(new Container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testItCanBeMadeThroughTheContainer()
+    {
+        Container::getInstance()->instance(RunnableDependency::class, $dependency = new RunnableDependency('resolved'));
+
+        $runnable = RunnableStub::make();
+
+        $this->assertSame($dependency, $runnable->dependency);
+    }
+
+    public function testItCanBeMadeWithParameters()
+    {
+        $runnable = ParameterizedRunnableStub::make(['value' => 'Taylor']);
+
+        $this->assertSame('Taylor', $runnable->value);
+    }
+
+    public function testItCanBeRunThroughTheContainer()
+    {
+        Container::getInstance()->instance(RunnableDependency::class, new RunnableDependency('Hello'));
+
+        $this->assertSame('Hello Taylor', RunnableStub::run('Taylor'));
+    }
+
+    public function testItCanBeFakedWithAResult()
+    {
+        $fake = RunnableStub::fake('Hello Taylor');
+
+        $this->assertSame('Hello Taylor', RunnableStub::run('Taylor'));
+        $this->assertSame($fake, Container::getInstance()->make(RunnableStub::class));
+
+        $fake->shouldHaveReceived('handle')->once()->with('Taylor');
+    }
+
+    public function testItCanBeFakedWithAClosure()
+    {
+        $fake = RunnableStub::fake(fn (string $name) => "Hello {$name}");
+
+        $this->assertSame('Hello Taylor', RunnableStub::run('Taylor'));
+
+        $fake->shouldHaveReceived('handle')->once()->with('Taylor');
+    }
+
+    public function testItCanBeFakedWithoutAResult()
+    {
+        BooleanRunnableStub::fake();
+
+        $this->assertFalse(BooleanRunnableStub::run());
+    }
+}
+
+class RunnableStub
+{
+    use Runnable;
+
+    public function __construct(public RunnableDependency $dependency)
+    {
+    }
+
+    public function handle(string $name): string
+    {
+        return "{$this->dependency->value} {$name}";
+    }
+}
+
+class ParameterizedRunnableStub
+{
+    use Runnable;
+
+    public function __construct(public string $value)
+    {
+    }
+
+    public function handle(): string
+    {
+        return $this->value;
+    }
+}
+
+class RunnableDependency
+{
+    public function __construct(public string $value)
+    {
+    }
+}
+
+class BooleanRunnableStub
+{
+    use Runnable;
+
+    public function handle(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Foundation/Concerns/RunnableTest.php
+++ b/tests/Foundation/Concerns/RunnableTest.php
@@ -22,22 +22,6 @@ class RunnableTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItCanBeMadeThroughTheContainer()
-    {
-        Container::getInstance()->instance(RunnableDependency::class, $dependency = new RunnableDependency('resolved'));
-
-        $runnable = RunnableStub::make();
-
-        $this->assertSame($dependency, $runnable->dependency);
-    }
-
-    public function testItCanBeMadeWithParameters()
-    {
-        $runnable = ParameterizedRunnableStub::make(['value' => 'Taylor']);
-
-        $this->assertSame('Taylor', $runnable->value);
-    }
-
     public function testItCanBeRunThroughTheContainer()
     {
         Container::getInstance()->instance(RunnableDependency::class, new RunnableDependency('Hello'));
@@ -83,20 +67,6 @@ class RunnableStub
     public function handle(string $name): string
     {
         return "{$this->dependency->value} {$name}";
-    }
-}
-
-class ParameterizedRunnableStub
-{
-    use Runnable;
-
-    public function __construct(public string $value)
-    {
-    }
-
-    public function handle(): string
-    {
-        return $this->value;
     }
 }
 


### PR DESCRIPTION
This PR introduces a `Runnable` trait. I think this is the last piece of "architecture assistance" that the framework is missing which developers often have to invent themselves per project.

Applications often organize business logic into focused classes such as Actions and Queries (like [Laravel Fortify](https://github.com/laravel/fortify/tree/1.x/src/Actions)). These classes may contain constructor-injected dependencies while accepting invocation-specific arguments. Invoking them currently requires resolving the class manually:

```php
app(ProcessPayment::class)->handle($order);
```

Or using the `__invoke()` pattern:

```php
app(ProcessPayment::class)($order);
```

This is fine, but it leaves developers having to define this pattern themselves -- which has never really felt good. The above approaches make me feel like I'm inventing my own custom pattern, when I feel that the framework could provide assistance to guide me in a direction that offers me a defined structure and first-class testing capabilities.
 
Using the `Runnable` trait provides a concise equivalent that Laravel developers will feel right at home with, as it adopts the same conventions they're used to:

```php
use Illuminate\Foundation\Concerns\Runnable;

class ProcessPayment
{
    use Runnable;

    public function __construct(
        protected PaymentGateway $gateway
    ) {}

    public function handle(Order $order): PaymentResponse
    {
        return $this->gateway->process($order);
    }
}
```

```php
$response = ProcessPayment::run($order);
```

Like the `Dispatchable` trait, it gives an ordinary application class an opt-in static entry point backed by framework services. Its `fake` method uses the same container replacement and Mockery integration available through Laravel’s testing traits and facades.

The trait provides two methods:

- `run()` resolves the class through Laravel’s service container and forwards its arguments to `handle`.
- `fake()` replaces the class in the container with a Mockery fake.

A runnable response may be easily faked with a fixed result within application tests with an API we're all used to:

```php
$fake = ProcessPayment::fake($response);
```

Or with a callback when the result depends on the arguments:

```php
$fake = ProcessPayment::fake(
    fn (Order $order) => PaymentResponse::successful($order)
);
```

Because the fake is registered in the container and returned to the caller, higher-level tests can also exercise the surrounding application flow and verify how the operation was invoked:

```php
$fake->shouldHaveReceived('handle')
    ->once()
    ->with($order);
```

Runnable classes can also be used in dependency injection and still be faked in application tests as you'd expect:

```php
class OrderPaymentController extends Controller
{
    public function __invoke(Order $order, ProcessPayment $action): Response
    {
        $action->handle($order);

        // ...
    }
}
```

This trait based approach allows us not to enforce applications to adopt any specific "Actions" or "Queries" architecture -- but instead just provides an opt-in synchronous counterpart to Laravel’s existing `Dispatchable` trait.

Let me know your thoughts! ❤️ 