### PR TITLE
[13.x] Respect the query's table alias in relationship subqueries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -376,7 +376,7 @@ class Builder implements BuilderContract
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure && is_null($operator)) {
-            $column($query = $this->model->newQueryWithoutRelationships());
+            $column($query = $this->model->newQueryWithoutRelationships()->from($this->query->from));
 
             $this->eagerLoad = array_merge($this->eagerLoad, $query->getEagerLoads());
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -854,7 +854,7 @@ trait QueriesRelationships
         }
 
         if (is_null($this->query->columns)) {
-            $this->query->select([$this->query->from.'.*']);
+            $this->query->select([($this->getTableAlias() ?? $this->query->from).'.*']);
         }
 
         $relations = is_array($relations) ? $relations : [$relations];

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -241,7 +241,7 @@ class BelongsTo extends Relation
         }
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedForeignKeyName(), '=', $query->qualifyColumn($this->ownerKey)
+            $parentQuery->qualifyColumn($this->getQualifiedForeignKeyName()), '=', $query->qualifyColumn($this->ownerKey)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -702,7 +702,7 @@ abstract class HasOneOrManyThrough extends Relation
         $this->performJoin($query);
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedLocalKeyName(), '=', $this->getQualifiedFirstKeyName()
+            $parentQuery->qualifyColumn($this->getQualifiedLocalKeyName()), '=', $this->getQualifiedFirstKeyName()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -339,7 +339,7 @@ abstract class Relation implements BuilderContract
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedParentKeyName(), '=', $this->getExistenceCompareKey()
+            $parentQuery->qualifyColumn($this->getQualifiedParentKeyName()), '=', $this->getExistenceCompareKey()
         );
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1098,6 +1098,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $nestedQuery = Mockery::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedQuery->expects('from')->andReturnSelf();
         $nestedQuery->expects('getQuery')->andReturn($nestedRawQuery);
         $nestedQuery->expects('getEagerLoads')->andReturn([]);
         $nestedQuery->expects('removedScopes')->andReturn([]);
@@ -1161,6 +1162,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $nestedQuery = Mockery::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedQuery->expects('from')->andReturnSelf();
         $nestedQuery->expects('getQuery')->andReturn($nestedRawQuery);
         $nestedQuery->expects('getEagerLoads')->andReturn([]);
         $nestedQuery->expects('removedScopes')->andReturn([]);
@@ -1191,6 +1193,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $nestedQuery = Mockery::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedQuery->expects('from')->andReturnSelf();
         $nestedQuery->expects('getQuery')->andReturn($nestedRawQuery);
         $nestedQuery->expects('getEagerLoads')->andReturn([]);
         $nestedQuery->expects('removedScopes')->andReturn([]);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -210,6 +210,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
         $builder->expects('select')->with(Mockery::type(Expression::class))->andReturnSelf();
         $relation->getParent()->expects('qualifyColumn')->andReturn('table.id');
+        $builder->expects('qualifyColumn')->with('table.id')->andReturn('table.id');
         $builder->expects('whereColumn')->with('table.id', '=', 'table.foreign_key')->andReturn($baseQuery);
         $baseQuery->expects('setBindings')->with([], 'select');
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1402,6 +1402,42 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('Child Post', $results->first()->name);
     }
 
+    public function testWhereHasRespectsTheQueryTableAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+        EloquentTestPost::create(['name' => 'First Post', 'user_id' => $user->id]);
+
+        $results = EloquentTestUser::from('users as u')->whereHas('posts')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
+    }
+
+    public function testWithCountRespectsTheQueryTableAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+        EloquentTestPost::create(['name' => 'First Post', 'user_id' => $user->id]);
+
+        $results = EloquentTestUser::from('users as u')->withCount('posts')->orderBy('id')->get();
+
+        $this->assertEquals([1, 0], $results->pluck('posts_count')->all());
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
+    }
+
+    public function testWhereHasOnBelongsToRespectsTheQueryTableAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        EloquentTestPost::create(['name' => 'First Post', 'user_id' => $user->id]);
+        EloquentTestPost::create(['name' => 'Orphan Post', 'user_id' => 0]);
+
+        $results = EloquentTestPost::from('posts as p')->whereHas('user')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('First Post', $results->first()->name);
+    }
+
     public function testAggregatedValuesOfDatetimeField()
     {
         EloquentTestUser::insert([

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1438,6 +1438,33 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('First Post', $results->first()->name);
     }
 
+    public function testWhereHasInsideNestedWhereRespectsTheQueryTableAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+        EloquentTestPost::create(['name' => 'First Post', 'user_id' => $user->id]);
+
+        $results = EloquentTestUser::from('users as u')->where(function ($query) {
+            $query->whereHas('posts');
+        })->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
+    }
+
+    public function testWhereHasMorphRespectsTheQueryTableAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $post = EloquentTestPost::create(['name' => 'First Post', 'user_id' => $user->id]);
+        $post->photos()->create(['name' => 'photo.jpg']);
+        EloquentTestPhoto::create(['name' => 'orphan.jpg', 'imageable_id' => 0, 'imageable_type' => EloquentTestPost::class]);
+
+        $results = EloquentTestPhoto::from('photos as p')->whereHasMorph('imageable', [EloquentTestPost::class])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('photo.jpg', $results->first()->name);
+    }
+
     public function testAggregatedValuesOfDatetimeField()
     {
         EloquentTestUser::insert([


### PR DESCRIPTION
When an Eloquent query aliases its table, `whereHas()`, `has()`, `withCount()` and `whereHasMorph()` build subqueries that reference the parent model's table name instead of the alias. The database cannot resolve that column, so the query fails.

```php
EloquentTestUser::from('users as u')->whereHas('posts')->get();
// select * from "users" as "u" where exists (
//     select * from "posts" where "users"."id" = "posts"."user_id"
// )
// SQLSTATE[HY000]: no such column: users.id
```

`withCount()` fails the same way, and additionally mangles its wildcard select:

```php
EloquentTestUser::from('users as u')->withCount('posts')->get();
// select "users" as "u.*", (select count(*) from "posts" where "users"."id" = ...) ...
```

There are two independent causes.

## 1. The outer column was qualified through the model

A relationship existence query compares a column from the subquery against a column from the **outer** query. The outer column was qualified through the parent *model*:

```php
return $query->select($columns)->whereColumn(
    $this->getQualifiedParentKeyName(), '=', $this->getExistenceCompareKey()
);
```

`getQualifiedParentKeyName()` resolves to `$this->parent->qualifyColumn(...)`, and a model only knows its own table, so the alias on the query is never taken into account.

The outer column is now qualified through `$parentQuery`. `Eloquent\Builder::qualifyColumn()` already resolves the query's alias and returns an already-qualified column untouched, so this is a no-op unless the query actually carries an alias:

```php
$parentQuery->qualifyColumn($this->getQualifiedParentKeyName())
```

`BelongsTo` already qualified its inner column through `$query`, so this follows the pattern that was already there. The same change is applied to the three places that qualify an outer column:

- `Relation::getRelationExistenceQuery()` — covers `HasOne`, `HasMany`, `MorphOne`, `MorphMany` and the `ofMany` variants
- `BelongsTo::getRelationExistenceQuery()`
- `HasOneOrManyThrough::getRelationExistenceQuery()`

`BelongsToMany` and `MorphToMany` already resolved correctly and are unchanged.

Separately, `withAggregate()` built its wildcard select by string concatenation on the raw `from` clause:

```php
$this->query->select([$this->query->from.'.*']);
```

With `from` set to `users as u` that produces the column `users as u.*`, which the grammar then reads as a table with the alias `u.*`. It now uses the alias when one is present, and keeps using the `from` clause otherwise, so a query reading from a table other than the model's own is unaffected.

## 2. Nested where closures dropped the from clause

Fixing the qualification is not enough, because a closure passed to `where()` received a query built from the model:

```php
$column($query = $this->model->newQueryWithoutRelationships());
```

The nested builder therefore read from the model's table and lost the alias, so any relationship subquery built inside the closure qualified against the wrong table again:

```php
EloquentTestUser::from('users as u')->where(fn ($q) => $q->whereHas('posts'));
// ... where (exists (select * from "posts" where "users"."id" = "posts"."user_id"))
```

`Query\Builder::forNestedWhere()` already carries the from clause into the nested query, so the nested Eloquent builder now does the same. This also covers `whereNot()` and `orWhereNot()`, which delegate to `where()`, and `whereHasMorph()`, which wraps each type in a nested closure.

## Scope

Nothing changes for queries without an alias: `qualifyColumn()` returns the qualified name it was given, the wildcard select falls back to the `from` clause, and the nested query receives the from clause it would have built anyway. Only aliased queries, which currently produce unresolvable SQL, take a different path.

Self-referencing relationships are worth calling out, since the self-relation branch is chosen by comparing the two from clauses. `whereHas()` on a self-referencing `BelongsTo` and `HasMany` returns the same rows with and without an alias, both called directly and inside a nested closure.

## Tests

Five integration tests were added to `DatabaseEloquentIntegrationTest`, covering `whereHas()` on a `HasMany`, `withCount()` (which also exercises the wildcard select), `whereHas()` on a `BelongsTo`, `whereHas()` inside a nested `where()` closure, and `whereHasMorph()`. All five fail on the current branch with the SQL shown above.

Four existing tests mock the builder and assert the exact calls made, so they needed expectations for the calls this change adds — `qualifyColumn()` on the parent query in `DatabaseEloquentHasOneTest::testRelationCountQueryCanBeBuilt`, and `from()` on the nested query in `DatabaseEloquentBuilderTest::testNestedWhere`, `testWhereNot` and `testOrWhereNot`. The arguments those tests assert are unchanged.
