### PR TITLE
[13.x] Fix `doesnt_contain` validation rule ignoring non-string values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -588,6 +588,8 @@ trait ValidatesAttributes
             return false;
         }
 
+        $value = array_map(strval(...), array_filter($value, is_scalar(...)));
+
         return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value, true));
     }
 

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -100,4 +100,18 @@ class ValidationRuleDoesntContainTest extends TestCase
 
         $this->assertSame($expectation, $v->passes());
     }
+
+    #[TestWith([[1], false])]
+    #[TestWith([[1.0], false])]
+    #[TestWith([[true], false])]
+    #[TestWith([['1'], false])]
+    #[TestWith([[2], true])]
+    public function testDoesntContainRuleMatchesValuesThatAreNotStrings(array $value, bool $expectation)
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => $value], ['x' => ['doesnt_contain:1']]);
+
+        $this->assertSame($expectation, $v->passes());
+    }
 }


### PR DESCRIPTION
#61318 switched `doesnt_contain` to a strict `in_array()` comparison, but rule parameters always arrive as strings while the validated array can hold integers, floats or booleans. `doesnt_contain:1` therefore passes for `['flags' => [1]]` and lets the prohibited value through, and the same input can satisfy `contains:1` and `doesnt_contain:1` at the same time.

This casts the scalar values to string before the strict comparison, the same way #61146 did for the `in` rule. Exact string matches and the `0e123` bypass that #61318 closed both keep their current behavior.

Fixes #61491.
