### PR TITLE
[13.x] Propagate command_retries to phpredis cluster connections

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -55,7 +55,9 @@ class PhpRedisConnector implements Connector
             array_map($this->buildClusterConnectionString(...), $config), $options
         );
 
-        return new PhpRedisClusterConnection($connector(), $connector, $config);
+        return new PhpRedisClusterConnection($connector(), $connector, array_merge($config, [
+            'command_retries' => (int) Arr::get($options, 'command_retries', 0),
+        ]));
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -304,6 +304,32 @@ class PhpRedisConnectorTest extends TestCase
         $this->assertIsCallable($property->getValue($connection));
     }
 
+    public function testConnectToClusterPropagatesCommandRetriesFromOptionsToTheConnection()
+    {
+        $connector = new ClusterStubPhpRedisConnector;
+
+        $connection = $connector->connectToCluster(
+            [['host' => '127.0.0.1', 'port' => 6379]], [], ['command_retries' => 3]
+        );
+
+        $property = new ReflectionProperty(PhpRedisConnection::class, 'config');
+
+        $this->assertSame(3, $property->getValue($connection)['command_retries']);
+    }
+
+    public function testConnectToClusterPropagatesCommandRetriesFromClusterOptionsToTheConnection()
+    {
+        $connector = new ClusterStubPhpRedisConnector;
+
+        $connection = $connector->connectToCluster(
+            [['host' => '127.0.0.1', 'port' => 6379]], ['command_retries' => 5], []
+        );
+
+        $property = new ReflectionProperty(PhpRedisConnection::class, 'config');
+
+        $this->assertSame(5, $property->getValue($connection)['command_retries']);
+    }
+
     #[RequiresPhpExtension('redis')]
     public function testConnectToClusterAllowsTheConnectionToRebuildItsClient()
     {


### PR DESCRIPTION
`PhpRedisConnection::command()` reads its retry budget from the connection config:

```php
$retries = max(
    $this->isRetryable($method, $parameters) ? 1 : 0,
    (int) ($this->config['command_retries'] ?? 0),
);
```

For a flat connection this works, because the connector passes the connection's own config straight through to `PhpRedisConnection`.

For a **cluster** connection it can never work. `PhpRedisConnector::connectToCluster()` builds the connection from the parsed seed-node list:

```php
return new PhpRedisClusterConnection($connector(), $connector, $config);
```

where `$config` is the numerically-keyed list of node configs produced by `RedisManager::resolveCluster()`. `$this->config['command_retries']` is therefore always absent and the budget is always `max(isRetryable ? 1 : 0, 0)` — so `command_retries` (added in #61175) silently does nothing on cluster connections, and the count can't be raised the way the config stub advertises. There's also nowhere valid to put the key: any string-keyed member added to a `clusters.<name>` array is fed through `parseConnectionConfiguration()` / `buildClusterConnectionString()` as if it were a node.

The cluster and global options are already merged just above:

```php
$options = array_merge($options, $clusterOptions, Arr::pull($config, 'options', []));
```

This PR propagates the knob from those resolved options into the config the connection receives, so `redis.options.command_retries` (or `clusters.options.command_retries`) reaches cluster connections the same way `redis.<connection>.command_retries` reaches flat ones:

```php
return new PhpRedisClusterConnection($connector(), $connector, array_merge($config, [
    'command_retries' => (int) Arr::get($options, 'command_retries', 0),
]));
```

### Backwards compatibility

- Flat phpredis connections and Predis are untouched.
- The connector closure already captured the original node list, so the merged key only affects `$this->config` on the connection (which is read by key, never iterated as nodes). Existing cluster behaviour is unchanged when `command_retries` is unset (the value resolves to `0`, exactly as today).

### Tests

Added two tests to `PhpRedisConnectorTest` asserting the value is propagated from both the global options and the cluster options into the connection config. Full `PhpRedisConnectorTest` suite passes; Pint clean.

### Follow-ups

Two related resilience gaps around the same retry path (a warning-shaped TLS reset that `HandleExceptions` turns into an `ErrorException` bypassing the retry loop, and connect-time cluster failures that occur before any `command()` exists to retry) will be raised as separate PRs to keep this one focused.
