### PR TITLE
[13.x] Qualify soft delete column with the query's table alias

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2186,8 +2186,14 @@ class Builder implements BuilderContract
     {
         $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
-        if (! str_contains($column, '.') && ! is_null($alias = $this->getTableAlias())) {
-            return $alias.'.'.$column;
+        if (! is_null($alias = $this->getTableAlias())) {
+            if (! str_contains($column, '.')) {
+                return $alias.'.'.$column;
+            }
+
+            if (str_starts_with($column, $table = $this->model->getTable().'.')) {
+                return $alias.'.'.substr($column, strlen($table));
+            }
         }
 
         return $this->model->qualifyColumn($column);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2186,6 +2186,10 @@ class Builder implements BuilderContract
     {
         $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
+        if (! str_contains($column, '.') && ! is_null($alias = $this->getTableAlias())) {
+            return $alias.'.'.$column;
+        }
+
         return $this->model->qualifyColumn($column);
     }
 
@@ -2197,7 +2201,25 @@ class Builder implements BuilderContract
      */
     public function qualifyColumns($columns)
     {
-        return $this->model->qualifyColumns($columns);
+        return (new BaseCollection($columns))
+            ->map(fn ($column) => $this->qualifyColumn($column))
+            ->all();
+    }
+
+    /**
+     * Get the alias given to the query's table, if any.
+     *
+     * @return string|null
+     */
+    protected function getTableAlias()
+    {
+        if (! is_string($this->query->from)) {
+            return null;
+        }
+
+        $segments = preg_split('/\s+as\s+/i', $this->query->from);
+
+        return count($segments) > 1 ? array_last($segments) : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2207,9 +2207,13 @@ class Builder implements BuilderContract
      */
     public function qualifyColumns($columns)
     {
-        return (new BaseCollection($columns))
-            ->map(fn ($column) => $this->qualifyColumn($column))
-            ->all();
+        $qualified = [];
+
+        foreach ($columns as $key => $column) {
+            $qualified[$key] = $this->qualifyColumn($column);
+        }
+
+        return $qualified;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -25,7 +25,7 @@ class SoftDeletingScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereNull($model->getQualifiedDeletedAtColumn());
+        $builder->whereNull($builder->qualifyColumn($model->getDeletedAtColumn()));
     }
 
     /**
@@ -58,7 +58,7 @@ class SoftDeletingScope implements Scope
     protected function getDeletedAtColumn(Builder $builder)
     {
         if ((array) $builder->getQuery()->joins !== []) {
-            return $builder->getModel()->getQualifiedDeletedAtColumn();
+            return $builder->qualifyColumn($builder->getModel()->getDeletedAtColumn());
         }
 
         return $builder->getModel()->getDeletedAtColumn();
@@ -142,7 +142,7 @@ class SoftDeletingScope implements Scope
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->whereNull(
-                $model->getQualifiedDeletedAtColumn()
+                $builder->qualifyColumn($model->getDeletedAtColumn())
             );
 
             return $builder;
@@ -161,7 +161,7 @@ class SoftDeletingScope implements Scope
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->whereNotNull(
-                $model->getQualifiedDeletedAtColumn()
+                $builder->qualifyColumn($model->getDeletedAtColumn())
             );
 
             return $builder;

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -25,7 +25,7 @@ class SoftDeletingScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereNull($builder->qualifyColumn($model->getDeletedAtColumn()));
+        $builder->whereNull($builder->qualifyColumn($model->getQualifiedDeletedAtColumn()));
     }
 
     /**
@@ -58,7 +58,7 @@ class SoftDeletingScope implements Scope
     protected function getDeletedAtColumn(Builder $builder)
     {
         if ((array) $builder->getQuery()->joins !== []) {
-            return $builder->qualifyColumn($builder->getModel()->getDeletedAtColumn());
+            return $builder->qualifyColumn($builder->getModel()->getQualifiedDeletedAtColumn());
         }
 
         return $builder->getModel()->getDeletedAtColumn();
@@ -142,7 +142,7 @@ class SoftDeletingScope implements Scope
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->whereNull(
-                $builder->qualifyColumn($model->getDeletedAtColumn())
+                $builder->qualifyColumn($model->getQualifiedDeletedAtColumn())
             );
 
             return $builder;
@@ -161,7 +161,7 @@ class SoftDeletingScope implements Scope
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->whereNotNull(
-                $builder->qualifyColumn($model->getDeletedAtColumn())
+                $builder->qualifyColumn($model->getQualifiedDeletedAtColumn())
             );
 
             return $builder;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -324,6 +324,20 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo_table.column', 'foo_table.name'], $builder->qualifyColumns(['column', 'name']));
     }
 
+    public function testQualifyColumnWithTableAlias()
+    {
+        $query = Mockery::mock(BaseBuilder::class);
+        $query->expects('from')->with('foo_table');
+        $query->from = 'foo_table as alias';
+
+        $builder = new Builder($query);
+        $builder->setModel(new EloquentBuilderTestStubStringPrimaryKey);
+
+        $this->assertSame('alias.column', $builder->qualifyColumn('column'));
+        $this->assertSame('other_table.column', $builder->qualifyColumn('other_table.column'));
+        $this->assertEquals(['alias.column', 'alias.name'], $builder->qualifyColumns(['column', 'name']));
+    }
+
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
     {
         $builder = Mockery::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -334,6 +334,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel(new EloquentBuilderTestStubStringPrimaryKey);
 
         $this->assertSame('alias.column', $builder->qualifyColumn('column'));
+        $this->assertSame('alias.column', $builder->qualifyColumn('foo_table.column'));
         $this->assertSame('other_table.column', $builder->qualifyColumn('other_table.column'));
         $this->assertEquals(['alias.column', 'alias.name'], $builder->qualifyColumns(['column', 'name']));
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -111,6 +111,19 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull(SoftDeletesTestUser::find(1));
     }
 
+    public function testSoftDeletesAreNotRetrievedWhenTableIsAliased()
+    {
+        $this->createUsers();
+
+        $users = SoftDeletesTestUser::from('users as u')->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(2, $users->first()->id);
+        $this->assertCount(2, SoftDeletesTestUser::from('users as u')->withTrashed()->get());
+        $this->assertCount(1, SoftDeletesTestUser::from('users as u')->withTrashed()->withoutTrashed()->get());
+        $this->assertEquals(1, SoftDeletesTestUser::from('users as u')->onlyTrashed()->first()->id);
+    }
+
     public function testSoftDeletesAreNotRetrievedFromBaseQuery()
     {
         $this->createUsers();

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -19,7 +19,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope = Mockery::mock(SoftDeletingScope::class.'[extend]');
         $builder = Mockery::mock(EloquentBuilder::class);
         $model = Mockery::mock(Model::class);
-        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
+        $builder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
         $builder->expects('whereNull')->with('table.deleted_at');
 
         $scope->apply($builder, $model);
@@ -123,7 +124,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder = Mockery::mock(EloquentBuilder::class);
         $givenBuilder->expects('getModel')->andReturn($model);
         $givenBuilder->expects('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
-        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
+        $givenBuilder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
         $givenBuilder->expects('whereNotNull')->with('table.deleted_at');
         $result = $callback($givenBuilder);
 
@@ -144,7 +146,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder = Mockery::mock(EloquentBuilder::class);
         $givenBuilder->expects('getModel')->andReturn($model);
         $givenBuilder->expects('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
-        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
+        $givenBuilder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
         $givenBuilder->expects('whereNull')->with('table.deleted_at');
         $result = $callback($givenBuilder);
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -19,8 +19,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope = Mockery::mock(SoftDeletingScope::class.'[extend]');
         $builder = Mockery::mock(EloquentBuilder::class);
         $model = Mockery::mock(Model::class);
-        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
-        $builder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
+        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $builder->expects('qualifyColumn')->with('table.deleted_at')->andReturn('table.deleted_at');
         $builder->expects('whereNull')->with('table.deleted_at');
 
         $scope->apply($builder, $model);
@@ -124,8 +124,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder = Mockery::mock(EloquentBuilder::class);
         $givenBuilder->expects('getModel')->andReturn($model);
         $givenBuilder->expects('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
-        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
-        $givenBuilder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
+        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $givenBuilder->expects('qualifyColumn')->with('table.deleted_at')->andReturn('table.deleted_at');
         $givenBuilder->expects('whereNotNull')->with('table.deleted_at');
         $result = $callback($givenBuilder);
 
@@ -146,8 +146,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder = Mockery::mock(EloquentBuilder::class);
         $givenBuilder->expects('getModel')->andReturn($model);
         $givenBuilder->expects('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
-        $model->expects('getDeletedAtColumn')->andReturn('deleted_at');
-        $givenBuilder->expects('qualifyColumn')->with('deleted_at')->andReturn('table.deleted_at');
+        $model->expects('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $givenBuilder->expects('qualifyColumn')->with('table.deleted_at')->andReturn('table.deleted_at');
         $givenBuilder->expects('whereNull')->with('table.deleted_at');
         $result = $callback($givenBuilder);
 


### PR DESCRIPTION
When a query uses a table alias, the soft delete scope still uses the model's table name:

```php
User::from('users as u')->toSql();
// select * from "users" as "u" where "users"."deleted_at" is null
```

This fails because the table is only known as `u`. In a correlated subquery it is worse, because `users.deleted_at` then points to the outer query's table and returns wrong results without any error. We have hit this in a few of our projects and had to add `withTrashed()` to aliased subqueries by hand each time. A typical case is a count subquery like:

```php
User::query()->withTrashed()->addSelect([
    'active_count' => User::query()
        ->from('users as u')
        ->selectRaw('count(*)')
        ->whereColumn('u.parent_id', 'users.id'),
]);
```

`addUpdatedAtColumn()` already handles the alias for updates, so this does the same for the soft delete scope.

Changes:

- `Builder::qualifyColumn()` uses the alias from the `from` clause if there is one, otherwise the model table as before.
- `SoftDeletingScope` qualifies the column through the builder in `apply()`, `withoutTrashed()`, `onlyTrashed()` and the join case on delete.

Result:

```php
User::from('users as u')->toSql();
// select * from "users" as "u" where "u"."deleted_at" is null
```

Queries without an alias are not affected. Subquery and raw `from` clauses are expressions and are skipped.

Tests added for the builder and for the scope with an aliased table. The integration test fails on `13.x` with `no such column: users.deleted_at`.
