### PR TITLE
[13.x] Allow custom columns on database notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -39,7 +39,22 @@ class DatabaseChannel
             'read_at' => method_exists($notification, 'initialDatabaseReadAtValue')
                 ? $notification->initialDatabaseReadAtValue($notifiable)
                 : null,
+            ...$this->getAdditionalAttributes($notifiable, $notification),
         ];
+    }
+
+    /**
+     * Get any additional attributes to persist on the database notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return array
+     */
+    protected function getAdditionalAttributes($notifiable, Notification $notification)
+    {
+        return method_exists($notification, 'databaseAttributes')
+            ? $notification->databaseAttributes($notifiable)
+            : [];
     }
 
     /**

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -63,6 +63,25 @@ class NotificationDatabaseChannelTest extends TestCase
         $channel = new ExtendedDatabaseChannel;
         $channel->send($notifiable, $notification);
     }
+
+    public function testCustomAttributesAreSentToDatabase()
+    {
+        $notification = new NotificationDatabaseChannelCustomAttributesTestNotification;
+        $notification->id = 1;
+        $notifiable = Mockery::mock();
+
+        $notifiable->expects('routeNotificationFor->create')->with([
+            'id' => 1,
+            'type' => get_class($notification),
+            'data' => ['invoice_id' => 1],
+            'read_at' => null,
+            'organization_id' => 2,
+            'message' => 'foo',
+        ]);
+
+        $channel = new DatabaseChannel;
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationDatabaseChannelTestNotification extends Notification
@@ -88,6 +107,22 @@ class NotificationDatabaseChannelCustomizeTypeTestNotification extends Notificat
     public function initialDatabaseReadAtValue()
     {
         return Carbon::now();
+    }
+}
+
+class NotificationDatabaseChannelCustomAttributesTestNotification extends Notification
+{
+    public function toDatabase($notifiable)
+    {
+        return new DatabaseMessage(['invoice_id' => 1]);
+    }
+
+    public function databaseAttributes($notifiable)
+    {
+        return [
+            'organization_id' => 2,
+            'message' => 'foo',
+        ];
     }
 }
 


### PR DESCRIPTION
## Description

`Illuminate\Notifications\Channels\DatabaseChannel` currently persists a fixed
column set on the `notifications` table (`id`, `type`, `notifiable_type`,
`notifiable_id`, `data`, `read_at`, timestamps). Applications that need extra
columns per notification (for example a multi-tenant app storing
`organization_id`) have no supported hook and must subclass the channel and
re-implement `buildPayload()`.

This PR lets a notification declare additional attributes to persist on the
database notification via a new `databaseAttributes($notifiable)` method, which
the channel merges into the payload before inserting. When the method is
absent, behavior is unchanged.

## Current workaround

Until now the only way to add a column was to subclass the channel and
override `buildPayload()`, merging the extra attribute into the parent payload:

```php
namespace App;

use Illuminate\Notifications\Notification;

class DatabaseChannel extends \Illuminate\Notifications\Channels\DatabaseChannel
{
    protected function buildPayload($notifiable, Notification $notification)
    {
        return [
            ...parent::buildPayload($notifiable, $notification),
            'organization_id' => property_exists($notification, 'organization')
                ? $notification->organization->id
                : null,
        ];
    }
}
```

### Tradeoffs of the workaround

- The subclass re-invokes the parent `buildPayload()` and merges attribute by
  attribute; any future change to the parent's shape (or new columns added by
  the framework) has to be re-mirrored here.
- `buildPayload()` is protected and not part of a documented extension point, so
  the override relies on implementation details rather than a stable contract.
- Every project that needs a custom column re-implements the same merge, instead
  of declaring the attributes on the notification itself.

## Proposed API

The channel merges one new opt-in method into the payload before inserting:

```php
use Illuminate\Notifications\Notification;

class Example extends Notification
{
    public function __construct(public Organization $organization) {}

    public function via(object $notifiable): array
    {
        return ['database', 'mail'];
    }

    public function toDatabase(object $notifiable): array
    {
        return ['message' => 'Hello'];
    }

    /**
     * Extra columns to persist on the notifications row.
     *
     * @return array<string, mixed>
     */
    public function databaseAttributes(object $notifiable): array
    {
        return ['organization_id' => $this->organization->id];
    }
}
```

## Why this shape

The channel already uses `method_exists()` checks to opt into optional
notification methods (`databaseType`, `initialDatabaseReadAtValue`), so
`databaseAttributes` follows the same pattern: optional, backward compatible,
and it keeps the `data` payload separate from the extra columns.

## Tests

- `testCustomAttributesAreSentToDatabase` asserts the extra attributes reach
  the `create()` payload next to the standard columns.
- Existing tests cover unchanged behavior when `databaseAttributes` is absent.