### PR TITLE
[13.x] Add PHPDoc and type declarations in resource JSON:API resource stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/resource-json-api.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-json-api.stub
@@ -8,15 +8,19 @@ class {{ class }} extends JsonApiResource
 {
     /**
      * The resource's attributes.
+     *
+     * @var list<string>
      */
-    public $attributes = [
+    public array $attributes = [
         // ...
     ];
 
     /**
      * The resource's relationships.
+     *
+     * @var list<string>|array<string, \Closure|string|null>
      */
-    public $relationships = [
+    public array $relationships = [
         // ...
     ];
 }


### PR DESCRIPTION
This PR adds native `array` type declarations and more specific PHPDoc types to the JSON resource stub.

The generated resource now provides better type information for the `$attributes` and `$relationships` properties, improving IDE support and static analysis without changing their runtime behavior.

This is backwards compatible as the existing properties already contain arrays.