### PR TITLE
Preserve cursor values when transforming cursor paginator items

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -79,6 +79,20 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     protected $cursor;
 
     /**
+     * The cursor that points to the previous set of items.
+     *
+     * @var \Illuminate\Pagination\Cursor|null
+     */
+    protected $previousCursor;
+
+    /**
+     * The cursor that points to the next set of items.
+     *
+     * @var \Illuminate\Pagination\Cursor|null
+     */
+    protected $nextCursor;
+
+    /**
      * The paginator parameters for the cursor.
      *
      * @var array
@@ -166,7 +180,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
             return null;
         }
 
-        return $this->getCursorForItem($this->items->first(), false);
+        return $this->previousCursor ?? $this->getCursorForItem($this->items->first(), false);
     }
 
     /**
@@ -185,7 +199,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
             return null;
         }
 
-        return $this->getCursorForItem($this->items->last(), true);
+        return $this->nextCursor ?? $this->getCursorForItem($this->items->last(), true);
     }
 
     /**
@@ -412,6 +426,9 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function through(callable $callback)
     {
+        $this->previousCursor = $this->previousCursor();
+        $this->nextCursor = $this->nextCursor();
+
         $this->items->transform($callback);
 
         return $this;

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -77,6 +77,21 @@ class CursorPaginatorTest extends TestCase
 
         $this->assertInstanceOf(CursorPaginator::class, $p);
         $this->assertSame([['id' => 6], ['id' => 7]], $p->items());
+        $this->assertSame($this->getCursor(['id' => 5]), $p->nextCursor()->encode());
+    }
+
+    public function testCanTransformPaginatorItemsWhenCursorPointsToPreviousItems()
+    {
+        $cursor = new Cursor(['id' => 6], false);
+        $p = new CursorPaginator([['id' => 5], ['id' => 4], ['id' => 3]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $p->through(fn ($item) => ['name' => 'Item '.$item['id']]);
+
+        $this->assertSame([['name' => 'Item 4'], ['name' => 'Item 5']], $p->items());
+        $this->assertSame($this->getCursor(['id' => 4], false), $p->previousCursor()->encode());
+        $this->assertSame($this->getCursor(['id' => 5]), $p->nextCursor()->encode());
     }
 
     public function testCursorPaginatorOnFirstAndLastPage()


### PR DESCRIPTION
`CursorPaginator::through()` transforms the paginator's item collection in place. Since cursors are currently generated from that transformed collection, changing or removing an ordered column can alter the pagination boundary.

This change captures the previous and next cursors immediately before `through()` transforms the items, keeping cursor pagination based on the original query results while allowing the response shape to change.

For example, transforming page IDs `4` and `5` into `6` and `7` must still produce a next cursor for `5`; otherwise the following query can skip records.

Related to #56510, but requires no additional public API or opt-in.

Tests:

- `vendor/bin/phpunit tests/Pagination/CursorPaginatorTest.php --colors=never`
- `vendor/bin/phpunit tests/Pagination --colors=never`
- `vendor/bin/phpunit tests/Integration/Database/EloquentCursorPaginateTest.php --colors=never`
- `vendor/bin/phpunit tests/Integration/Http/ResourceTest.php --colors=never`
