### PR TITLE
[13.x] Honor wherePivot() closures in pivot mutations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -105,6 +105,13 @@ class BelongsToMany extends Relation
     protected $pivotWhereNulls = [];
 
     /**
+     * Any pivot table restrictions for closure-based where clauses.
+     *
+     * @var array
+     */
+    protected $pivotWhereClosures = [];
+
+    /**
      * The default values for the pivot columns.
      *
      * @var array
@@ -403,6 +410,8 @@ class BelongsToMany extends Relation
             $column($pivotQuery);
 
             $this->query->getQuery()->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+
+            $this->pivotWhereClosures[] = [$column, $boolean];
 
             return $this;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -682,6 +682,16 @@ trait InteractsWithPivotTable
             $query->whereNull(...$arguments);
         }
 
+        foreach ($this->pivotWhereClosures as [$column, $boolean]) {
+            $pivotQuery = (new ($this->getPivotClass()))
+                ->setTable($this->table)
+                ->newQueryWithoutRelationships();
+
+            $column($pivotQuery);
+
+            $query->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+        }
+
         return $query->where($this->getQualifiedForeignPivotKeyName(), $this->parent->{$this->parentKey});
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
@@ -129,6 +129,61 @@ class DatabaseEloquentBelongsToManyWherePivotClosureTest extends TestCase
         $this->assertEquals($user1->id, $results->first()->id);
     }
 
+    public function testWherePivotWithClosureScopesDetach(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->detach();
+
+        $remaining = $project->subscribers()->get();
+
+        $this->assertCount(1, $remaining);
+        $this->assertTrue($remaining->contains('id', $muted->id));
+    }
+
+    public function testWherePivotWithClosureScopesUpdateExistingPivot(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false, 'role' => 'member']);
+        $project->subscribers()->attach($muted->id, ['muted' => true, 'role' => 'member']);
+
+        $affected = $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->updateExistingPivot($muted->id, ['role' => 'admin']);
+
+        $this->assertSame(0, $affected);
+        $this->assertSame('member', $project->subscribers()->find($muted->id)->pivot->role);
+    }
+
+    public function testWherePivotWithClosureScopesSync(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->sync([]);
+
+        $remaining = $project->subscribers()->get();
+
+        $this->assertTrue($remaining->contains('id', $muted->id));
+        $this->assertFalse($remaining->contains('id', $active->id));
+    }
+
     protected function connection()
     {
         return Eloquent::getConnectionResolver()->connection();


### PR DESCRIPTION
Fixes #61471

`wherePivot()` with a closure only scoped the relation select query. It never recorded the constraint for `newPivotQuery()`, so `detach()`, `sync()`, and `updateExistingPivot()` ran unscoped and could change / delete pivot rows outside the intended filter.

The string form of `wherePivot()` already worked because those clauses are stored in `$pivotWheres`. This records closure scopes the same way and reapplies them in `newPivotQuery()`.

Added regression tests for scoped `detach()`, `updateExistingPivot()`, and `sync()`.