### PR TITLE
[13.x] Avoid rebuilding the key collection on every element in `chunkBy()`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -938,9 +938,13 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($key);
 
-        return $this->chunkWhile(
-            fn ($value, $key, $chunk) => $callback($value, $key) == $callback($chunk->last(), $chunk->keys()->last())
-        );
+        return $this->chunkWhile(function ($value, $key, $chunk) use ($callback) {
+            $items = $chunk->all();
+
+            $lastKey = array_key_last($items);
+
+            return $callback($value, $key) == $callback($items[$lastKey], $lastKey);
+        });
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2496,6 +2496,18 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testChunkByPassesTheKeyToTheCallback($collection)
+    {
+        $data = (new $collection(['a1' => 1, 'a2' => 2, 'b1' => 3, 'b2' => 4, 'a3' => 5]))
+            ->chunkBy(fn ($value, $key) => $key[0]);
+
+        $this->assertCount(3, $data);
+        $this->assertEquals(['a1' => 1, 'a2' => 2], $data->first()->toArray());
+        $this->assertEquals(['b1' => 3, 'b2' => 4], $data->get(1)->toArray());
+        $this->assertEquals(['a3' => 5], $data->last()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testChunkByWithDotNotation($collection)
     {
         $data = (new $collection([


### PR DESCRIPTION
`chunkBy()` compares each element against the last element of the chunk being built, and it resolved that element's key with `$chunk->keys()->last()`:

```php
return $this->chunkWhile(
    fn ($value, $key, $chunk) => $callback($value, $key) == $callback($chunk->last(), $chunk->keys()->last())
);
```

`keys()` allocates a new collection holding every key in the chunk, and it runs once per element examined. While a chunk keeps growing, that work grows with it, so a collection that groups into one long run is quadratic rather than linear.

## Measurements

Grouping a collection whose values are all equal, so the chunk grows to the full length. Same machine, PHP 8.4:

| N | before | after | |
|---|---|---|---|
| 5,000 | 0.025s | 0.002s | x15 |
| 20,000 | 0.278s | 0.006s | x43 |
| 50,000 | 1.686s | 0.016s | x103 |
| 100,000 | 19.790s | 0.034s | x590 |

Doubling the input multiplied the runtime by roughly 3.2 to 3.7 before, and by roughly 2.0 after.

Collections that group into many short chunks were never quadratic, since the chunk stays small. They still improve, from about 510k to about 750k elements per second, because the per-element allocation is gone.

## Change

The chunk's items are read once and the previous key comes from `array_key_last()`:

```php
return $this->chunkWhile(function ($value, $key, $chunk) use ($callback) {
    $items = $chunk->all();

    $lastKey = array_key_last($items);

    return $callback($value, $key) == $callback($items[$lastKey], $lastKey);
});
```

The comparison is unchanged, including the loose `==`. `$chunk` is seeded with the first element before `chunkWhile()` invokes the callback, so it is never empty here and `array_key_last()` always returns a key that exists. `all()` returns the underlying array, and it is only read, so no copy is made.

## Tests

The four existing `chunkBy()` tests pass unchanged on both `Collection` and `LazyCollection`.

I also compared the old and new implementations directly across 88 combinations of dataset and callback — runs, associative and sparse keys, nulls, values that compare loosely equal such as `0`/`'0'`/`false`/`null` and `'1e2'`/`'100'`, dot-notation keys, and a 50-element single run — on both classes. The output is identical in every case.

One test is added. The existing tests cover callbacks taking only the value, string keys and dot notation, but none passes a callback that reads the `$key` argument, which is the value this change moves. `testChunkByPassesTheKeyToTheCallback` covers it. It passes before and after, since this is a coverage gap rather than a behaviour change.
