### PR TITLE
[13.x] Fix string key bindings in array lookups and presence checks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -285,6 +285,13 @@ class Builder implements BuilderContract
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
                 $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id);
             } else {
+                if ($this->model->getKeyType() === 'string') {
+                    $id = array_map(
+                        fn ($value) => is_scalar($value) ? (string) $value : $value,
+                        $id instanceof Arrayable ? $id->toArray() : $id,
+                    );
+                }
+
                 $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
             }
 
@@ -314,6 +321,13 @@ class Builder implements BuilderContract
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
                 $this->query->whereIntegerNotInRaw($this->model->getQualifiedKeyName(), $id);
             } else {
+                if ($this->model->getKeyType() === 'string') {
+                    $id = array_map(
+                        fn ($value) => is_scalar($value) ? (string) $value : $value,
+                        $id instanceof Arrayable ? $id->toArray() : $id,
+                    );
+                }
+
                 $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
             }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1716,9 +1716,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // correct set of attributes in case the developers wants to check these.
         $key = ($instance = new static)->getKeyName();
 
+        $query = $instance->getKeyType() === 'string'
+            ? $instance->whereKey($ids)
+            : $instance->whereIn($key, $ids);
+
         $count = 0;
 
-        foreach ($instance->whereIn($key, $ids)->get() as $model) {
+        foreach ($query->get() as $model) {
             if ($model->delete()) {
                 $count++;
             }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -102,9 +102,14 @@ trait SoftDeletes
         // correct set of attributes in case the developers wants to check these.
         $key = ($instance = new static)->getKeyName();
 
+        $query = $instance::withTrashed();
+        $query = $instance->getKeyType() === 'string'
+            ? $query->whereKey($ids)
+            : $query->whereIn($key, $ids);
+
         $count = 0;
 
-        foreach ($instance::withTrashed()->whereIn($key, $ids)->get() as $model) {
+        foreach ($query->get() as $model) {
             if ($model->forceDelete()) {
                 $count++;
             }

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -44,7 +44,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, '=', $value);
+        $query = $this->table($collection)->where($column, '=', $this->normalizeValue($value));
 
         if (! is_null($excludeId) && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
@@ -64,9 +64,20 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
      */
     public function getMultiCount($collection, $column, array $values, array $extra = [])
     {
-        $query = $this->table($collection)->whereIn($column, $values);
+        $query = $this->table($collection)->whereIn($column, array_map($this->normalizeValue(...), $values));
 
         return $this->addConditions($query, $extra)->distinct()->count($column);
+    }
+
+    /**
+     * Normalize integer and boolean values for string parameter binding.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function normalizeValue($value)
+    {
+        return is_int($value) || is_bool($value) ? (string) (int) $value : $value;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2387,6 +2387,27 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($collection);
     }
 
+    public function testStringKeyArraysUseStringBindings()
+    {
+        foreach (['SQLite', 'MySql', 'MariaDb', 'Postgres', 'SqlServer'] as $database) {
+            $model = new EloquentBuilderTestStubStringPrimaryKey;
+            $this->mockConnectionForModel($model, $database);
+
+            foreach (['whereKey', 'whereKeyNot'] as $method) {
+                foreach ([[0, 10, '020', null], new BaseCollection([0, 10, '020', null])] as $ids) {
+                    $query = $model->newQuery()->$method($ids);
+
+                    $this->assertSame(['0', '10', '020', null], $query->getBindings());
+                }
+
+                $query = $model->newQuery()->$method([new Expression("'example'"), 10]);
+
+                $this->assertSame(['10'], $query->getBindings());
+                $this->assertStringContainsString("'example'", $query->toSql());
+            }
+        }
+    }
+
     public function testWhereKeyMethodWithModel()
     {
         $model = new EloquentBuilderTestStubStringPrimaryKey;
@@ -2587,7 +2608,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $keyName = $model->getQualifiedKeyName();
 
         $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
-            return $argument === [1, 2];
+            return $argument === ['1', '2'];
         }));
 
         $models = new Collection([
@@ -2611,7 +2632,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $keyName = $model->getQualifiedKeyName();
 
         $builder->getQuery()->expects('whereNotIn')->with($keyName, Mockery::on(function ($argument) {
-            return $argument === [1, 2];
+            return $argument === ['1', '2'];
         }));
 
         $models = [

--- a/tests/Database/DatabaseEloquentStringKeyIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentStringKeyIntegrationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentStringKeyIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+        $db->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        DB::schema()->create('string_keys', function ($table) {
+            $table->string('id')->primary();
+            $table->softDeletes();
+        });
+
+        DB::schema()->create('integer_keys', function ($table) {
+            $table->integer('id')->primary();
+            $table->softDeletes();
+        });
+
+        DB::table('integer_keys')->insert([['id' => 10], ['id' => 20]]);
+        DB::table('string_keys')->insert([['id' => '10'], ['id' => '20']]);
+        DB::connection()->enableQueryLog();
+    }
+
+    protected function tearDown(): void
+    {
+        Model::unsetConnectionResolver();
+        Model::clearBootedModels();
+    }
+
+    public function testDestroyPreservesIntegerKeyBindings()
+    {
+        $this->assertSame(0, IntegerKeyModel::destroy([10.5]));
+        $this->assertSame([10.5], DB::getQueryLog()[0]['bindings']);
+        $this->assertSame(1, IntegerKeyModel::destroy([10]));
+        $this->assertSame([20], IntegerKeyModel::all()->modelKeys());
+    }
+
+    public function testForceDestroyPreservesIntegerKeyBindings()
+    {
+        $this->assertSame(0, SoftDeletingIntegerKeyModel::forceDestroy([10.5]));
+        $this->assertSame([10.5], DB::getQueryLog()[0]['bindings']);
+        $this->assertSame(1, SoftDeletingIntegerKeyModel::forceDestroy([10]));
+        $this->assertSame([20], SoftDeletingIntegerKeyModel::withTrashed()->get()->modelKeys());
+    }
+
+    public function testFindManyUsesStringBindings()
+    {
+        $models = StringKeyModel::findMany(collect([10]));
+
+        $this->assertSame(['10'], $models->modelKeys());
+        $this->assertSame(['10'], DB::getQueryLog()[0]['bindings']);
+    }
+
+    public function testDestroyUsesStringBindings()
+    {
+        $this->assertSame(1, StringKeyModel::destroy([10]));
+        $this->assertSame(['10'], DB::getQueryLog()[0]['bindings']);
+        $this->assertSame(['20'], StringKeyModel::all()->modelKeys());
+    }
+
+    public function testSoftDestroyUsesStringBindings()
+    {
+        $this->assertSame(1, SoftDeletingStringKeyModel::destroy(collect([10])));
+        $this->assertSame(['10'], DB::getQueryLog()[0]['bindings']);
+        $this->assertSame(['20'], SoftDeletingStringKeyModel::all()->modelKeys());
+        $this->assertSame(['10'], SoftDeletingStringKeyModel::onlyTrashed()->get()->modelKeys());
+    }
+
+    public function testForceDestroyUsesStringBindings()
+    {
+        SoftDeletingStringKeyModel::find('10')->delete();
+        DB::flushQueryLog();
+
+        $this->assertSame(1, SoftDeletingStringKeyModel::forceDestroy([10]));
+        $this->assertSame(['10'], DB::getQueryLog()[0]['bindings']);
+        $this->assertSame(['20'], SoftDeletingStringKeyModel::withTrashed()->get()->modelKeys());
+    }
+}
+
+class StringKeyModel extends Model
+{
+    protected $table = 'string_keys';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    public $timestamps = false;
+}
+
+class SoftDeletingStringKeyModel extends StringKeyModel
+{
+    use SoftDeletes;
+}
+
+class IntegerKeyModel extends StringKeyModel
+{
+    protected $table = 'integer_keys';
+
+    protected $keyType = 'int';
+}
+
+class SoftDeletingIntegerKeyModel extends IntegerKeyModel
+{
+    use SoftDeletes;
+}

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Tests\Validation;
 
 use Closure;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Validation\DatabasePresenceVerifier;
 use Mockery;
+use PDO;
 use PHPUnit\Framework\TestCase;
 
 class ValidationDatabasePresenceVerifierTest extends TestCase
@@ -61,6 +63,35 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->expects('count')->andReturn(100);
 
         $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
+    }
+
+    public function testCountNormalizesIdentityBindings()
+    {
+        foreach ([10 => '10', 0 => '0'] as $value => $expected) {
+            $this->assertCountBindings($value, $expected);
+        }
+
+        $this->assertCountBindings(true, '1');
+        $this->assertCountBindings(false, '0');
+        $this->assertCountBindings('010', '010');
+        $this->assertCountBindings(null, null);
+    }
+
+    protected function assertCountBindings($value, $expected)
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $db = Mockery::mock(ConnectionResolverInterface::class);
+        $db->shouldReceive('connection')->andReturn($connection);
+        $verifier = new DatabasePresenceVerifier($db);
+        $extra = [fn ($query) => $query->where('owner_id', 7)];
+
+        $queries = $connection->pretend(fn () => $verifier->getCount('table', 'column', $value, null, null, $extra));
+
+        $this->assertSame($expected === null ? [7] : [$expected, 7], $queries[0]['bindings']);
+
+        $queries = $connection->pretend(fn () => $verifier->getMultiCount('table', 'column', [$value, 'example'], $extra));
+
+        $this->assertSame([$expected, 'example', 7], $queries[0]['bindings']);
     }
 
     public function testGetCountWithValidExcludeId()


### PR DESCRIPTION
A bulk delete can remove documents belonging to other users when numeric input is compared with string IDs. On MySQL and MariaDB, integer bindings can make different text IDs compare equal.

For example, consider a document model using `HasUlids` and these rows:

| ID | Owner | Title |
| --- | --- | --- |
| `01m0vzqg7n1x9ey00swy661j1x` | 1 | Alice's document |
| `01m0vzqg7r1rz0a11arsteh6k5` | 2 | Bob's document |
| `01m0vzqg7xphwy71wkwrby5897` | 3 | Charlie's document |

Alice is signed in as user 1. The application's bulk-delete action validates that the supplied IDs belong to her before deleting the requested models.

### Expected behavior

Submitting Alice's exact document ID deletes only her document. Invalid IDs should fail validation and leave all three documents untouched.

### Actual behavior

With numeric input, the ownership-scoped presence check can pass, but the subsequent bulk lookup can also match Bob's and Charlie's IDs. In the reported case, all three documents were deleted.

The inconsistency starts with parameter binding. Eloquent converts a scalar ID to a string for string-key models, but skips that conversion for arrays:

```php
Document::whereKey(10)->getBindings();
// Actual and expected: ['10']

Document::whereKey([10])->getBindings();
// Actual: [10]
// Expected: ['10']
```

### Fix

This PR applies the scalar conversion to arrays and collections in `whereKey()` and `whereKeyNot()`. String-key models also use this path in `destroy()` and `forceDestroy()`. Integer-key deletion keeps its current behavior, and nulls and query expressions are preserved.

Database presence checks now bind integer and boolean input values as strings too, while extra query conditions retain their original types.

Added regression tests for bindings, `findMany()`, bulk deletion, and integer-key compatibility. The database and validation suites completed without failures across 4,118 tests, with one skipped. The two network-dependent tests were run separately with network access. Pint passes. Integration tests use SQLite; the other database grammars have binding coverage.
