### PR TITLE
[13.x] Fix wherePivot() closure scope ignored in pivot table operations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -105,6 +105,13 @@ class BelongsToMany extends Relation
     protected $pivotWhereNulls = [];
 
     /**
+     * Any pivot table restrictions for closure-based where clauses.
+     *
+     * @var array
+     */
+    protected $pivotWhereClosures = [];
+
+    /**
      * The default values for the pivot columns.
      *
      * @var array
@@ -396,13 +403,11 @@ class BelongsToMany extends Relation
     public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure) {
-            $pivotQuery = (new ($this->getPivotClass()))
-                ->setTable($this->table)
-                ->newQueryWithoutRelationships();
-
-            $column($pivotQuery);
+            $pivotQuery = $this->newPivotQueryForClosure($column);
 
             $this->query->getQuery()->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+
+            $this->pivotWhereClosures[] = [$column, $boolean];
 
             return $this;
         }
@@ -410,6 +415,23 @@ class BelongsToMany extends Relation
         $this->pivotWheres[] = func_get_args();
 
         return $this->where($this->qualifyPivotColumn($column), $operator, $value, $boolean);
+    }
+
+    /**
+     * Build a new pivot model query with the given closure scope applied.
+     *
+     * @param  \Closure(\Illuminate\Database\Eloquent\Builder<TPivotModel>): mixed  $callback
+     * @return \Illuminate\Database\Eloquent\Builder<TPivotModel>
+     */
+    protected function newPivotQueryForClosure(Closure $callback)
+    {
+        $pivotQuery = (new ($this->getPivotClass()))
+            ->setTable($this->table)
+            ->newQueryWithoutRelationships();
+
+        $callback($pivotQuery);
+
+        return $pivotQuery;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -682,6 +682,12 @@ trait InteractsWithPivotTable
             $query->whereNull(...$arguments);
         }
 
+        foreach ($this->pivotWhereClosures as [$column, $boolean]) {
+            $pivotQuery = $this->newPivotQueryForClosure($column);
+
+            $query->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+        }
+
         return $query->where($this->getQualifiedForeignPivotKeyName(), $this->parent->{$this->parentKey});
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
@@ -129,6 +129,57 @@ class DatabaseEloquentBelongsToManyWherePivotClosureTest extends TestCase
         $this->assertEquals($user1->id, $results->first()->id);
     }
 
+    public function testWherePivotWithClosureScopesDetach(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->detach();
+
+        $this->assertCount(1, $project->subscribers()->get());
+        $this->assertTrue($project->subscribers()->get()->contains('id', $muted->id));
+    }
+
+    public function testWherePivotWithClosureScopesUpdateExistingPivot(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false, 'role' => 'member']);
+        $project->subscribers()->attach($muted->id, ['muted' => true, 'role' => 'member']);
+
+        $affected = $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->updateExistingPivot($muted->id, ['role' => 'admin']);
+
+        $this->assertSame(0, $affected);
+        $this->assertSame('member', $project->subscribers()->find($muted->id)->pivot->role);
+    }
+
+    public function testWherePivotWithClosureScopesSync(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->sync([]);
+
+        $this->assertTrue($project->subscribers()->get()->contains('id', $muted->id));
+        $this->assertFalse($project->subscribers()->get()->contains('id', $active->id));
+    }
+
     protected function connection()
     {
         return Eloquent::getConnectionResolver()->connection();


### PR DESCRIPTION
Closes #61471 : `wherePivot()`'s closure form scopes the relation's read query but never records the scope into `$pivotWheres`, so `InteractsWithPivotTable::newPivotQuery()` (the query builder shared by `detach()`, `updateExistingPivot()`, `newPivotStatementForId()`, and `sync()`) - builds itself *without* the defined scope. In practice, `$user->activeRoles()->detach()` (or `sync()`/`updateExistingPivot()`) silently **ignores the closure scope** and operates on the *entire* unscoped pivot table for that parent, deleting/updating rows outside the intended scope. The string form of `wherePivot()` is unaffected since it correctly records into `$pivotWheres`.

### Changes made

- `BelongsToMany::wherePivot()` now also records the closure scopes into a new `protected $pivotWhereClosures` array (mirroring `$pivotWheres`/`$pivotWhereIns`/`$pivotWhereNulls`), in addition to applying them to the relation's query as before.
- Extracted the pivot-model-builder-plus-closure logic into `BelongsToMany::newPivotQueryForClosure()`..and reused it in both site.
- `InteractsWithPivotTable::newPivotQuery()` now replays `$pivotWhereClosures` via `addNestedWhereQuery()`, alongside the existing three arrays - so `detach()`, `updateExistingPivot()`, `sync()`, `newPivotStatementForId()`, and `getCurrentlyAttachedPivots()` all honor closure-based pivot scopes correctly.
- Added necessary tests in `DatabaseEloquentBelongsToManyWherePivotClosureTest` covering closure-scoped `detach()`, `updateExistingPivot()`, and `sync()` behavior..

No breaking changes. This is a bug fix that just corrects the closure-scoped pivot operations to respect their declared scope, matching the behavior of string-form `wherePivot()`. 