### PR TITLE
[13.x] Restore the application after config:cache

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
 use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
@@ -96,6 +98,11 @@ class ConfigCacheCommand extends Command
         $app->useStoragePath($this->laravel->storagePath());
 
         $app->make(ConsoleKernelContract::class)->bootstrap();
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication($this->laravel);
+        Container::setInstance($this->laravel);
 
         return $app['config']->all();
     }

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
+use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Tests\Integration\Generators\TestCase;
 use LogicException;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
@@ -121,5 +123,19 @@ class ConfigCacheCommandTest extends TestCase
         }
 
         $this->assertFileDoesNotExist($this->app->getCachedConfigPath());
+    }
+
+    public function testItRestoresTheFacadeApplicationAfterBootingAFreshApplication(): void
+    {
+        $this->artisan('config:cache')->assertSuccessful();
+
+        $this->assertSame($this->app, Facade::getFacadeApplication());
+    }
+
+    public function testItRestoresTheContainerInstanceAfterBootingAFreshApplication(): void
+    {
+        $this->artisan('config:cache')->assertSuccessful();
+
+        $this->assertSame($this->app, Container::getInstance());
     }
 }


### PR DESCRIPTION
I opened #60758. `route:cache` was fixed in #61346 and #61405.

`config:cache` does the same thing. It boots a second application and leaves facades and the container on it.

This puts them back, same as `route:cache`.