### PR TITLE
[13.x] Recycle model instances provided to factory for()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -758,7 +758,9 @@ abstract class Factory
      */
     public function for($factory, $relationship = null)
     {
-        return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
+        $instance = $factory instanceof Model ? $this->recycle($factory) : $this;
+
+        return $instance->newInstance(['for' => $instance->for->concat([new BelongsToRelationship(
             $factory,
             $relationship ?? Str::camel(class_basename(
                 $factory instanceof Factory ? $factory->modelName() : $factory

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -885,6 +885,24 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(1, FactoryTestUser::count());
     }
 
+    public function test_for_method_with_model_instance_recycles_to_nested_factories()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $user = FactoryTestUserFactory::new()->create();
+        $post = FactoryTestPostFactory::new()
+            ->for($user, 'user')
+            ->hasComments(2)
+            ->create();
+
+        $this->assertSame(1, FactoryTestUser::count());
+        $this->assertEquals($user->id, $post->user_id);
+        $this->assertEquals($user->id, $post->comments[0]->user_id);
+        $this->assertEquals($user->id, $post->comments[1]->user_id);
+    }
+
     public function test_has_method_does_not_reassign_the_parent()
     {
         Factory::guessFactoryNamesUsing(function ($model) {


### PR DESCRIPTION
Fixes #58835.

When passing an existing model instance to `for()`, nested factories (like child models created via `has()`) don't know about it and end up creating duplicate parent models instead of reusing the one that was passed in.

This automatically adds the model to the factory's recycle pool when `for()` is called with a `Model` instance. That way any nested factories in the definition or child relationships reuse it directly.

Before:
```php
$user = User::factory()->create();

// Post factory has many comments, and Comment factory definition has 'user_id' => User::factory()
$post = Post::factory()->for($user)->hasComments(2)->create();

User::count(); // 3
```

After:
```php
User::count(); // 1
```

Tested:
- `vendor/bin/phpunit --filter="test_for_method_with_model_instance_recycles_to_nested_factories" tests/Database/DatabaseEloquentFactoryTest.php`
- `vendor/bin/phpunit tests/Database/DatabaseEloquentFactoryTest.php`
- `vendor/bin/pint src/Illuminate/Database/Eloquent/Factories/Factory.php tests/Database/DatabaseEloquentFactoryTest.php --test`
