### PR TITLE
[13.x] Retry a phpredis cluster connection reset at connect time

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -214,7 +214,11 @@ class PhpRedisConnector implements Connector
             $parameters[] = $options['password'] ?? null;
         }
 
-        return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
+        $connection = retry(2, fn () => $this->buildClusterConnection($parameters), 0, fn ($e) => Str::contains(
+            $e->getMessage(), 'Connection reset by peer'
+        ));
+
+        return tap($connection, function ($client) use ($options) {
             if (! empty($options['prefix'])) {
                 $client->setOption(Redis::OPT_PREFIX, $options['prefix']);
             }
@@ -259,6 +263,19 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_BACKOFF_CAP, $options['backoff_cap']);
             }
         });
+    }
+
+    /**
+     * Instantiate the RedisCluster client.
+     *
+     * @param  array  $parameters
+     * @return \RedisCluster
+     *
+     * @throws \RedisClusterException
+     */
+    protected function buildClusterConnection(array $parameters)
+    {
+        return new RedisCluster(...$parameters);
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Redis;
 
+use ErrorException;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
 use InvalidArgumentException;
@@ -302,6 +303,50 @@ class PhpRedisConnectorTest extends TestCase
         $property = new ReflectionProperty(PhpRedisConnection::class, 'connector');
 
         $this->assertIsCallable($property->getValue($connection));
+    }
+
+    public function testConnectToClusterRetriesAfterAConnectionResetAtConnectTime()
+    {
+        $connector = new class extends PhpRedisConnector
+        {
+            public int $attempts = 0;
+
+            protected function buildClusterConnection(array $parameters)
+            {
+                if (++$this->attempts < 2) {
+                    throw new ErrorException('RedisCluster::__construct(): SSL: Connection reset by peer');
+                }
+
+                return new class {
+                };
+            }
+        };
+
+        $connector->connectToCluster([['host' => '127.0.0.1', 'port' => 6379]], [], []);
+
+        $this->assertSame(2, $connector->attempts);
+    }
+
+    public function testConnectToClusterDoesNotRetryUnrelatedConnectErrors()
+    {
+        $connector = new class extends PhpRedisConnector
+        {
+            public int $attempts = 0;
+
+            protected function buildClusterConnection(array $parameters)
+            {
+                $this->attempts++;
+
+                throw new ErrorException("RedisCluster::__construct(): couldn't map cluster keyspace");
+            }
+        };
+
+        try {
+            $connector->connectToCluster([['host' => '127.0.0.1', 'port' => 6379]], [], []);
+            $this->fail('Expected ErrorException was not thrown.');
+        } catch (ErrorException $e) {
+            $this->assertSame(1, $connector->attempts);
+        }
     }
 
     #[RequiresPhpExtension('redis')]


### PR DESCRIPTION
`PhpRedisConnection::command()` reconnects and retries when a connection drops mid-command. But a TLS/socket reset that occurs while the cluster client is being **constructed** — e.g. `RedisCluster::__construct(): SSL: Connection reset by peer` — happens inside `PhpRedisConnector::createRedisClusterInstance()`, before any `PhpRedisConnection` (and therefore any `command()`) exists to retry. So that reset isn't covered by the command-level retry and fails the whole connection attempt, even though establishing the connection is idempotent and an immediate retry would usually succeed.

## What this changes

The `RedisCluster` construction is wrapped in a single bounded `retry()` that only fires when the failure message is a connection reset:

```php
$connection = retry(2, fn () => $this->buildClusterConnection($parameters), 0, fn ($e) => Str::contains(
    $e->getMessage(), 'Connection reset by peer'
));

return tap($connection, function ($client) use ($options) {
    // ...existing option setup...
});
```

The construction itself is extracted to a small `buildClusterConnection()` seam so the retry can be exercised without a live cluster.

## Backwards compatibility

- Only **one** extra attempt, and only when the message contains `Connection reset by peer`. Any other connect-time failure (misconfiguration, unreachable node, auth error) still throws immediately on the first attempt — no new latency and no masking of real errors.
- This mirrors the "automatic single retry" philosophy already used for safe commands; no new configuration is introduced.
- Flat (non-cluster) connections and Predis are untouched.

## Tests

Added to `PhpRedisConnectorTest` (no live cluster required, via the `buildClusterConnection()` seam):

- a connect-time reset is retried once and the connection then succeeds;
- an unrelated connect error is not retried and propagates on the first attempt.

## Related

This is one of two follow-ups to #61460 (`command_retries` for cluster connections); the other (#61462) handles a mid-command reset that surfaces as a warning-shaped `ErrorException`. All three are independent and can merge in any order.
