### PR TITLE
[13.x] Retry phpredis commands when a connection reset surfaces as a warning

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Redis\Connections;
 
 use Closure;
+use ErrorException;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -630,8 +631,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         while (true) {
             try {
                 return parent::command($method, $parameters);
-            } catch (RedisClusterException|RedisException $e) {
-                if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost', 'Error processing response from Redis node'])) {
+            } catch (RedisClusterException|RedisException|ErrorException $e) {
+                if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost', 'Error processing response from Redis node', 'Connection reset by peer'])) {
                     throw $e;
                 }
 

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Redis;
 
+use ErrorException;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
 use InvalidArgumentException;
@@ -321,6 +322,37 @@ class PhpRedisConnectorTest extends TestCase
 
         $this->assertSame(3, $connector->created);
         $this->assertNotSame($original, $connection->client());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionAutomaticallyRetriesAfterAConnectionResetWarning()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('get')->with('foo')->willThrowException(new ErrorException('Redis::get(): SSL: Connection reset by peer'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->assertSame('bar', $connection->command('get', ['foo']));
+        $this->assertSame($healthyClient, $connection->client());
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testConnectionDoesNotRetryUnrelatedWarnings()
+    {
+        $failedClient = $this->createMock(\Redis::class);
+        $failedClient->expects($this->once())->method('get')->with('foo')->willThrowException(new ErrorException('Redis::get(): Undefined variable'));
+
+        $healthyClient = $this->createMock(\Redis::class);
+        $healthyClient->expects($this->never())->method('get');
+
+        $connection = new PhpRedisConnection($failedClient, fn () => $healthyClient);
+
+        $this->expectExceptionObject(new ErrorException('Redis::get(): Undefined variable'));
+
+        $connection->command('get', ['foo']);
     }
 
     #[RequiresPhpExtension('redis')]


### PR DESCRIPTION
`PhpRedisConnection::command()` reconnects and retries safe commands when the connection drops mid-command:

```php
} catch (RedisClusterException|RedisException $e) {
    if (! Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost', 'Error processing response from Redis node'])) {
        throw $e;
    }

    $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
    ...
}
```

A TLS/socket reset does not always arrive as a `RedisException`. phpredis frequently surfaces it as a PHP **warning** — e.g. `Redis::get(): SSL: Connection reset by peer` — which `HandleExceptions` converts into a thrown `ErrorException` at the client-call line. Because `command()` only caught `RedisClusterException|RedisException`, that flavour of the *same underlying reset* skipped the reconnect-and-retry entirely and propagated to the caller. Both flavours appear in production telemetry for the same event.

## What this changes

`ErrorException` is added to the caught types, and `'Connection reset by peer'` to the recognized connection-loss markers, so a reset is handled identically whichever way it surfaces:

```php
} catch (RedisClusterException|RedisException|ErrorException $e) {
    if (! Str::contains($e->getMessage(), [..., 'Connection reset by peer'])) {
        throw $e;
    }
    ...
}
```

## Backwards compatibility

The existing message guard is unchanged except for the added marker, so **any `ErrorException` that does not match a connection-loss marker is rethrown untouched** — unrelated warnings-as-exceptions keep their current behaviour. Non-retryable commands still retry `0` times, so a reset on a write with side effects is not silently replayed. Predis is unaffected.

## Tests

Added to `PhpRedisConnectorTest`:

- a reset surfaced as `ErrorException('Redis::get(): SSL: Connection reset by peer')` is retried after rebuilding the client and returns the value;
- an unrelated `ErrorException` warning is rethrown without a retry.

## Related

This is one of two follow-ups to #61460 (`command_retries` for cluster connections). The other — a bounded retry for connection resets that occur at cluster *connect* time, before any `command()` exists to retry — is a separate PR. The three are independent and can merge in any order.
