### PR TITLE
[14.x] Ensure Cache has & forget work for arrays

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -105,6 +105,10 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function has($key): bool
     {
+        if (is_array($key)) {
+           return ! in_array(null, $this->many($key), true);
+        }
+
         return ! is_null($this->get($key));
     }
 
@@ -753,6 +757,10 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function forget($key)
     {
+        if (is_array($key)) {
+            return $this->deleteMultiple($key);
+        }
+
         $key = enum_value($key);
 
         $this->event(new ForgettingKey($this->getName(), $key));

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -106,7 +106,7 @@ class Repository implements ArrayAccess, CacheContract
     public function has($key): bool
     {
         if (is_array($key)) {
-           return ! in_array(null, $this->many($key), true);
+            return ! in_array(null, $this->many($key), true);
         }
 
         return ! is_null($this->get($key));

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -117,7 +117,6 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->missing('bar'));
     }
 
-
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $repo = $this->getRepository();
@@ -364,7 +363,6 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->expects('forget')->with('a-key')->andReturn(true);
         $repo->delete('a-key');
     }
-
 
     public function testSettingCache()
     {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -107,6 +107,16 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->missing('bar'));
     }
 
+    public function testHasMethodWithArray()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->expects('many')->with(['foo', 'bar'])->andReturn(['foo' => 'foo', 'bar' => 'bar']);
+        $repo->getStore()->expects('many')->with(['foo', 'baz'])->andReturn(['foo' => 'foo', 'baz' => null]);
+
+        $this->assertTrue($repo->has(['foo', TestCacheKey::BAR]));
+        $this->assertFalse($repo->has(['foo', 'baz']));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $repo = $this->getRepository();
@@ -343,6 +353,15 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->expects('forget')->with('a-key')->andReturn(true);
         $repo->delete('a-key');
+    }
+
+    public function testForgettingMultipleCacheKeys()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->expects('forget')->with('foo')->andReturn(true);
+        $repo->getStore()->expects('forget')->with('bar')->andReturn(false);
+
+        $this->assertFalse($repo->forget(['foo', TestCacheKey::BAR]));
     }
 
     public function testSettingCache()
@@ -845,4 +864,5 @@ class CacheRepositoryTest extends TestCase
 enum TestCacheKey: string
 {
     case FOO = 'foo';
+    case BAR = 'bar';
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -97,6 +97,16 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->has('baz'));
     }
 
+    public function testHasMethodWithArray()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->expects('many')->with(['foo', 'bar'])->andReturn(['foo' => 'foo', 'bar' => 'bar']);
+        $repo->getStore()->expects('many')->with(['foo', 'baz'])->andReturn(['foo' => 'foo', 'baz' => null]);
+
+        $this->assertTrue($repo->has(['foo', TestCacheKey::BAR]));
+        $this->assertFalse($repo->has(['foo', 'baz']));
+    }
+
     public function testMissingMethod()
     {
         $repo = $this->getRepository();
@@ -107,15 +117,6 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->missing('bar'));
     }
 
-    public function testHasMethodWithArray()
-    {
-        $repo = $this->getRepository();
-        $repo->getStore()->expects('many')->with(['foo', 'bar'])->andReturn(['foo' => 'foo', 'bar' => 'bar']);
-        $repo->getStore()->expects('many')->with(['foo', 'baz'])->andReturn(['foo' => 'foo', 'baz' => null]);
-
-        $this->assertTrue($repo->has(['foo', TestCacheKey::BAR]));
-        $this->assertFalse($repo->has(['foo', 'baz']));
-    }
 
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
@@ -347,14 +348,6 @@ class CacheRepositoryTest extends TestCase
         $repo->forget('a-key');
     }
 
-    public function testRemovingCacheKey()
-    {
-        // Alias of Forget
-        $repo = $this->getRepository();
-        $repo->getStore()->expects('forget')->with('a-key')->andReturn(true);
-        $repo->delete('a-key');
-    }
-
     public function testForgettingMultipleCacheKeys()
     {
         $repo = $this->getRepository();
@@ -363,6 +356,15 @@ class CacheRepositoryTest extends TestCase
 
         $this->assertFalse($repo->forget(['foo', TestCacheKey::BAR]));
     }
+
+    public function testRemovingCacheKey()
+    {
+        // Alias of Forget
+        $repo = $this->getRepository();
+        $repo->getStore()->expects('forget')->with('a-key')->andReturn(true);
+        $repo->delete('a-key');
+    }
+
 
     public function testSettingCache()
     {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -347,7 +347,7 @@ class CacheRepositoryTest extends TestCase
         $repo->forget('a-key');
     }
 
-    public function testForgettingMultipleCacheKeys()
+    public function testForgettingWithArray()
     {
         $repo = $this->getRepository();
         $repo->getStore()->expects('forget')->with('foo')->andReturn(true);


### PR DESCRIPTION
This surprised me as has / forget report that it works for arrays: 

<img width="554" height="40" alt="image" src="https://github.com/user-attachments/assets/2b69494e-4578-4bad-80b7-3311cd8cd0c6" />


But, if you do `Cache::has(['some', 'thing'])` even if it doesnt exist, it'll always return true, for **anything**.  

Similar for forget, if you give it an array it won't actually forget the array. 

```
Cache::forget(['item', 'item2']);

   WARNING  Array to string conversion in vendor/laravel/framework/src/Illuminate/Cache/RedisStore.php on line 288.
```


This PR ensures they work as expected, ie forget with an array will forget them all.. and has ensures all the items exist. The same as get() and put() do basically.
 
Its been like it in the docblocks for 4 years since https://github.com/laravel/framework/commit/732a29af3599adb5effebe1373783d0822535944 so, I didn't go with pulling array out, as people may still use it.

Let me know if you would rather me pull the array doc or, whatever you see best! 🫡 

I've targeted 14.x as folk may not realise this.. and dont fancy breaking apps