### PR TITLE
[13.x] Add `devServerUrl()` to Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -867,6 +867,16 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get the path to a given asset when running in HMR mode.
+     *
+     * @return string
+     */
+    protected function hotAsset($asset)
+    {
+        return $this->devServerUrl().'/'.$asset;
+    }
+
+    /**
      * Get the URL of the running Vite development server.
      *
      * @return string|null
@@ -878,16 +888,6 @@ class Vite implements Htmlable
         }
 
         return rtrim(file_get_contents($this->hotFile()));
-    }
-
-    /**
-     * Get the path to a given asset when running in HMR mode.
-     *
-     * @return string
-     */
-    protected function hotAsset($asset)
-    {
-        return $this->devServerUrl().'/'.$asset;
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -867,13 +867,27 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get the URL of the running Vite development server.
+     *
+     * @return string|null
+     */
+    public function devServerUrl()
+    {
+        if (! $this->isRunningHot()) {
+            return null;
+        }
+
+        return rtrim(file_get_contents($this->hotFile()));
+    }
+
+    /**
      * Get the path to a given asset when running in HMR mode.
      *
      * @return string
      */
     protected function hotAsset($asset)
     {
-        return rtrim(file_get_contents($this->hotFile())).'/'.$asset;
+        return $this->devServerUrl().'/'.$asset;
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -115,6 +115,30 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testItCanRetrieveTheDevServerUrl()
+    {
+        $this->makeViteHotFile();
+
+        $this->assertSame('http://localhost:3000', app(Vite::class)->devServerUrl());
+    }
+
+    public function testTheDevServerUrlIsNullWhenNotRunningHot()
+    {
+        $this->assertNull(app(Vite::class)->devServerUrl());
+    }
+
+    public function testTheDevServerUrlRespectsACustomHotFile()
+    {
+        $this->makeViteHotFile(__DIR__.'/custom-hot');
+
+        $this->assertSame(
+            'http://localhost:3000',
+            app(Vite::class)->useHotFile(__DIR__.'/custom-hot')->devServerUrl()
+        );
+
+        unlink(__DIR__.'/custom-hot');
+    }
+
     public function testViteHotModuleReplacementWithJsOnly()
     {
         $this->makeViteHotFile();


### PR DESCRIPTION
The URL of the running Vite development server is only reachable through the protected `hotAsset()` method, so applications that need the origin on its own end up reading the hot file directly:

```php
rtrim(file_get_contents(app(Vite::class)->hotFile()));
```

That duplicates the framework's own logic and quietly ignores `useHotFile()`.

The case I hit is Content Security Policy. A local policy has to allow the dev server origin, and hard-coding it breaks the moment Vite falls back to another port because its configured one is taken — every asset is then blocked with a CSP violation, which reads like a misconfigured policy rather than a port collision. Reading the hot file fixes it, but the framework already knows the answer.

```php
$policy->add(Directive::STYLE, app(Vite::class)->devServerUrl());
```

`hotAsset()` now delegates to the new method, so there is a single reader of the hot file. It returns `null` when the dev server isn't running, which matters because callers like the above run on every request whether Vite is up or not — `hotAsset()` itself assumes it is running hot, since internally it is only reached behind `isRunningHot()`.

No behaviour changes and nothing existing becomes public.