### PR TITLE
[13.x] Fix static Eloquent builder macros

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -22,7 +22,9 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
 use ReflectionMethod;
+use RuntimeException;
 use SortDirection;
+use Throwable;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -2290,7 +2292,11 @@ class Builder implements BuilderContract
             $callable = static::$macros[$method];
 
             if ($callable instanceof Closure) {
-                $callable = $callable->bindTo($this, static::class);
+                try {
+                    $callable = $callable->bindTo($this, static::class) ?? throw new RuntimeException;
+                } catch (Throwable) {
+                    $callable = $callable->bindTo(null, static::class);
+                }
             }
 
             return $callable(...$parameters);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -809,6 +809,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
+    public function testStaticGlobalMacrosAreCalledOnBuilder()
+    {
+        Builder::macro('staticMacro', static function () {
+            return 'foo';
+        });
+
+        $this->assertSame('foo', $this->getBuilder()->staticMacro());
+    }
+
     public function testMissingStaticMacrosThrowsProperException()
     {
         $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()'));


### PR DESCRIPTION
#59414 added support for static closures to `Macroable`. This PR adds the same support to `Eloquent\Builder`, which implements its own macro handling without using the `Macroable` trait.

Following #59414, this PR attempts to bind the closure to the builder instance. If binding fails, it retries with the closure bound to `null`. However, using reflection through `RebindsCallbacksToSelf`, as proposed in [#60043](https://github.com/laravel/framework/pull/60043), is recommended for the following reasons:

- The benchmarks below cover static and non-static closures using try-catch and reflection. They show that reflection does not meaningfully impact performance: the non-static try-catch path, which should be the fastest because it avoids reflection and does not require a fallback binding, is marginally faster (~92 nanoseconds faster per call).

  | Approach   | Closure    | One million calls | Benchmark                                                                |
  | ---------- | ---------- | ----------------: | ------------------------------------------------------------------------ |
  | Try-catch  | Static     |            826 ms | [https://3v4l.org/hCN8r/perf](https://3v4l.org/hCN8r/perf) (from #60043) |
  | Reflection | Static     |            209 ms | [https://3v4l.org/hC73H/perf](https://3v4l.org/hC73H/perf) (from #60043) |
  | Try-catch  | Non-static |            116 ms | [https://3v4l.org/ZpCFJ/perf](https://3v4l.org/ZpCFJ/perf)               |
  | Reflection | Non-static |            208 ms | [https://3v4l.org/X0XjJ/perf](https://3v4l.org/X0XjJ/perf)               |

- The fallback treats every binding failure as evidence that the closure is static, potentially obscuring unrelated failures. For example, rebinding a first-class callable created from an instance method to another object can fail. Retrying it with `null` also fails because the method cannot be unbound, replacing the original failure with a second one: [https://3v4l.org/2qXuK](https://3v4l.org/2qXuK).

- [PHP 9 will promote invalid closure bindings from warnings to errors](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_closure_binding_issues). Although `catch (Throwable)` will continue to handle the initial error for static closures, reflection would avoid intentionally triggering an error during otherwise successful execution.

- `RebindsCallbacksToSelf` distinguishes anonymous closures from closures representing first-class callables, preventing unsupported rebindings.

Overall, reflection provides more precise behavior, performs better for static closures, and adds only negligible overhead to non-static closures.