### PR TITLE
[13.x] Fix SelfBuilding build stack cleanup after exceptions

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1215,9 +1215,11 @@ class Container implements ArrayAccess, ContainerContract
 
         $this->buildStack[] = $concrete;
 
-        $instance = $this->call([$concrete, 'newInstance']);
-
-        array_pop($this->buildStack);
+        try {
+            $instance = $this->call([$concrete, 'newInstance']);
+        } finally {
+            array_pop($this->buildStack);
+        }
 
         $this->fireAfterResolvingAttributeCallbacks(
             $reflector->getAttributes(), $instance

--- a/tests/Integration/Container/BuildableIntegrationTest.php
+++ b/tests/Integration/Container/BuildableIntegrationTest.php
@@ -32,12 +32,28 @@ class BuildableIntegrationTest extends TestCase
 
         config(['aim.away_message.duration' => 5]);
 
-        try {
-            $this->app->make(AolInstantMessengerConfig::class);
-        } catch (ValidationException $exception) {
-            $this->assertArrayHasKey('away_message.duration', $exception->errors());
-            $this->assertStringContainsString('60', $exception->errors()['away_message.duration'][0]);
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            try {
+                $this->app->make(AolInstantMessengerConfig::class);
+
+                $this->fail("Expected a validation exception on attempt {$attempt}.");
+            } catch (ValidationException $exception) {
+                $this->assertArrayHasKey('away_message.duration', $exception->errors());
+                $this->assertStringContainsString('60', $exception->errors()['away_message.duration'][0]);
+            }
         }
+
+        config([
+            'aim.away_message.duration' => 60,
+            'aim.away_message.body' => 'back online',
+        ]);
+
+        $config = $this->app->make(AolInstantMessengerConfig::class);
+
+        $this->assertEquals(60, $config->awayMessageDuration);
+        $this->assertSame('back online', $config->awayMessage);
+        $this->assertSame('api-key', $config->apiKey);
+        $this->assertSame('cosmastech', $config->userName);
     }
 }
 


### PR DESCRIPTION
When a `SelfBuilding::newInstance()` factory throws, its class remains on the container's build stack. Resolving the same class again then skips the factory and goes straight to the constructor, bypassing any validation or initialization in the factory.

This moves the factory's stack cleanup into a `finally` block. Successful resolution and after-resolving callback order stay the same, and a factory can still build its own class through the container.

The existing integration test now checks two consecutive invalid resolutions on the same container, followed by a successful resolution with valid configuration. Before the fix, it fails on the second attempt because the expected `ValidationException` is not thrown. With the fix, both invalid attempts are rejected and the container recovers.

Validation on PHP 8.5.10:

- Container unit and integration tests: 210 tests, 453 assertions passed.
- PHP syntax checks, Pint, and `git diff --check` passed.
- PHPStan `types` passed with `--memory-limit=512M`.
- PHPStan `src` reports four errors in `Connector.php`, `MySqlSchemaState.php`, and `Route.php`. The same errors occur with this fix removed. Both PHPStan commands initially hit the local 128 MB memory limit and were rerun with 512 MB.

The full CI matrix has not been run locally.

Fixes #61453
