### PR TITLE
[13.x] Add `freshForUpdate()` method to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2087,9 +2087,42 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return;
         }
 
-        return $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+        return $this->freshUsingQuery(
+            $this->newQueryWithoutScopes(),
+            is_string($with) ? func_get_args() : $with
+        );
+    }
+
+    /**
+     * Reload a fresh model instance from the database while locking it for updating.
+     *
+     * @param  array|string  $with
+     * @return static|null
+     */
+    public function freshForUpdate($with = [])
+    {
+        if (! $this->exists) {
+            return;
+        }
+
+        return $this->freshUsingQuery(
+            $this->newQueryWithoutScopes()->lockForUpdate(),
+            is_string($with) ? func_get_args() : $with
+        );
+    }
+
+    /**
+     * Reload a fresh model instance using the given query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @param  array  $with
+     * @return static|null
+     */
+    protected function freshUsingQuery(Builder $query, array $with = [])
+    {
+        return $this->setKeysForSelectQuery($query)
             ->useWritePdo()
-            ->with(is_string($with) ? func_get_args() : $with)
+            ->with($with)
             ->first();
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2190,6 +2190,42 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNull($freshNotStoredUser);
     }
 
+    public function testFreshForUpdateMethodOnModel()
+    {
+        $user = EloquentTestUser::create([
+            'id' => 1,
+            'email' => 'taylorotwell@gmail.com',
+        ]);
+
+        EloquentTestPost::create([
+            'user_id' => 1,
+            'name' => 'First Post',
+        ]);
+
+        EloquentTestUser::whereKey($user)->update(['name' => 'Abigail Otwell']);
+
+        $fresh = EloquentTestUser::resolveConnection()->transaction(function () use ($user) {
+            return $user->freshForUpdate();
+        });
+
+        $this->assertNotSame($user, $fresh);
+        $this->assertSame('Abigail Otwell', $fresh->name);
+        $this->assertNull($user->name);
+        $this->assertFalse($fresh->relationLoaded('posts'));
+
+        $freshWithRelations = EloquentTestUser::resolveConnection()->transaction(function () use ($user) {
+            return $user->freshForUpdate('posts');
+        });
+
+        $this->assertNotSame($user, $freshWithRelations);
+        $this->assertSame('Abigail Otwell', $freshWithRelations->name);
+        $this->assertTrue($freshWithRelations->relationLoaded('posts'));
+        $this->assertCount(1, $freshWithRelations->posts);
+
+        $notStoredUser = new EloquentTestUser(['id' => 2]);
+        $this->assertNull($notStoredUser->freshForUpdate());
+    }
+
     public function testFreshMethodOnCollection()
     {
         EloquentTestUser::insert([['id' => 1, 'email' => 'taylorotwell@gmail.com'], ['id' => 2, 'email' => 'taylorotwell@gmail.com']]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -745,6 +745,29 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('Abigail', $model->getOriginal('name'));
     }
 
+    public function testFreshForUpdateUsesLockForUpdate()
+    {
+        $model = Mockery::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->setRawAttributes(['id' => 1, 'name' => 'Taylor'], true);
+
+        $freshModel = new EloquentModelStub;
+        $freshModel->setRawAttributes(['id' => 1, 'name' => 'Abigail']);
+
+        $query = Mockery::mock(Builder::class);
+        $model->expects('newQueryWithoutScopes')->once()->andReturn($query);
+        $query->expects('lockForUpdate')->once()->andReturnSelf();
+        $query->expects('where')->once()->with('id', '=', 1)->andReturnSelf();
+        $query->expects('useWritePdo')->once()->andReturnSelf();
+        $query->expects('with')->once()->with([])->andReturnSelf();
+        $query->expects('first')->once()->andReturn($freshModel);
+
+        $result = $model->freshForUpdate();
+
+        $this->assertSame($freshModel, $result);
+        $this->assertSame('Taylor', $model->name);
+    }
+
     public function testDestroyMethodCallsQueryBuilderCorrectly()
     {
         EloquentModelDestroyStub::destroy(1, 2, 3);


### PR DESCRIPTION
Following the addition of `refreshForUpdate()` in #61247, this PR introduces `freshForUpdate()` to Eloquent models as a `fresh()` counterpart.

Because `refreshForUpdate()` automatically re-loads all currently loaded relationships on the model, obtaining a fresh, locked instance without carrying over or re-querying those relations currently requires writing `$model->unsetRelations()->refreshForUpdate()` or falling back to manual queries like `Model::query()->lockForUpdate()->find(...)`.

`freshForUpdate()` provides a clean shorthand that starts with an empty relations state (or only the relations explicitly requested):

```php
// Before:
$order->unsetRelations()->refreshForUpdate();
// or:
$order = Order::query()->lockForUpdate()->find($order->id);

// After:
$order = $order->freshForUpdate();
// Or eager-loading only what you need:
$order = $order->freshForUpdate('items');
```