### PR TITLE
[13.x] Push batched jobs to their own queue when the batch has no queue

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -185,11 +185,17 @@ class Batch implements Arrayable, JsonSerializable
         $this->repository->transaction(function () use ($jobs, $count) {
             $this->repository->incrementTotalJobs($this->id, $count);
 
-            $this->queue->connection($this->options['connection'] ?? null)->bulk(
-                $jobs->all(),
-                $data = '',
-                $this->options['queue'] ?? null
-            );
+            $connection = $this->queue->connection($this->options['connection'] ?? null);
+
+            if (isset($this->options['queue'])) {
+                $connection->bulk($jobs->all(), $data = '', $this->options['queue']);
+
+                return;
+            }
+
+            foreach ($jobs->groupBy(fn ($job) => $job->queue ?? '') as $group) {
+                $connection->bulk($group->all(), $data = '', $group->first()->queue ?? null);
+            }
         });
 
         return $this->fresh();

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -673,17 +673,71 @@ class BusBatchTest extends TestCase
 
         $connection->expects('bulk')->with(Mockery::on(function ($args) {
             return true;
-        }), '', null);
+        }), '', 'custom-queue');
 
         $batch->add([
             [$firstJob, $secondJob],
         ]);
 
-        // Both jobs had ->onQueue('custom-queue') set before batching.
-        // The second job retains its queue, but the first job's queue
-        // is wiped to null by Batch::add() calling allOnQueue(null).
         $this->assertSame('custom-queue', $secondJob->queue);
         $this->assertSame('custom-queue', $firstJob->queue);
+    }
+
+    public function test_jobs_are_pushed_to_their_own_queue_when_batch_has_no_queue()
+    {
+        $queue = Mockery::mock(Factory::class);
+
+        $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
+
+        $pendingBatch = (new PendingBatch(new Container, collect()))
+            ->onConnection('test-connection');
+
+        $batch = $repository->store($pendingBatch);
+
+        $highJob = (new ChainHeadJob)->onQueue('high');
+        $lowJob = (new SecondTestJob)->onQueue('low');
+        $anotherHighJob = (new ThirdTestJob)->onQueue('high');
+        $defaultJob = new ThirdTestJob;
+
+        $connection = Mockery::mock(QueueContract::class);
+        $queue->expects('connection')
+            ->with('test-connection')
+            ->andReturn($connection);
+
+        $connection->expects('bulk')->with([$highJob, $anotherHighJob], '', 'high');
+        $connection->expects('bulk')->with([$lowJob], '', 'low');
+        $connection->expects('bulk')->with([$defaultJob], '', null);
+
+        $batch = $batch->add([$highJob, $lowJob, $anotherHighJob, $defaultJob]);
+
+        $this->assertEquals(4, $batch->totalJobs);
+    }
+
+    public function test_batch_queue_takes_precedence_over_job_queues()
+    {
+        $queue = Mockery::mock(Factory::class);
+
+        $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
+
+        $pendingBatch = (new PendingBatch(new Container, collect()))
+            ->onConnection('test-connection')
+            ->onQueue('test-queue');
+
+        $batch = $repository->store($pendingBatch);
+
+        $highJob = (new ChainHeadJob)->onQueue('high');
+        $defaultJob = new SecondTestJob;
+
+        $connection = Mockery::mock(QueueContract::class);
+        $queue->expects('connection')
+            ->with('test-connection')
+            ->andReturn($connection);
+
+        $connection->expects('bulk')->with([$highJob, $defaultJob], '', 'test-queue');
+
+        $batch = $batch->add([$highJob, $defaultJob]);
+
+        $this->assertEquals(2, $batch->totalJobs);
     }
 
     public function test_chained_closure_after_multiple_batches_is_properly_dispatched()

--- a/tests/Integration/Database/Queue/BatchQueueTest.php
+++ b/tests/Integration/Database/Queue/BatchQueueTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Queue;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration('laravel', 'queue')]
+#[WithConfig('queue.default', 'database')]
+class BatchQueueTest extends DatabaseTestCase
+{
+    public function testBatchedJobsArePushedToTheirOwnQueue()
+    {
+        Bus::batch([
+            (new BatchQueueTestJob)->onQueue('high'),
+            new BatchQueueTestJob,
+            (new BatchQueueTestJob)->onQueue('low'),
+        ])->dispatch();
+
+        $this->assertSame(
+            ['high', 'default', 'low'],
+            DB::table('jobs')->orderBy('id')->pluck('queue')->all()
+        );
+    }
+
+    public function testBatchQueueTakesPrecedenceOverJobQueues()
+    {
+        Bus::batch([
+            (new BatchQueueTestJob)->onQueue('high'),
+            new BatchQueueTestJob,
+        ])->onQueue('batches')->dispatch();
+
+        $this->assertSame(
+            ['batches', 'batches'],
+            DB::table('jobs')->orderBy('id')->pluck('queue')->all()
+        );
+    }
+}
+
+class BatchQueueTestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+}


### PR DESCRIPTION
When a batch is dispatched without `onQueue()`, every job goes to the default queue even if the job itself set a queue:

```php
Bus::batch([
    (new ResizeImage($photo))->onQueue('images'),
])->dispatch();

// jobs.queue = "default", a worker on --queue=images never picks it up
```

With this change the job goes to `images`. `Bus::batch()->onQueue()` still applies to every job as before, so existing batches are not affected.