### PR TITLE
[13.x] Avoid holding the job_batches row lock across round trips on PostgreSQL

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -137,6 +137,14 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function decrementPendingJobs(string $batchId, string $jobId)
     {
+        if ($this->connection instanceof PostgresConnection) {
+            return $this->updateAtomicValuesUsingReturning(
+                $batchId,
+                '"pending_jobs" = "pending_jobs" - 1, "failed_job_ids" = (coalesce("failed_job_ids", \'[]\')::jsonb - ?::text)::text',
+                [$jobId]
+            );
+        }
+
         $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
             return [
                 'pending_jobs' => $batch->pending_jobs - 1,
@@ -160,6 +168,14 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function incrementFailedJobs(string $batchId, string $jobId)
     {
+        if ($this->connection instanceof PostgresConnection) {
+            return $this->updateAtomicValuesUsingReturning(
+                $batchId,
+                '"failed_jobs" = "failed_jobs" + 1, "failed_job_ids" = (case when coalesce("failed_job_ids", \'[]\')::jsonb @> to_jsonb(?::text) then coalesce("failed_job_ids", \'[]\')::jsonb else coalesce("failed_job_ids", \'[]\')::jsonb || to_jsonb(?::text) end)::text',
+                [$jobId, $jobId]
+            );
+        }
+
         $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
             return [
                 'pending_jobs' => $batch->pending_jobs,
@@ -192,6 +208,29 @@ class DatabaseBatchRepository implements PrunableBatchRepository
                 $this->connection->table($this->table)->where('id', $batchId)->update($values);
             });
         });
+    }
+
+    /**
+     * Update the batch's job counts using a single "returning" statement.
+     *
+     * @param  string  $batchId
+     * @param  string  $columns
+     * @param  array  $bindings
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     */
+    protected function updateAtomicValuesUsingReturning(string $batchId, string $columns, array $bindings)
+    {
+        $table = $this->connection->getQueryGrammar()->wrapTable($this->table);
+
+        $batch = $this->connection->selectFromWriteConnection(
+            "update {$table} set {$columns} where \"id\" = ? returning \"pending_jobs\", \"failed_jobs\"",
+            array_merge($bindings, [$batchId])
+        )[0] ?? null;
+
+        return new UpdatedBatchJobCounts(
+            (int) ($batch->pending_jobs ?? 0),
+            (int) ($batch->failed_jobs ?? 0)
+        );
     }
 
     /**

--- a/tests/Integration/Database/Postgres/DatabaseBatchRepositoryTest.php
+++ b/tests/Integration/Database/Postgres/DatabaseBatchRepositoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Bus\BatchFactory;
+use Illuminate\Bus\DatabaseBatchRepository;
+use Illuminate\Contracts\Queue\Factory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Mockery as m;
+
+class DatabaseBatchRepositoryTest extends PostgresTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        if (! Schema::hasTable('job_batches')) {
+            Schema::create('job_batches', function (Blueprint $table) {
+                $table->string('id')->primary();
+                $table->string('name');
+                $table->integer('total_jobs');
+                $table->integer('pending_jobs');
+                $table->integer('failed_jobs');
+                $table->text('failed_job_ids');
+                $table->text('options')->nullable();
+                $table->integer('cancelled_at')->nullable();
+                $table->integer('created_at');
+                $table->integer('finished_at')->nullable();
+            });
+        }
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('job_batches');
+    }
+
+    public function testDecrementPendingJobsReturnsTheDecrementedCount()
+    {
+        $this->insertBatch('batch', pendingJobs: 3);
+
+        $counts = $this->repository()->decrementPendingJobs('batch', 'job-1');
+
+        $this->assertSame(2, $counts->pendingJobs);
+        $this->assertSame(0, $counts->failedJobs);
+        $this->assertSame(2, (int) DB::table('job_batches')->where('id', 'batch')->value('pending_jobs'));
+    }
+
+    public function testConcurrentDecrementsEachObserveADistinctCount()
+    {
+        $this->insertBatch('batch', pendingJobs: 3);
+
+        $repository = $this->repository();
+
+        $this->assertSame(2, $repository->decrementPendingJobs('batch', 'job-1')->pendingJobs);
+        $this->assertSame(1, $repository->decrementPendingJobs('batch', 'job-2')->pendingJobs);
+        $this->assertSame(0, $repository->decrementPendingJobs('batch', 'job-3')->pendingJobs);
+    }
+
+    public function testIncrementFailedJobsAppendsTheJobIdOnce()
+    {
+        $this->insertBatch('batch', pendingJobs: 2);
+
+        $repository = $this->repository();
+
+        $counts = $repository->incrementFailedJobs('batch', 'job-1');
+
+        $this->assertSame(2, $counts->pendingJobs);
+        $this->assertSame(1, $counts->failedJobs);
+
+        $counts = $repository->incrementFailedJobs('batch', 'job-1');
+
+        $this->assertSame(2, $counts->failedJobs);
+        $this->assertSame(['job-1'], json_decode(DB::table('job_batches')->where('id', 'batch')->value('failed_job_ids'), true));
+    }
+
+    public function testDecrementPendingJobsRemovesAPreviouslyFailedJobId()
+    {
+        $this->insertBatch('batch', pendingJobs: 2);
+
+        $repository = $this->repository();
+
+        $repository->incrementFailedJobs('batch', 'job-1');
+
+        $counts = $repository->decrementPendingJobs('batch', 'job-1');
+
+        $this->assertSame(1, $counts->pendingJobs);
+        $this->assertSame(1, $counts->failedJobs);
+        $this->assertSame([], json_decode(DB::table('job_batches')->where('id', 'batch')->value('failed_job_ids'), true));
+    }
+
+    protected function repository()
+    {
+        return new DatabaseBatchRepository(
+            new BatchFactory(m::mock(Factory::class)), DB::connection(), 'job_batches'
+        );
+    }
+
+    protected function insertBatch(string $id, int $pendingJobs)
+    {
+        DB::table('job_batches')->insert([
+            'id' => $id,
+            'name' => $id,
+            'total_jobs' => $pendingJobs,
+            'pending_jobs' => $pendingJobs,
+            'failed_jobs' => 0,
+            'failed_job_ids' => '[]',
+            'options' => null,
+            'created_at' => time(),
+            'cancelled_at' => null,
+            'finished_at' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
`DatabaseBatchRepository::decrementPendingJobs()` and `incrementFailedJobs()` (called on every job completion/failure within a batch) both go through `updateAtomicValues()`:

```php
return $this->connection->transaction(function () use ($batchId, $callback) {
    $batch = $this->connection->table($this->table)->where('id', $batchId)
        ->lockForUpdate()
        ->first();

    return is_null($batch) ? [] : tap($callback($batch), function ($values) use ($batchId) {
        $this->connection->table($this->table)->where('id', $batchId)->update($values);
    });
});
```

The row lock is taken by the `SELECT ... FOR UPDATE`, then **held across a client round trip**, the PHP callback (`json_decode`/`array_diff`/`json_encode` over `failed_job_ids`), a second round trip for the `UPDATE`, and the commit. On a batch processed by many concurrent workers, the batch's single `job_batches` row becomes a serialization point whose lock hold time is coupled to worker latency — any client-side delay (GC pause, network jitter, CPU steal) extends the hold, and every other completion in the batch, plus any concurrent `Batch::add()`, queues behind it. The values callers actually depend on (`pending_jobs` reaching `0` fires the batch's finished callbacks) only need per-statement atomicity, not a client-held lock.

## What this changes

On PostgreSQL, each update becomes a single atomic `UPDATE ... RETURNING` statement whose post-image is returned to the caller:

```sql
update "job_batches" set
    "pending_jobs" = "pending_jobs" - 1,
    "failed_job_ids" = (coalesce("failed_job_ids", '[]')::jsonb - ?::text)::text
where "id" = ?
returning "pending_jobs", "failed_jobs"
```

The lock now exists only while the engine applies the update; concurrent updates serialize inside the database and exactly one caller still observes `pending_jobs = 0`. The `jsonb` expressions reproduce the existing `failed_job_ids` bookkeeping exactly — `- ?::text` removes the id on the retry path, and the `@>` containment check plus `||` appends it uniquely on failure. (The `jsonb` existence operator `?` is intentionally avoided because it collides with PDO placeholders; the containment operator is used instead.)

## Backwards compatibility

This is scoped to PostgreSQL via the existing `instanceof PostgresConnection` seam already used elsewhere in this class (`serialize()`/`unserialize()`). **Every other driver — MySQL, MariaDB, SQLite, SQL Server — keeps the current lock-based path byte-for-byte**, so there is no behavioural change for them. MySQL has no `UPDATE ... RETURNING`, which is exactly why this is not applied universally.

## Tests

`tests/Integration/Database/Postgres/DatabaseBatchRepositoryTest.php` (gated to `pgsql`) covers, against a real PostgreSQL server:

- decrement returns the decremented `pending_jobs` and persists it;
- successive decrements each observe a distinct count, with exactly one reaching `0`;
- failure appends the job id once and still increments `failed_jobs` on a repeat;
- the retry path removes a previously-failed id while leaving `failed_jobs` untouched.

The existing sqlite-based `BusBatchTest` (fallback path) continues to pass unchanged.
