### PR TITLE
[13.x] Fix array access on HTTP client responses and requests 

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -305,7 +305,7 @@ class Request implements ArrayAccess
      */
     public function offsetGet($offset): mixed
     {
-        return $this->data()[$offset];
+        return $this->data()[$offset] ?? null;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -554,7 +554,7 @@ class Response implements ArrayAccess, Stringable
      */
     public function offsetGet($offset): mixed
     {
-        return $this->json()[$offset];
+        return $this->json()[$offset] ?? null;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -453,6 +453,32 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $response->object()->result->foo);
     }
 
+    public function testArrayAccessDoesNotRaiseErrorsForMissingKeys()
+    {
+        $response = new Response(new Psr7Response(502, [], '<html>Bad Gateway</html>'));
+        $request = new Request(new GuzzleRequest(
+            'POST', 'http://foo.com/api', ['Content-Type' => 'application/json'], '{"foo":"bar"}'
+        ));
+
+        $errors = [];
+
+        set_error_handler(function ($level, $message) use (&$errors) {
+            $errors[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->assertNull($response['missing']);
+            $this->assertSame('bar', $request['foo']);
+            $this->assertNull($request['missing']);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $errors);
+    }
+
     public function testResponseObjectIsTappable()
     {
         $bar = null;


### PR DESCRIPTION
```php
$response = Http::get('https://example.com/api');

$response['missing'];
// Warning: Undefined array key "missing"
```

`offsetExists()` guards with `isset()`, `offsetGet()` doesn't. If the body isn't JSON, `json()` returns `null` and it warns "Trying to access array offset on null", which `HandleExceptions` turns into an `ErrorException`.

`$response->json('missing')` already returns `null` quietly. `Illuminate\Http\Client\Request` has the same problem, so it's fixed too.