### PR TITLE
[13.x] Validate dynamic component names before rendering

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -21,6 +21,13 @@ use ReflectionClass;
 class ComponentTagCompiler
 {
     /**
+     * The regular expression for component names.
+     *
+     * @var string
+     */
+    protected const COMPONENT_NAME_PATTERN = '[\w\-:.]*';
+
+    /**
      * The Blade compiler instance.
      *
      * @var \Illuminate\View\Compilers\BladeCompiler
@@ -64,6 +71,17 @@ class ComponentTagCompiler
     }
 
     /**
+     * Determine if the given value is a valid component name.
+     *
+     * @param  string  $component
+     * @return bool
+     */
+    public static function isValidComponentName(string $component)
+    {
+        return $component !== '' && preg_match('/\A'.static::COMPONENT_NAME_PATTERN.'\z/', $component) === 1;
+    }
+
+    /**
      * Compile the component and slot tags within the given string.
      *
      * @param  string  $value
@@ -103,10 +121,12 @@ class ComponentTagCompiler
      */
     protected function compileOpeningTags(string $value)
     {
+        $componentNamePattern = static::COMPONENT_NAME_PATTERN;
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                x[-\:]({$componentNamePattern})
                 (?<attributes>
                     (?:
                         \s+
@@ -167,10 +187,12 @@ class ComponentTagCompiler
      */
     protected function compileSelfClosingTags(string $value)
     {
+        $componentNamePattern = static::COMPONENT_NAME_PATTERN;
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                x[-\:]({$componentNamePattern})
                 \s*
                 (?<attributes>
                     (?:
@@ -504,7 +526,7 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value)
     {
-        return preg_replace("/<\/\s*x[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
+        return preg_replace("/<\/\s*x[-\:]".static::COMPONENT_NAME_PATTERN."\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
     }
 
     /**

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler;
+use InvalidArgumentException;
 
 use function Illuminate\Support\enum_value;
 
@@ -60,6 +61,10 @@ class DynamicComponent extends Component
 EOF;
 
         return function ($data) use ($template) {
+            if (! ComponentTagCompiler::isValidComponentName($this->component)) {
+                throw new InvalidArgumentException('Invalid dynamic component name.');
+            }
+
             $bindings = $this->bindings($class = $this->classForComponent());
 
             return str_replace(

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\Component;
+use Illuminate\View\ViewException;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Finder\Finder;
@@ -93,6 +94,45 @@ class BladeTest extends TestCase
         $this->assertSame('<div class="ml-2" wire:model="foo" wire:model.lazy="bar">
     Hello Taylor
 </div>', trim($view));
+    }
+
+    #[RunInSeparateProcess]
+    public function test_rendering_a_dynamic_class_component()
+    {
+        Blade::component('dynamic-hello', HelloComponent::class);
+
+        $view = Blade::render('<x-dynamic-component :component="$name" name="Taylor" />', [
+            'name' => 'dynamic-hello',
+        ]);
+
+        $this->assertSame('Hello Taylor', trim($view));
+    }
+
+    public function test_rendering_a_dynamic_mail_component()
+    {
+        View::addNamespace('mail', dirname(__DIR__, 3).'/src/Illuminate/Mail/resources/views/html');
+
+        $view = Blade::render('<x-dynamic-component :component="$name">Hello Taylor</x-dynamic-component>', [
+            'name' => 'mail::panel',
+        ]);
+
+        $this->assertStringContainsString('class="panel"', $view);
+        $this->assertStringContainsString('Hello Taylor', $view);
+    }
+
+    public function test_invalid_dynamic_names_are_rejected_with_a_cached_view()
+    {
+        $template = '<x-dynamic-component :component="$name" />';
+
+        for ($attempt = 0; $attempt < 2; $attempt++) {
+            try {
+                Blade::render($template, ['name' => 'panel with-space']);
+
+                $this->fail('An invalid dynamic component name was rendered.');
+            } catch (ViewException $exception) {
+                $this->assertStringContainsString('Invalid dynamic component name.', $exception->getMessage());
+            }
+        }
     }
 
     public function test_rendering_the_same_dynamic_component_with_different_attributes()

--- a/tests/View/DynamicComponentTest.php
+++ b/tests/View/DynamicComponentTest.php
@@ -2,13 +2,80 @@
 
 namespace Illuminate\Tests\View;
 
+use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\DynamicComponent;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
 class DynamicComponentTest extends TestCase
 {
+    #[DataProvider('invalidComponentNames')]
+    public function testInvalidNamesAreRejectedBeforeComponentResolution(string $name): void
+    {
+        $component = new DynamicComponent($name);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid dynamic component name.');
+
+        ($component->render())([]);
+    }
+
+    public static function invalidComponentNames(): array
+    {
+        return [
+            [''],
+            ['panel with-space'],
+            ["panel\n"],
+            ["panel\0"],
+            ['panel{{ }}'],
+            ['panel{!! !!}'],
+            ['panel@'],
+            ['panel<?'],
+            ['panel>'],
+            ['panel/'],
+            ['panel"'],
+            ["panel'"],
+            ['mail::panel with-space'],
+        ];
+    }
+
+    public function testNamesAreValidatedWhenTheRenderCallbackRuns(): void
+    {
+        $component = new DynamicComponent('panel');
+        $render = $component->render();
+        $component->component = 'panel with-space';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid dynamic component name.');
+
+        $render([]);
+    }
+
+    public function testInvalidBackedEnumNamesAreRejected(): void
+    {
+        $component = new DynamicComponent(DynamicComponentName::Invalid);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid dynamic component name.');
+
+        ($component->render())([]);
+    }
+
+    public function testValidComponentNamesMatchTheTagGrammar(): void
+    {
+        foreach (['alert', 'Alert2', 'input_label', 'forms.input-label', 'package::alert', 'mail::panel'] as $name) {
+            $this->assertTrue(ComponentTagCompiler::isValidComponentName($name));
+        }
+
+        $component = new DynamicComponent(DynamicComponentName::Panel);
+
+        $this->assertSame('panel', $component->component);
+        $this->assertTrue(ComponentTagCompiler::isValidComponentName($component->component));
+    }
+
     public function testCompileSlotsExcludesDefaultSlot(): void
     {
         $component = new DynamicComponent('alert');
@@ -35,4 +102,10 @@ class DynamicComponentTest extends TestCase
 
         $this->assertSame('', $result);
     }
+}
+
+enum DynamicComponentName: string
+{
+    case Panel = 'panel';
+    case Invalid = 'panel with-space';
 }


### PR DESCRIPTION
A runtime component name can be treated as Blade code instead of just selecting a component.

For example, a dashboard might choose a panel from a saved layout preference:

```blade
<x-dynamic-component :component="$panel" />
```

When `$panel` is `dashboard.summary`, this should render the summary panel. If the value contains template syntax, it should be rejected as an invalid component name.

### Expected behavior

Only names accepted by Blade's component-tag grammar reach component lookup and template generation. Invalid names throw `InvalidArgumentException`.

### Actual behavior

`DynamicComponent` inserts the runtime name into the opening and closing tags of a new Blade template without checking its syntax. If that value reaches template generation, Blade can interpret parts of the name as code during the next compilation step.

This PR validates the name at the start of the render callback, before class lookup or template generation. This also covers changes to the public `component` property after construction. The name pattern is shared with the tag compiler so the two checks use the same grammar.

Valid class, anonymous, and namespaced components continue to render, including `mail::panel`. Backed enums use the same validation after their values are converted to strings.

Added tests for invalid names, enum values, property changes, repeated rendering with a cached view, and valid class and mail components. All 495 view tests pass with the unit and integration suites run separately. Pint passes on the four changed files.
