### PR TITLE
Wrap the closure return type in `withFreshQueryLog()`

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -716,7 +716,7 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback in "dry run" mode.
      *
-     * @param  (\Closure(): array{query: string, bindings: array, time: float|null}[])  $callback
+     * @param  (\Closure(): (array{query: string, bindings: array, time: float|null}[]))  $callback
      * @return array{query: string, bindings: array, time: float|null}[]
      */
     protected function withFreshQueryLog($callback)


### PR DESCRIPTION
`withFreshQueryLog()` is annotated:

```
@param  (\Closure(): array{query: string, bindings: array, time: float|null}[])  $callback
```

No phpdoc standard settles whether that trailing `[]` belongs to the return type or to the whole closure. PHPStan binds it to the return type, so `$callback` is a closure returning a list of log entries. Mago, another static analyser, binds it to the closure and reads `$callback` as an array of closures. That contradicts the method's own `@return array{...}[]` and the body doing `$result = $callback()`.

Wrapping the return type in parentheses says which one was meant, and both analysers then agree. PHPStan's inference does not change. I ran both forms and each gives:

```
Closure(): array<array{query: string, bindings: array, time: float|null}>
```

Mago's maintainer suggested this form for the same reason, since neither analyser can change its precedence without breaking its own users: https://github.com/carthage-software/mago/issues/2310

This is the only annotation of this shape in the framework.
