### PR TITLE
[13.x] Fix parameter docblocks that contradict the native signature

### DIFF
--- a/src/Illuminate/Container/Attributes/Give.php
+++ b/src/Illuminate/Container/Attributes/Give.php
@@ -13,7 +13,7 @@ class Give implements ContextualAttribute
      * Provide a concrete class implementation for dependency injection.
      *
      * @param  string  $class
-     * @param  array|null  $params
+     * @param  array  $params
      */
     public function __construct(
         public string $class,

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -71,7 +71,7 @@ class ModelIdentifier
     /**
      * Specify the collection class that should be used when serializing / restoring collections.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Collection>  $collectionClass
+     * @param  class-string<\Illuminate\Database\Eloquent\Collection>|null  $collectionClass
      * @return $this
      */
     public function useCollectionClass(?string $collectionClass)

--- a/src/Illuminate/Image/Transformations/Resize.php
+++ b/src/Illuminate/Image/Transformations/Resize.php
@@ -7,8 +7,8 @@ use Illuminate\Contracts\Image\Transformation;
 class Resize implements Transformation
 {
     /**
-     * @param  positive-int  $width
-     * @param  positive-int  $height
+     * @param  positive-int|null  $width
+     * @param  positive-int|null  $height
      */
     public function __construct(
         public readonly ?int $width,

--- a/src/Illuminate/Image/Transformations/Scale.php
+++ b/src/Illuminate/Image/Transformations/Scale.php
@@ -7,8 +7,8 @@ use Illuminate\Contracts\Image\Transformation;
 class Scale implements Transformation
 {
     /**
-     * @param  positive-int  $width
-     * @param  positive-int  $height
+     * @param  positive-int|null  $width
+     * @param  positive-int|null  $height
      */
     public function __construct(
         public readonly ?int $width,

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -504,7 +504,7 @@ abstract class ServiceProvider
     /**
      * Register commands that should run on "reload".
      *
-     * @param  string|null  $reload
+     * @param  string  $reload
      * @param  string|null  $key
      * @return void
      */


### PR DESCRIPTION
Four `@param` annotations in `src/Illuminate` describe a type the method's own signature does not accept — or accept a type the signature rejects. Each one is verifiable from the declaration sitting next to it.

**`Container\Attributes\Give::__construct()`** documents `@param array|null $params`, but the promoted parameter is `public array $params = []`. Passing `null` is a `TypeError`, and PHPStan reports the annotation twice:

```
src/Illuminate/Container/Attributes/Give.php:18: PHPDoc tag @param for parameter $params with type array|null is not subtype of native type array.
src/Illuminate/Container/Attributes/Give.php:20: PHPDoc type for property Illuminate\Container\Attributes\Give::$params with type array|null is not subtype of native type array.
```

**`Support\ServiceProvider::reloads()`** documents `@param string|null $reload` while the signature is `protected function reloads(string $reload, ?string $key = null)` — the first argument is required and non-nullable. The sibling directly above it, `optimizes(?string $optimize = null, ?string $clear = null, ?string $key = null)`, is genuinely nullable, which is where the annotation appears to have come from:

```
src/Illuminate/Support/ServiceProvider.php:511: PHPDoc tag @param for parameter $reload with type string|null is not subtype of native type string.
```

**`Image\Transformations\Resize` and `Scale`** document `@param positive-int $width` / `$height`, but both constructors take `?int`, and `null` is the supported way to constrain only one dimension. The only callers say so themselves:

```php
/**
 * @param  int<1, max>|null  $width
 * @param  int<1, max>|null  $height
 */
public function scale(?int $width = null, ?int $height = null): static
{
    if ($width === null && $height === null) {
        throw new ImageException('At least one scale dimension must be specified.');
    }

    return $this->transform(new Scale(
        $width === null ? null : max(1, $width),
        $height === null ? null : max(1, $height),
    ));
}
```

The framework's own tests exercise that path — `new Scale(200, null)` and `new Scale(null, 100)` in the GD and Imagick driver tests. `Resize` and `Scale` are also the only two transformations with nullable dimensions: `Crop`, `Cover` and `Contain` all declare `int`, so their `positive-int` annotations are correct as they stand.

**`Contracts\Database\ModelIdentifier::useCollectionClass()`** documents `@param class-string<\Illuminate\Database\Eloquent\Collection> $collectionClass` while the signature is `?string` and the property it assigns is already `@var class-string<\Illuminate\Database\Eloquent\Collection>|null`. The framework passes `null` itself whenever the queued collection is a plain Eloquent collection:

```php
))->useCollectionClass(
    ($collectionClass = get_class($value)) !== EloquentCollection::class
        ? $collectionClass
        : null
);
```

Docblocks only, no behavior change. Pint passes on the touched files and the two PHPStan errors quoted above are gone.
