### PR TITLE
[13.x] Fix wherePivot() closure scope being ignored in pivot table operations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -396,15 +396,20 @@ class BelongsToMany extends Relation
     public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure) {
-            $pivotQuery = $this->newPivotQueryForClosure($column);
+            $pivotQuery = (new ($this->getPivotClass()))
+                ->setTable($this->table)
+                ->newQueryWithoutRelationships();
+
+            $column($pivotQuery);
+
+            $this->pivotWheres[] = [
+                fn ($query) => $query->addNestedWhereQuery($pivotQuery->getQuery()),
+                null,
+                null,
+                $boolean,
+            ];
 
             $this->query->getQuery()->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
-
-            $this->pivotWheres[] = [function ($nestedQuery) use ($column) {
-                $nestedQuery->addNestedWhereQuery(
-                    $this->newPivotQueryForClosure($column)->getQuery()
-                );
-            }, null, null, $boolean];
 
             return $this;
         }
@@ -412,23 +417,6 @@ class BelongsToMany extends Relation
         $this->pivotWheres[] = func_get_args();
 
         return $this->where($this->qualifyPivotColumn($column), $operator, $value, $boolean);
-    }
-
-    /**
-     * Build a new pivot model query with the given closure scope applied.
-     *
-     * @param  \Closure(\Illuminate\Database\Eloquent\Builder<TPivotModel>): mixed  $callback
-     * @return \Illuminate\Database\Eloquent\Builder<TPivotModel>
-     */
-    protected function newPivotQueryForClosure(Closure $callback)
-    {
-        $pivotQuery = (new ($this->getPivotClass()))
-            ->setTable($this->table)
-            ->newQueryWithoutRelationships();
-
-        $callback($pivotQuery);
-
-        return $pivotQuery;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -396,13 +396,15 @@ class BelongsToMany extends Relation
     public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure) {
-            $pivotQuery = (new ($this->getPivotClass()))
-                ->setTable($this->table)
-                ->newQueryWithoutRelationships();
-
-            $column($pivotQuery);
+            $pivotQuery = $this->newPivotQueryForClosure($column);
 
             $this->query->getQuery()->addNestedWhereQuery($pivotQuery->getQuery(), $boolean);
+
+            $this->pivotWheres[] = [function ($nestedQuery) use ($column) {
+                $nestedQuery->addNestedWhereQuery(
+                    $this->newPivotQueryForClosure($column)->getQuery()
+                );
+            }, null, null, $boolean];
 
             return $this;
         }
@@ -410,6 +412,23 @@ class BelongsToMany extends Relation
         $this->pivotWheres[] = func_get_args();
 
         return $this->where($this->qualifyPivotColumn($column), $operator, $value, $boolean);
+    }
+
+    /**
+     * Build a new pivot model query with the given closure scope applied.
+     *
+     * @param  \Closure(\Illuminate\Database\Eloquent\Builder<TPivotModel>): mixed  $callback
+     * @return \Illuminate\Database\Eloquent\Builder<TPivotModel>
+     */
+    protected function newPivotQueryForClosure(Closure $callback)
+    {
+        $pivotQuery = (new ($this->getPivotClass()))
+            ->setTable($this->table)
+            ->newQueryWithoutRelationships();
+
+        $callback($pivotQuery);
+
+        return $pivotQuery;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWherePivotClosureTest.php
@@ -129,6 +129,57 @@ class DatabaseEloquentBelongsToManyWherePivotClosureTest extends TestCase
         $this->assertEquals($user1->id, $results->first()->id);
     }
 
+    public function testWherePivotWithClosureScopesDetach(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->detach();
+
+        $this->assertCount(1, $project->subscribers()->get());
+        $this->assertTrue($project->subscribers()->get()->contains('id', $muted->id));
+    }
+
+    public function testWherePivotWithClosureScopesSync(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false]);
+        $project->subscribers()->attach($muted->id, ['muted' => true]);
+
+        $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->sync([]);
+
+        $this->assertTrue($project->subscribers()->get()->contains('id', $muted->id));
+        $this->assertFalse($project->subscribers()->get()->contains('id', $active->id));
+    }
+
+    public function testWherePivotWithClosureScopesUpdateExistingPivot(): void
+    {
+        $project = WherePivotClosureProject::create(['title' => 'Project 1']);
+        $active = WherePivotClosureUser::create(['name' => 'Active User']);
+        $muted = WherePivotClosureUser::create(['name' => 'Muted User']);
+
+        $project->subscribers()->attach($active->id, ['muted' => false, 'role' => 'member']);
+        $project->subscribers()->attach($muted->id, ['muted' => true, 'role' => 'member']);
+
+        $affected = $project->subscribers()->wherePivot(function ($query) {
+            $query->active();
+        })->updateExistingPivot($muted->id, ['role' => 'admin']);
+
+        $this->assertSame(0, $affected);
+        $this->assertSame('member', $project->subscribers()->find($muted->id)->pivot->role);
+    }
+
     protected function connection()
     {
         return Eloquent::getConnectionResolver()->connection();


### PR DESCRIPTION
Closes #61471. In short, `wherePivot()` accepts a closure in #61150, but the closure branch returns early after merging the nested where into the relation query.. it never records the constraint in `$pivotWheres`. `newPivotQuery()` rebuilds its query from `$pivotWheres` only, so every method that goes through it runs completely unscoped: `detach()`, `updateExistingPivot()`, `newPivotStatementForId()`, and `sync()` (via `getCurrentlyAttachedPivots()`).. which means silently touching pivot rows **outside the closure's intended scope**, making it a **data-loss** bug. 
I've described this in more detail in the issue post #61471.

### Changes I made

This PR records the already-built pivot query into `$pivotWheres`, so `newPivotQuery()` can replay it.. it matches what the string form (`wherePivot('col', val)`) already does. 

Added 3 tests for `detach()`, `sync()`, and `updateExistingPivot()` with a closure scope.

Note: I stored it in `pivotWheres`, coz `newPivotQuery()` already replays every entry in `pivotWheres` via `$query->where(...$args)`, and `where()` natively treats a `Closure` argument as a nested where group. So a closure scope just slots into that same mechanism instead of needing its own storage array and its own replay loop. 
The stored closure just **replays the already-built pivot query** (it is built once, when `wherePivot()` was called) into whatever query `newPivotQuery()` hands it.

This PR is a retried version of the fix, I earlier submitted a fix for this and that approach didnt get merged (I guess that wasn't much suitable probably), that's why here I am re-PR-ing it with an updated approach with less changes made. hope it can solve the issue better.

Note that this PR desp and all the changes I made is **not AI-written and reviewed carefully**. so if any further modification needed in this approach or any better approach/suggestion u have in mind for this issue, kindly let me know so I can address it better way making the necessary changes, @taylorotwell. thank you. 