### PR TITLE
Fix/file rule types chaining

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -12,9 +12,16 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
+/**
+ * @method static $this types(string|array<int, string> $mimetypes)
+ * @method $this types(string|array<int, string> $mimetypes)
+ */
 class File implements Rule, DataAwareRule, ValidatorAwareRule
 {
-    use Conditionable, Macroable;
+    use Conditionable, Macroable {
+        Macroable::__call as macroCall;
+        Macroable::__callStatic as macroCallStatic;
+    }
 
     /**
      * The MIME types that the given file should match. This array may also contain file extensions.
@@ -137,12 +144,19 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to the given MIME types or file extensions.
      *
+     * Declared protected so that both the static and the instance form route
+     * through __callStatic and __call respectively. Calling it statically
+     * begins a new rule; calling it on an existing rule adds to that rule
+     * rather than silently discarding it.
+     *
      * @param  string|array<int, string>  $mimetypes
-     * @return static
+     * @return $this
      */
-    public static function types($mimetypes)
+    protected function types($mimetypes)
     {
-        return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+        $this->allowedMimetypes = (array) $mimetypes;
+
+        return $this;
     }
 
     /**
@@ -399,5 +413,37 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         $this->data = $data;
 
         return $this;
+    }
+
+    /**
+     * Dynamically handle calls to the rule.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($method === 'types') {
+            return $this->types(...$parameters);
+        }
+
+        return $this->macroCall($method, $parameters);
+    }
+
+    /**
+     * Dynamically handle static calls to the rule.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if ($method === 'types') {
+            return (new static)->types(...$parameters);
+        }
+
+        return static::macroCallStatic($method, $parameters);
     }
 }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -322,6 +322,29 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testTypesPreservesPriorChainConfiguration()
+    {
+        $this->fails(
+            File::default()->max(1024)->types(['txt']),
+            UploadedFile::fake()->create('foo.txt', 1025),
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->max(1024)->types(['txt']),
+            UploadedFile::fake()->create('foo.txt', 1024),
+        );
+    }
+
+    public function testTypesPreservesImageConfiguration()
+    {
+        $this->fails(
+            File::image()->max(1024)->types(['jpg', 'jpeg']),
+            UploadedFile::fake()->image('foo.jpg')->size(1025),
+            ['validation.max.file']
+        );
+    }
+
     public function testMaxWithHumanReadableSize()
     {
         $this->fails(


### PR DESCRIPTION
Fix File rule types() discarding prior chain configuration

File::types() was a static factory returning `new static()`. PHP permits
calling a static method through an instance, so using it mid-chain built a
fresh rule and silently dropped everything configured before it:

    File::image()->max(1)->types(['jpg'])   // no size validation runs at all
    File::image()->types(['jpg'])->max(1)   // works

There was no warning and no error, so any chain in the first form validated
less than it appeared to. The neighbouring extensions() method is a normal
instance method returning $this, so the two behaved oppositely. File::image()
also lost its $allowSvg flag, since `new static()` re-ran the ImageFile
constructor with no arguments.

Make types() a protected instance method that mutates and returns $this, and
route both entry points to it through __call and __callStatic. Protected
visibility is required: PHP raises an Error rather than dispatching to
__callStatic when a public non-static method is called statically, so the
implementation has to be inaccessible for the static factory form to keep
working. Macroable's magic methods are aliased and fall through unchanged.

Static usage keeps its existing behaviour; instance usage now adds to the
rule instead of replacing it.