### PR TITLE
[13.x] Fix RateLimited job middleware hitting limits that did not block the job

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -99,7 +99,9 @@ class RateLimited
                     ? $job->release($this->releaseAfter ?: $this->getTimeUntilNextRetry($limit->key))
                     : false;
             }
+        }
 
+        foreach ($limits as $limit) {
             $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -55,6 +55,14 @@ class RateLimitedWithRedis extends RateLimited
             }
         }
 
+        foreach ($limits as $limit) {
+            if (! $this->acquire($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
+                return $this->shouldRelease
+                    ? $job->release($this->releaseAfter ?: $this->getTimeUntilNextRetry($limit->key))
+                    : false;
+            }
+        }
+
         return $next($job);
     }
 
@@ -76,7 +84,30 @@ class RateLimitedWithRedis extends RateLimited
             $redis, $key, $maxAttempts, $decaySeconds
         );
 
-        return tap(! $limiter->acquire(), function () use ($key, $limiter) {
+        return tap($limiter->tooManyAttempts(), function () use ($key, $limiter) {
+            $this->decaysAt[$key] = $limiter->decaysAt;
+        });
+    }
+
+    /**
+     * Acquire a slot for the given key.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int  $decaySeconds
+     * @return bool
+     */
+    protected function acquire($key, $maxAttempts, $decaySeconds)
+    {
+        $redis = Container::getInstance()
+            ->make(Redis::class)
+            ->connection($this->connectionName);
+
+        $limiter = new DurationLimiter(
+            $redis, $key, $maxAttempts, $decaySeconds
+        );
+
+        return tap($limiter->acquire(), function () use ($key, $limiter) {
             $this->decaysAt[$key] = $limiter->decaysAt;
         });
     }

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -150,6 +150,44 @@ class RateLimitedTest extends TestCase
         $this->assertJobWasReleasedAfter(RateLimitedReleaseAfterTestJob::class, 60);
     }
 
+    public function testLimitsAreNotHitWhenAnotherLimitIsReached()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function () {
+            return [
+                Limit::perHour(10)->by('global'),
+                Limit::perHour(1)->by('tenant'),
+            ];
+        });
+
+        $this->assertJobRanSuccessfully(RateLimitedTestJob::class);
+        $this->assertJobWasReleased(RateLimitedTestJob::class);
+        $this->assertJobWasReleased(RateLimitedTestJob::class);
+
+        $this->assertSame(1, $rateLimiter->attempts(md5('test'.'global')));
+        $this->assertSame(1, $rateLimiter->attempts(md5('test'.'tenant')));
+    }
+
+    public function testLimitsAreNotHitWhenAnotherLimitIsReachedAndJobIsSkipped()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function () {
+            return [
+                Limit::perHour(10)->by('global'),
+                Limit::perHour(1)->by('tenant'),
+            ];
+        });
+
+        $this->assertJobRanSuccessfully(RateLimitedDontReleaseTestJob::class);
+        $this->assertJobWasSkipped(RateLimitedDontReleaseTestJob::class);
+        $this->assertJobWasSkipped(RateLimitedDontReleaseTestJob::class);
+
+        $this->assertSame(1, $rateLimiter->attempts(md5('test'.'global')));
+        $this->assertSame(1, $rateLimiter->attempts(md5('test'.'tenant')));
+    }
+
     public function testMiddlewareSerialization()
     {
         $rateLimited = new RateLimited('limiterName');

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -111,6 +111,50 @@ class RateLimitedWithRedisTest extends TestCase
         $this->assertJobWasReleased($nonAdminJob);
     }
 
+    public function testLimitsAreNotHitWhenAnotherLimitIsReached()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+        $testJob = new RedisRateLimitedTestJob;
+
+        $rateLimiter->for($testJob->key, function () {
+            return [
+                Limit::perHour(10)->by('global'),
+                Limit::perHour(1)->by('tenant'),
+            ];
+        });
+
+        $this->assertJobRanSuccessfully($testJob);
+        $this->assertJobWasReleased($testJob);
+        $this->assertJobWasReleased($testJob);
+
+        $redis = $this->app->make('redis')->connection();
+
+        $this->assertSame(1, (int) $redis->hget(md5($testJob->key.'global'), 'count'));
+        $this->assertSame(1, (int) $redis->hget(md5($testJob->key.'tenant'), 'count'));
+    }
+
+    public function testLimitsAreNotHitWhenAnotherLimitIsReachedAndJobIsSkipped()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+        $testJob = new RedisRateLimitedDontReleaseTestJob;
+
+        $rateLimiter->for($testJob->key, function () {
+            return [
+                Limit::perHour(10)->by('global'),
+                Limit::perHour(1)->by('tenant'),
+            ];
+        });
+
+        $this->assertJobRanSuccessfully($testJob);
+        $this->assertJobWasSkipped($testJob);
+        $this->assertJobWasSkipped($testJob);
+
+        $redis = $this->app->make('redis')->connection();
+
+        $this->assertSame(1, (int) $redis->hget(md5($testJob->key.'global'), 'count'));
+        $this->assertSame(1, (int) $redis->hget(md5($testJob->key.'tenant'), 'count'));
+    }
+
     public function testMiddlewareSerialization()
     {
         $rateLimited = new RateLimitedWithRedis('limiterName', 'default');


### PR DESCRIPTION
When a job uses `RateLimited` with multiple limits and one of them is exhausted, the job gets released but the limits checked before it are already incremented. So a job that never ran still counts against those limits, and this happens again on every release.

For example, with a global limit and a per-tenant limit, one tenant hitting its own limit eats the global limit for everyone else.

This is the same issue as #54386, fixed in `ThrottleRequests` by #58707. This PR does the same for the queue middleware: check all limits first, then hit them.