### PR TITLE
[13.x] Respect relationship ownership during upserts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -322,7 +322,31 @@ abstract class HasOneOrMany extends Relation
             $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
         }
 
-        return $this->getQuery()->upsert($values, $uniqueBy, $update);
+        $query = clone $this->getQuery();
+        $query->getQuery()->upsertConstraints = $constraints = $this->getUpsertConstraints();
+
+        if ($values !== [] && $update !== []) {
+            // Keep ownership columns stable while MySQL evaluates each assignment.
+            $update = array_filter(
+                $update ?? array_keys(array_first($values)),
+                fn ($value, $key) => ! in_array(is_int($key) ? $value : $key, $constraints, true),
+                ARRAY_FILTER_USE_BOTH,
+            );
+
+            $update = $update ?: $constraints;
+        }
+
+        return $query->upsert($values, $uniqueBy, $update);
+    }
+
+    /**
+     * Get the ownership columns which must match before an upsert may update a row.
+     *
+     * @return list<string>
+     */
+    protected function getUpsertConstraints()
+    {
+        return [$this->getForeignKeyName()];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -128,6 +128,12 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /** @inheritDoc */
+    protected function getUpsertConstraints()
+    {
+        return [...parent::getUpsertConstraints(), $this->getMorphType()];
+    }
+
+    /** @inheritDoc */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -115,6 +115,15 @@ class Builder implements BuilderContract
     public $distinct = false;
 
     /**
+     * The columns which must match the inserted values before an upsert may update a row.
+     *
+     * @internal
+     *
+     * @var list<string>
+     */
+    public $upsertConstraints = [];
+
+    /**
      * The table which the query is targeting.
      *
      * @var \Illuminate\Database\Query\Expression|string

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1458,6 +1458,20 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the ownership comparisons for an upsert update.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  callable(string): string  $value
+     * @return string
+     */
+    protected function compileUpsertConstraints(Builder $query, callable $value)
+    {
+        return (new Collection($query->upsertConstraints))
+            ->map(fn ($column) => $this->wrap($query->from.'.'.$column).' = '.$value($column))
+            ->implode(' and ');
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -435,14 +435,21 @@ class MySqlGrammar extends Grammar
 
         $sql .= ' on duplicate key update ';
 
-        $columns = (new Collection($update))->map(function ($value, $key) use ($useUpsertAlias) {
-            if (! is_numeric($key)) {
-                return $this->wrap($key).' = '.$this->parameter($value);
+        $source = fn ($column) => $useUpsertAlias
+            ? $this->wrap('laravel_upsert_alias').'.'.$this->wrap($column)
+            : 'values('.$this->wrap($column).')';
+
+        $constraints = $this->compileUpsertConstraints($query, $source);
+
+        $columns = (new Collection($update))->map(function ($value, $key) use ($source, $constraints) {
+            $column = $this->wrap(is_numeric($key) ? $value : $key);
+            $value = is_numeric($key) ? $source($value) : $this->parameter($value);
+
+            if ($constraints !== '') {
+                $value = 'if('.$constraints.', '.$value.', '.$column.')';
             }
 
-            return $useUpsertAlias
-                ? $this->wrap($value).' = '.$this->wrap('laravel_upsert_alias').'.'.$this->wrap($value)
-                : $this->wrap($value).' = values('.$this->wrap($value).')';
+            return $column.' = '.$value;
         })->implode(', ');
 
         return $sql.$columns;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -496,7 +496,15 @@ class PostgresGrammar extends Grammar
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
-        return $sql.$columns;
+        $sql .= $columns;
+
+        if ($query->upsertConstraints) {
+            $sql .= ' where '.$this->compileUpsertConstraints(
+                $query, fn ($column) => $this->wrapValue('excluded').'.'.$this->wrap($column),
+            );
+        }
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -365,7 +365,15 @@ class SQLiteGrammar extends Grammar
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
-        return $sql.$columns;
+        $sql .= $columns;
+
+        if ($query->upsertConstraints) {
+            $sql .= ' where '.$this->compileUpsertConstraints(
+                $query, fn ($column) => $this->wrapValue('excluded').'.'.$this->wrap($column),
+            );
+        }
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -479,7 +479,15 @@ class SqlServerGrammar extends Grammar
                     : $this->wrap($key).' = '.$this->parameter($value);
             })->implode(', ');
 
-            $sql .= 'when matched then update set '.$update.' ';
+            $sql .= 'when matched';
+
+            if ($query->upsertConstraints) {
+                $sql .= ' and '.$this->compileUpsertConstraints(
+                    $query, fn ($column) => $this->wrap('laravel_source.'.$column),
+                );
+            }
+
+            $sql .= ' then update set '.$update.' ';
         }
 
         $sql .= 'when not matched then insert ('.$columns.') values ('.$columns.');';

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -259,6 +259,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testRelationUpsertFillsForeignKey()
     {
         $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn(Mockery::mock(QueryBuilder::class));
 
         $relation->getQuery()->expects('upsert')->with(
             [

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -68,6 +68,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphRelationUpsertFillsForeignKey()
     {
         $relation = $this->getManyRelation();
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn(Mockery::mock(QueryBuilder::class));
 
         $relation->getQuery()->expects('upsert')->with(
             [

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4818,6 +4818,66 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpsertUpdateConstraints()
+    {
+        foreach ([$this->getSQLiteBuilder(), $this->getPostgresBuilder()] as $builder) {
+            $builder->upsertConstraints = ['owner_id', 'owner_type'];
+            $builder->getConnection()->expects('affectingStatement')->with(
+                'insert into "items" ("email", "owner_id", "owner_type") values (?, ?, ?) on conflict ("email") do update set "name" = ? where "items"."owner_id" = "excluded"."owner_id" and "items"."owner_type" = "excluded"."owner_type"',
+                ['example', 7, 'parent', 'updated']
+            )->andReturn(1);
+
+            $this->assertSame(1, $builder->from('items')->upsert(
+                [['email' => 'example', 'owner_id' => 7, 'owner_type' => 'parent']],
+                'email', ['name' => 'updated'],
+            ));
+        }
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->upsertConstraints = ['owner_id', 'owner_type'];
+        $builder->getConnection()->expects('affectingStatement')->with(
+            'merge [items] using (values (?, ?, ?)) [laravel_source] ([email], [owner_id], [owner_type]) on [laravel_source].[email] = [items].[email] when matched and [items].[owner_id] = [laravel_source].[owner_id] and [items].[owner_type] = [laravel_source].[owner_type] then update set [name] = ? when not matched then insert ([email], [owner_id], [owner_type]) values ([email], [owner_id], [owner_type]);',
+            ['example', 7, 'parent', 'updated']
+        )->andReturn(1);
+
+        $this->assertSame(1, $builder->from('items')->upsert(
+            [['email' => 'example', 'owner_id' => 7, 'owner_type' => 'parent']],
+            'email', ['name' => 'updated'],
+        ));
+    }
+
+    public function testMySqlUpsertUpdateConstraints()
+    {
+        foreach ([$this->getMySqlBuilder(), $this->getMariaDbBuilder()] as $builder) {
+            $builder->upsertConstraints = ['owner_id', 'owner_type'];
+            $builder->getConnection()->expects('getConfig')->with('use_upsert_alias')->andReturn(false);
+            $builder->getConnection()->expects('affectingStatement')->with(
+                'insert into `items` (`email`, `owner_id`, `owner_type`) values (?, ?, ?) on duplicate key update `name` = if(`items`.`owner_id` = values(`owner_id`) and `items`.`owner_type` = values(`owner_type`), ?, `name`), `email` = if(`items`.`owner_id` = values(`owner_id`) and `items`.`owner_type` = values(`owner_type`), values(`email`), `email`)',
+                ['example', 7, 'parent', 'updated']
+            )->andReturn(1);
+
+            $this->assertSame(1, $builder->from('items')->upsert(
+                [['email' => 'example', 'owner_id' => 7, 'owner_type' => 'parent']],
+                'email', ['name' => 'updated', 'email'],
+            ));
+        }
+    }
+
+    public function testMySqlUpsertUpdateConstraintsWithAlias()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->upsertConstraints = ['owner_id'];
+        $builder->getConnection()->expects('getConfig')->with('use_upsert_alias')->andReturn(true);
+        $builder->getConnection()->expects('affectingStatement')->with(
+            'insert into `items` (`email`, `owner_id`) values (?, ?) as laravel_upsert_alias on duplicate key update `email` = if(`items`.`owner_id` = `laravel_upsert_alias`.`owner_id`, `laravel_upsert_alias`.`email`, `email`)',
+            ['example', 7]
+        )->andReturn(1);
+
+        $this->assertSame(1, $builder->from('items')->upsert(
+            [['email' => 'example', 'owner_id' => 7]], 'email', ['email'],
+        ));
+    }
+
     public function testUpsertMethod()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Integration/Database/EloquentRelationshipUpsertTest.php
+++ b/tests/Integration/Database/EloquentRelationshipUpsertTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class EloquentRelationshipUpsertTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('upsert_parents', function ($table) {
+            $table->id();
+        });
+
+        Schema::create('upsert_children', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('parent_id');
+            $table->string('parent_type')->default('parent');
+            $table->string('reference')->unique();
+            $table->string('name')->default('original');
+            $table->timestamps();
+        });
+
+        Relation::morphMap(['parent' => UpsertParent::class]);
+    }
+
+    #[DataProvider('relationshipUpserts')]
+    public function testUpsertPreservesOwnership($relationship, $update)
+    {
+        $parent = UpsertParent::create();
+        $otherParent = UpsertParent::create();
+        $owned = $parent->$relationship()->create(['reference' => 'owned']);
+        $other = $otherParent->$relationship()->create(['reference' => 'other']);
+        $original = $other->fresh()->getRawOriginal();
+        $this->travel(1)->seconds();
+        $relation = $parent->$relationship();
+
+        $relation->upsert([
+            ['reference' => 'owned', 'name' => 'updated'],
+            ['reference' => 'other', 'name' => 'updated'],
+            ['reference' => 'new', 'name' => 'inserted'],
+        ], 'reference', $update);
+
+        $this->assertSame($original, $other->fresh()->getRawOriginal());
+        $this->assertSame('updated', $owned->fresh()->name);
+        $this->assertSame($parent->id, UpsertChild::where('reference', 'new')->first()->parent_id);
+        $this->assertSame([], $relation->getQuery()->getQuery()->upsertConstraints);
+    }
+
+    public static function relationshipUpserts()
+    {
+        foreach (['children', 'child', 'morphChildren', 'morphChild'] as $relationship) {
+            yield $relationship.' default updates' => [$relationship, null];
+            yield $relationship.' named updates' => [$relationship, ['name']];
+            yield $relationship.' assigned updates' => [$relationship, ['name' => 'updated']];
+        }
+    }
+
+    public function testMorphUpsertPreservesOwnerType()
+    {
+        $parent = UpsertParent::create();
+        $other = UpsertChild::create([
+            'parent_id' => $parent->id, 'parent_type' => 'another-parent', 'reference' => 'other',
+        ]);
+        $original = $other->fresh()->getRawOriginal();
+        $this->travel(1)->seconds();
+
+        $parent->morphChildren()->upsert([
+            ['reference' => 'other', 'name' => 'updated'],
+        ], 'reference');
+
+        $this->assertSame($original, $other->fresh()->getRawOriginal());
+    }
+
+    public function testOwnerColumnsCannotBeReassignedByTheUpdateList()
+    {
+        $parent = UpsertParent::create();
+        $child = $parent->morphChildren()->create(['reference' => 'owned']);
+
+        $parent->morphChildren()->upsert([
+            ['reference' => 'owned', 'name' => 'updated'],
+        ], 'reference', ['parent_id' => 999, 'parent_type' => 'another-parent', 'name']);
+
+        $this->assertSame($parent->id, $child->fresh()->parent_id);
+        $this->assertSame('parent', $child->fresh()->parent_type);
+        $this->assertSame('updated', $child->fresh()->name);
+    }
+
+    public function testUpsertWithExpressions()
+    {
+        $parent = UpsertParent::create();
+        $child = $parent->children()->create(['reference' => 'owned']);
+
+        $parent->children()->upsert([['reference' => 'owned']], 'reference', [
+            'name' => new Expression("'updated'"),
+        ]);
+
+        $this->assertSame('updated', $child->fresh()->name);
+    }
+
+    public function testUpsertWithOnlyOwnershipUpdates()
+    {
+        $parent = UpsertParent::create();
+        $child = $parent->children()->create(['reference' => 'owned']);
+
+        $relation = $parent->children();
+        $relation->getRelated()->timestamps = false;
+        $relation->upsert([['reference' => 'owned']], 'reference', ['parent_id']);
+
+        $this->assertSame($parent->id, $child->fresh()->parent_id);
+        $this->assertSame(0, $parent->children()->upsert([], 'reference'));
+    }
+}
+
+class UpsertParent extends Model
+{
+    protected $table = 'upsert_parents';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function children()
+    {
+        return $this->hasMany(UpsertChild::class, 'parent_id');
+    }
+
+    public function child()
+    {
+        return $this->hasOne(UpsertChild::class, 'parent_id');
+    }
+
+    public function morphChildren()
+    {
+        return $this->morphMany(UpsertChild::class, 'parent');
+    }
+
+    public function morphChild()
+    {
+        return $this->morphOne(UpsertChild::class, 'parent');
+    }
+}
+
+class UpsertChild extends Model
+{
+    protected $table = 'upsert_children';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
Calling `upsert()` through a relationship can update a record belonging to another parent. Laravel adds the parent's foreign key to the inserted values, but the database's conflict update never checks that ownership.

For example, consider an import of a user's related documents. Each document has a globally unique reference:

| Reference | Owner | Title |
| --- | --- | --- |
| `alice-document` | Alice | Alice's notes |
| `bob-document` | Bob | Bob's notes |

### Expected behavior

An import through Alice's relationship updates her existing documents and inserts new ones for her. A conflict with a document belonging to Bob should leave his row unchanged.

### Actual behavior

The conflict update can modify Bob's document. If the update list is omitted, it can also replace the foreign key with Alice's ID and transfer the document to her.

### Fix

This PR checks ownership inside the upsert statement, so there is no separate lookup or race between checking and writing. It covers `HasOne`, `HasMany`, `MorphOne`, and `MorphMany`; polymorphic relationships check both the owner ID and type.

PostgreSQL and SQLite add a condition to the conflict update. SQL Server adds it to `WHEN MATCHED`. MySQL and MariaDB condition each assignment on matching ownership. Ownership columns are excluded from requested updates, and the query is cloned so these constraints do not leak into later calls.

The check covers relationship ownership, not arbitrary additional `where` clauses. MySQL and MariaDB use no-op assignments for a different owner, so their update triggers can still run. This does not provide isolation from custom trigger side effects, and affected-row counts retain database-specific semantics.

Validation: 2,861 database tests and 37 relationship integration tests completed without failures, with one skipped. The integration tests ran on SQLite; SQL and binding assertions cover all five database grammars, including the MySQL upsert alias. Pint passes.
