### PR TITLE
[13.x] Allow enums in queue pause/resume methods

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -232,12 +232,15 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Pause a queue by its connection and name.
      *
-     * @param  string  $connection
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $connection
+     * @param  \UnitEnum|string  $queue
      * @return void
      */
     public function pause($connection, $queue)
     {
+        $connection = enum_value($connection);
+        $queue = enum_value($queue);
+
         $this->app['cache']
             ->store()
             ->forever("illuminate:queue:paused:{$connection}:{$queue}", true);
@@ -250,13 +253,16 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Pause a queue by its connection and name for a given amount of time.
      *
-     * @param  string  $connection
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $connection
+     * @param  \UnitEnum|string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return void
      */
     public function pauseFor($connection, $queue, $ttl)
     {
+        $connection = enum_value($connection);
+        $queue = enum_value($queue);
+
         $this->app['cache']
             ->store()
             ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
@@ -285,12 +291,15 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Resume a paused queue by its connection and name.
      *
-     * @param  string  $connection
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $connection
+     * @param  \UnitEnum|string  $queue
      * @return void
      */
     public function resume($connection, $queue)
     {
+        $connection = enum_value($connection);
+        $queue = enum_value($queue);
+
         $this->app['cache']
             ->store()
             ->forget("illuminate:queue:paused:{$connection}:{$queue}");

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -255,4 +255,22 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame(['database', 'notifications'], $parser->parse('database:notifications'));
         $this->assertSame(['redis', 'foo:bar'], $parser->parse('redis:foo:bar'));
     }
+
+    public function testEnumsAreAccepted()
+    {
+        $this->manager->pause(Enum::Redis, Enum::Emails);
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+
+        $this->manager->resume(Enum::Redis, Enum::Emails);
+        $this->assertFalse($this->manager->isPaused('redis', 'emails'));
+
+        $this->manager->pauseFor(Enum::Redis, Enum::Emails, 30);
+        $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+    }
+}
+
+enum Enum: string
+{
+    case Redis = 'redis';
+    case Emails = 'emails';
 }

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -258,19 +258,23 @@ class QueuePauseResumeTest extends TestCase
 
     public function testEnumsAreAccepted()
     {
-        $this->manager->pause(Enum::Redis, Enum::Emails);
+        $this->manager->pause(PauseQueueConnection::Redis, PauseQueueName::Emails);
         $this->assertTrue($this->manager->isPaused('redis', 'emails'));
 
-        $this->manager->resume(Enum::Redis, Enum::Emails);
+        $this->manager->resume(PauseQueueConnection::Redis, PauseQueueName::Emails);
         $this->assertFalse($this->manager->isPaused('redis', 'emails'));
 
-        $this->manager->pauseFor(Enum::Redis, Enum::Emails, 30);
+        $this->manager->pauseFor(PauseQueueConnection::Redis, PauseQueueName::Emails, 30);
         $this->assertTrue($this->manager->isPaused('redis', 'emails'));
     }
 }
 
-enum Enum: string
+enum PauseQueueConnection: string
 {
     case Redis = 'redis';
+}
+
+enum PauseQueueName: string
+{
     case Emails = 'emails';
 }


### PR DESCRIPTION
Felt weird to me that we can use enums in the Queue/Connection attributes in jobs, and with various of the manager methods ie route/forward, but we can't use it in pause/resume. 

This meant in userland logic we'd be using mostly enums, but when using pause/resume etc, it would be strings. So, this just allows us a more uniform codebase.

For context, we allow some end users to pause specific queues.

This PR just allows us to use enums for the following ie:

```php
Queue::pause(Queues::notifications, Connections::Redis); 
Queue::resume(Queues::notifications, Connections::Redis); 
Queue::pauseFor(Queues::notifications,Connections::Redis , 60); 
```

The methods are nicer in 14.x cos connection etc defaults...