### PR TITLE
[13.x] defer all logic to the dedicated rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\AnyOf;

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -135,11 +135,7 @@ class Rule
      */
     public static function in($values)
     {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        return new In(is_array($values) ? $values : func_get_args());
+        return new In(...func_get_args());
     }
 
     /**
@@ -150,11 +146,7 @@ class Rule
      */
     public static function notIn($values)
     {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        return new NotIn(is_array($values) ? $values : func_get_args());
+        return new NotIn(...func_get_args());
     }
 
     /**
@@ -335,11 +327,7 @@ class Rule
      */
     public static function contains($values)
     {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        return new Rules\Contains(is_array($values) ? $values : func_get_args());
+        return new Rules\Contains(...func_get_args());
     }
 
     /**
@@ -350,11 +338,7 @@ class Rule
      */
     public static function doesntContain($values)
     {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        return new Rules\DoesntContain(is_array($values) ? $values : func_get_args());
+        return new Rules\DoesntContain(...func_get_args());
     }
 
     /**


### PR DESCRIPTION
the rules

- `In`
- `NotIn`
- `Contains`
- `DoesntContain`

contain the same logic in the `Rule` static function as they do in the actual constructor of the rule class itself. we can use argument unpacking to defer the logic to the individual constructors with no change in behavior.

this is consistent with other static methods in the `Rule` class like `ArrayKeys`.

as an additional refactor we can use variadic parameters, but I was planning on doing that in a PR to master since it changes the method signature.