### PR TITLE
Wrap the autocompleter callback return type in `askWithCompletion()`

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -169,7 +169,7 @@ trait InteractsWithIO
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  iterable|(callable(string): string[])  $choices
+     * @param  iterable|(callable(string): list<string>)  $choices
      * @param  string|null  $default
      * @return mixed
      */


### PR DESCRIPTION
Similar fix to #61444, on a different method.