### PR TITLE
[13.x] Fix `LazyCollection::take()` with a negative limit larger than the collection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1572,8 +1572,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $position = ($position + 1) % $limit;
                 }
 
-                for ($i = 0, $end = min($limit, count($ringBuffer)); $i < $end; $i++) {
-                    $pointer = ($position + $i) % $limit;
+                $oldest = count($ringBuffer) === $limit ? $position : 0;
+
+                for ($i = 0, $end = count($ringBuffer); $i < $end; $i++) {
+                    $pointer = ($oldest + $i) % $limit;
                     yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
                 }
             });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2860,6 +2860,24 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testTakeLastWhenTheLimitExceedsTheCollectionSize($collection)
+    {
+        $data = new $collection(['taylor', 'dayle', 'shawn']);
+
+        $this->assertEquals([0 => 'taylor', 1 => 'dayle', 2 => 'shawn'], $data->take(-3)->all());
+        $this->assertEquals([0 => 'taylor', 1 => 'dayle', 2 => 'shawn'], $data->take(-4)->all());
+        $this->assertEquals([0 => 'taylor', 1 => 'dayle', 2 => 'shawn'], $data->take(-100)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testTakeLastPreservesKeysWhenTheLimitExceedsTheCollectionSize($collection)
+    {
+        $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
+
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->take(-5)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testTakeUntilUsingValue($collection)
     {
         $data = new $collection([1, 2, 3, 4]);


### PR DESCRIPTION
`take()` with a negative limit returns the last `$limit` items. `LazyCollection` implements this with a circular buffer so it does not have to hold the whole collection in memory, but the buffer is read back incorrectly when it never filled up.

```php
(new Collection(['a', 'b', 'c']))->take(-5);     // ['a', 'b', 'c']
(new LazyCollection(['a', 'b', 'c']))->take(-5); // ['' => null, 0 => 'a']
```

The `LazyCollection` result also emits two warnings per missing slot:

```
Warning: Undefined array key 3 in .../LazyCollection.php on line 1577
Warning: Trying to access array offset on null in .../LazyCollection.php on line 1577
```

## Cause

After the write loop, `$position` is the next slot to write to, which is the oldest item **only once the buffer has wrapped around**. While the buffer is still partially filled, the oldest item is at index `0` and `$position` is equal to the number of items written, so it points just past the filled region:

```php
for ($i = 0, $end = min($limit, count($ringBuffer)); $i < $end; $i++) {
    $pointer = ($position + $i) % $limit;
    yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
}
```

With three items and a limit of five, the loop reads slots `3`, `4`, `0` instead of `0`, `1`, `2`: two slots were never written, and `'b'` and `'c'` are never yielded. Because the unwritten slots are `null`, `$ringBuffer[$pointer][0]` is also `null`, so the first yielded key is `null` (which becomes `''`) with a `null` value.

This is silent data loss rather than an error: the collection keeps the right count in some cases but the wrong contents, and any `null` key collapses earlier entries.

## Fix

Start reading at index `0` while the buffer is still partially filled, and iterate over what was actually written:

```php
$oldest = count($ringBuffer) === $limit ? $position : 0;

for ($i = 0, $end = count($ringBuffer); $i < $end; $i++) {
    $pointer = ($oldest + $i) % $limit;
```

`min($limit, count($ringBuffer))` becomes redundant because `count($ringBuffer)` never exceeds `$limit`.

The write loop is untouched, so the memory characteristics are unchanged — the buffer still holds at most `abs($limit)` items.

## Scope

Only the partially filled case changes. Once `abs($limit) <= count()`, the buffer has wrapped, `count($ringBuffer) === $limit`, and `$oldest` is `$position` exactly as before. `take(0)` and positive limits do not reach this branch at all. After the fix `LazyCollection` matches `Collection` for every combination of collection size and negative limit, keys included.

## Tests

Two cases were added to `SupportCollectionTest`, both on the existing `collectionClassProvider` so they run against `Collection` and `LazyCollection`:

- `testTakeLastWhenTheLimitExceedsTheCollectionSize` — limits equal to, one past, and far past the collection size.
- `testTakeLastPreservesKeysWhenTheLimitExceedsTheCollectionSize` — string keys survive.

Both fail on `LazyCollection` before this change and pass after; the `Collection` variants pass either way. The existing `testTakeLast` covers the wrapped path and is unaffected.

The gap was easy to miss: `testTakeLast` uses `take(-2)` on three items, so it only ever exercised a buffer that had already wrapped.
