### PR TITLE
[13.x] Fix Class `Illuminate\Session\ArraySessionHandler` implementing `SessionHandlerInterface` is missing the `create_sid()` method which will be required in PHP 9.0

### DIFF
--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -54,6 +54,16 @@ class ArraySessionHandler implements SessionHandlerInterface
     }
 
     /**
+     * Create a new session ID.
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id();
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return string|false

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Support\InteractsWithTime;
+use RuntimeException;
 use SessionHandlerInterface;
 
 class ArraySessionHandler implements SessionHandlerInterface
@@ -60,7 +61,7 @@ class ArraySessionHandler implements SessionHandlerInterface
      */
     public function create_sid(): string
     {
-        return session_create_id();
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -14,6 +14,14 @@ class ArraySessionHandlerTest extends TestCase
         $this->assertInstanceOf(SessionHandlerInterface::class, new ArraySessionHandler(10));
     }
 
+    public function test_it_creates_session_ids()
+    {
+        $sessionId = (new ArraySessionHandler(10))->create_sid();
+
+        $this->assertIsString($sessionId);
+        $this->assertNotEmpty($sessionId);
+    }
+
     public function test_it_initializes_the_session()
     {
         $handler = new ArraySessionHandler(10);


### PR DESCRIPTION
The following deprecation error will be available in PHP 8.6

<img width="2442" height="458" alt="CleanShot 2026-09-07 at 18 18 12@2x" src="https://github.com/user-attachments/assets/42e6efed-dba0-4c55-86a6-541a8f5de76e" />


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
