### PR TITLE
[13.x] Update Redis cache tag expiration after touch

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -74,6 +74,31 @@ class RedisTaggedCache extends TaggedCache
     }
 
     /**
+     * Adjust the expiration time of a cached item.
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
+     * @return bool
+     */
+    public function touch($key, $ttl)
+    {
+        $key = enum_value($key);
+
+        $seconds = $this->getSeconds($ttl);
+
+        $result = parent::touch($key, $seconds);
+
+        if ($result && $seconds > 0) {
+            $this->tags->addEntry(
+                $this->itemKey($key),
+                $seconds
+            );
+        }
+
+        return $result;
+    }
+
+    /**
      * Increment the value of an item in the cache.
      *
      * @param  \UnitEnum|string  $key

--- a/tests/Cache/CacheRedisTaggedCacheTest.php
+++ b/tests/Cache/CacheRedisTaggedCacheTest.php
@@ -2,11 +2,14 @@
 
 namespace Illuminate\Tests\Cache;
 
+use DateInterval;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\RedisTaggedCache;
 use Illuminate\Cache\RedisTagSet;
+use Illuminate\Support\Carbon;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class CacheRedisTaggedCacheTest extends TestCase
@@ -34,6 +37,7 @@ class CacheRedisTaggedCacheTest extends TestCase
     {
         return [
             'put' => ['put', ['value', 60], 'put', ['value', 60], [60], true],
+            'touch' => ['touch', [60], 'touch', [60], [60], true],
             'forever' => ['forever', ['value'], 'forever', ['value'], [], true],
             'add' => ['add', ['value', 60], 'add', ['value', 60], [60], true],
             'increment' => ['increment', [2], 'increment', [2], [null, 'NX'], 2],
@@ -60,11 +64,51 @@ class CacheRedisTaggedCacheTest extends TestCase
     {
         return [
             'put' => ['put', ['value', 60], 'put', ['value', 60]],
+            'touch' => ['touch', [60], 'touch', [60]],
             'forever' => ['forever', ['value'], 'forever', ['value']],
             'add' => ['add', ['value', 60], 'add', ['value', 60]],
             'increment' => ['increment', [2], 'increment', [2]],
             'decrement' => ['decrement', [2], 'decrement', [2]],
         ];
+    }
+
+    #[TestWith([0])]
+    #[TestWith([-1])]
+    #[TestWith(['past'])]
+    public function testTouchWithExpiredTtlForgetsItem(int|string $ttl)
+    {
+        Carbon::setTestNow(Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            [$cache, $store, $tags, $itemKey] = $this->getCache();
+
+            $store->expects('forget')->with($itemKey)->once()->andReturn(true);
+            $store->expects('touch')->never();
+            $tags->expects('addEntry')->never();
+
+            $this->assertTrue($cache->touch('key', $ttl === 'past' ? Carbon::now()->subSecond() : $ttl));
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    #[TestWith(['interval'])]
+    #[TestWith(['datetime'])]
+    public function testTouchRegistersTagEntriesWithTheSameSecondsAsTheStore(string $type)
+    {
+        Carbon::setTestNow(Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            [$cache, $store, $tags, $itemKey] = $this->getCache();
+            $ttl = $type === 'interval' ? new DateInterval('PT120S') : Carbon::now()->addSeconds(120);
+
+            $store->expects('touch')->with($itemKey, 120)->once()->globally()->ordered()->andReturn(true);
+            $tags->expects('addEntry')->with($itemKey, 120)->once()->globally()->ordered();
+
+            $this->assertTrue($cache->touch('key', $ttl));
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     private function getCache(): array

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Sleep;
 use Mockery;
@@ -159,6 +160,30 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->flush();
 
         $this->assertNull(Cache::store('redis')->tags(['votes'])->get(RedisTaggedCacheTestKey::PERSON_1));
+    }
+
+    public function testTouchedTagEntriesRemainFlushableAfterOriginalExpiration()
+    {
+        Carbon::setTestNow($now = Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            $cache = Cache::store('redis')->tags(['people', 'author']);
+            $cache->put(RedisTaggedCacheTestKey::PERSON_1, 'Sally', 60);
+
+            $this->assertTrue($cache->touch(RedisTaggedCacheTestKey::PERSON_1, 120));
+
+            Carbon::setTestNow($now->copy()->addSeconds(61));
+
+            $cache->flushStale();
+
+            $this->assertSame('Sally', $cache->get(RedisTaggedCacheTestKey::PERSON_1));
+
+            $cache->flush();
+
+            $this->assertNull($cache->get(RedisTaggedCacheTestKey::PERSON_1));
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     public function testIncrementedTagEntriesProperlyTurnStale()


### PR DESCRIPTION
Calling `touch()` on a Redis tagged cache updates the value key's TTL but leaves its expiration score in the tag sorted sets unchanged. After the original expiration time passes, `flushStale()` removes the tag references while the value is still alive. A subsequent tag `flush()` can no longer find and delete that value.

This adds a `RedisTaggedCache::touch()` override that updates the tag expiration after a successful parent call with a positive TTL. It normalizes enum keys and passes the calculated seconds to the parent, so date-based TTLs are not calculated twice. Failed writes do not register tag entries, and zero or expired TTLs retain the existing `forget()` behavior.

The integration regression writes an entry with two tags and a 60-second TTL, touches it to 120 seconds, advances Laravel's clock by 61 seconds, and calls `flushStale()`. The entry remains readable, but a subsequent tag `flush()` must remove it. Before the fix, the final assertion fails because the value is still present. The test uses an enum key and does not sleep or wait for Redis expiration.

### Validation

- Unit regression fails before the fix because the expected `addEntry()` calls are missing.
- The integration regression fails before the fix and passes afterward with both phpredis and predis against Redis 8.6.1.
- `CacheRedisTaggedCacheTest`: 17 tests, 17 assertions, passing.
- `CacheRepositoryTest`: 85 tests, 118 assertions, passing.
- New integration regression: 1 test, 3 assertions, no skips for each client.
- Full `RedisStoreTest`: 24 tests, 57 assertions, 1 existing skip for each client (`testIncrementWithSerializationEnabled`).
- PHP syntax checks, Pint, `git diff --check`, and PHPStan types pass.
- PHPStan src reports four errors that also occur on the clean upstream commit with the same dependencies: two unmatched ignore identifiers and two potentially hooked property unsets. Both PHPStan configurations were run with a 512M memory limit.

Tested on PHP 8.5.10 and upstream `13.x` at `baedec2039f6fcbbb6578532c12f9aaebc5a6151`.
