### PR TITLE
[13.x] Fix contains/doesnt_contain validation rules using inconsistent comparison strictness

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -571,7 +571,9 @@ trait ValidatesAttributes
             return false;
         }
 
-        return array_all($parameters, fn ($parameter) => in_array($parameter, $value));
+        $value = array_map(fn ($item) => is_scalar($item) ? (string) $item : $item, $value);
+
+        return array_all($parameters, fn ($parameter) => in_array($parameter, $value, true));
     }
 
     /**
@@ -587,6 +589,8 @@ trait ValidatesAttributes
         if (! is_array($value)) {
             return false;
         }
+
+        $value = array_map(fn ($item) => is_scalar($item) ? (string) $item : $item, $value);
 
         return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value, true));
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -571,9 +571,11 @@ trait ValidatesAttributes
             return false;
         }
 
-        $value = array_map(fn ($item) => is_scalar($item) ? (string) $item : $item, $value);
+        $stringify = fn ($item) => is_scalar($item) ? (string) $item : $item;
 
-        return array_all($parameters, fn ($parameter) => in_array($parameter, $value, true));
+        $value = array_map($stringify, $value);
+
+        return array_all($parameters, fn ($parameter) => in_array($stringify($parameter), $value, true));
     }
 
     /**
@@ -590,9 +592,11 @@ trait ValidatesAttributes
             return false;
         }
 
-        $value = array_map(fn ($item) => is_scalar($item) ? (string) $item : $item, $value);
+        $stringify = fn ($item) => is_scalar($item) ? (string) $item : $item;
 
-        return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value, true));
+        $value = array_map($stringify, $value);
+
+        return array_all($parameters, fn ($parameter) => ! in_array($stringify($parameter), $value, true));
     }
 
     /**

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Fixtures/Enums.php';
@@ -86,6 +87,28 @@ class ValidationRuleContainsTest extends TestCase
 
         // Test with nullable field
         $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::contains('admin')]]);
+        $this->assertTrue($v->passes());
+    }
+
+    #[TestWith([['0e123'], false])]
+    #[TestWith([['0'], true])]
+    public function testContainsRuleDoesNotUseLooseComparisons(array $value, bool $expectation)
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => $value], ['x' => ['contains:0']]);
+
+        $this->assertSame($expectation, $v->passes());
+    }
+
+    public function testContainsRuleMatchesNonStringScalarValues()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['flags' => [true]], ['flags' => 'contains:1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['flags' => [1]], ['flags' => 'contains:1']);
         $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -111,4 +111,23 @@ class ValidationRuleContainsTest extends TestCase
         $v = new Validator($trans, ['flags' => [1]], ['flags' => 'contains:1']);
         $this->assertTrue($v->passes());
     }
+
+    public function testContainsRuleMatchesNonStringScalarParametersFromArraySyntax()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['flags' => [1]], ['flags' => [['contains', 1]]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['flags' => [true]], ['flags' => [['contains', true]]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testContainsRuleDoesNotThrowForNonScalarParameter()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['roles' => ['admin']], ['roles' => [['contains', ['admin']]]]);
+        $this->assertTrue($v->fails());
+    }
 }

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -111,4 +111,23 @@ class ValidationRuleDoesntContainTest extends TestCase
         $v = new Validator($trans, ['flags' => [1]], ['flags' => 'doesnt_contain:1']);
         $this->assertTrue($v->fails());
     }
+
+    public function testDoesntContainRuleMatchesNonStringScalarParametersFromArraySyntax()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['flags' => [1]], ['flags' => [['doesnt_contain', 1]]]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['flags' => [true]], ['flags' => [['doesnt_contain', true]]]);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testDoesntContainRuleDoesNotThrowForNonScalarParameter()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['roles' => ['admin']], ['roles' => [['doesnt_contain', ['admin']]]]);
+        $this->assertTrue($v->passes());
+    }
 }

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -100,4 +100,15 @@ class ValidationRuleDoesntContainTest extends TestCase
 
         $this->assertSame($expectation, $v->passes());
     }
+
+    public function testDoesntContainRuleMatchesNonStringScalarValues()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['flags' => [true]], ['flags' => 'doesnt_contain:1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['flags' => [1]], ['flags' => 'doesnt_contain:1']);
+        $this->assertTrue($v->fails());
+    }
 }


### PR DESCRIPTION
Closes #61491: `contains` was using loose `in_array()` while `doesnt_contain` used strict. they're supposed to be logical opposites, but this inconsistency let both pass on the same input - e.g. `flags => [true]` with `contains:1` and `doesnt_contain:1` both pass, because `"1" == true` loosely but `"1" !== true` strictly ([ValidatesAttributes.php](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Validation/Concerns/ValidatesAttributes.php): L568-L591). kindly check the issue #61491, I've added more detailed report there.

This was actually fixed once (#61318 made `doesnt_contain` strict, #61320 tried the same for `contains`) but #61320 got reverted later. because going strict without normalizing types broke matches like `[1]` (int) against `contains:1` (string param).

### Changes I made

in this fix, I've normalize the array values and the rule params to strings, and then compare strictly.. like `in` rule already uses (#61146 by @crynobone). This closes the gap which #61320 hit, while keeping the strict comparison that #61318 needed (numeric-string collisions like `'0e123'` vs `0` stay correctly non-matching).

Added tests covering: numeric-string edge cases (`'0e123'` vs `0`) staying non-matching for both rules, non-string-scalar values matching via string-syntax, the same via array-rule syntax (`['contains', 1]`) - since that path hands parameters without string-casting them, unlike string-rule syntax, non-scalar params (e.g. an array) failing gracefully instead of throwing.

Possible breaking change after this fix: normalizing values to strings means a few loose-comparison matches that worked before, now won't work:
- `[false]` with `contains:0` - used to pass (`false == "0"`), now fails (`(string) false` is `""`, not `"0"`)
- `[1.0]` with `contains:1.0` - used to pass, now fails on format mismatch unless the param string matches PHP's exact float-to-string output

Both are edge cases that only worked before because of the **loose-comparison bug** this PR fixes - anyone relying on them was actually relying on an **inconsistency** between two rules that are documented as opposites. this PR just fixes the bug. and the alternative (leaving `contains` and `doesnt_contain` able to both pass on the same input) is a worse correctness bug than losing this narrow edge-case match. 

Still, if this looks problematic to merge into `13.x`, I can submit this for the `master` also. please let me know which one is preferable.

Note: this PR desp and all the changes I made is not AI-made and I've tested+reviewed my changes carefully. so if any further modification needed in this approach or any better approach/suggestion u have in mind for this issue, kindly let me know. thank you.