### PR TITLE
[13.x] Fix query string ? encoding regression introduced in v12.69.2

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -378,7 +378,7 @@ class RouteUrlGenerator
     protected function encodeParameter($value)
     {
         return is_string($value) || $value instanceof Stringable
-            ? strtr((string) $value, ['%' => '%25', '?' => '%3F', '#' => '%23'])
+            ? str_replace('%', '%25', (string) $value)
             : $value;
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -800,6 +800,24 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/1', $url->route('foo', ['bar' => 1]));
     }
 
+    public function testQueryStringDelimitersAreNotEncodedInRouteUrls()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
+        $routes->add(new Route(['GET'], 'page/{id}', ['as' => 'page', function () {
+            //
+        }]));
+
+        // Query string ? and & must not be percent-encoded in the final URL
+        $this->assertSame('http://www.foo.com/page/99?q=foo&size=all', $url->route('page', ['id' => 99, 'q' => 'foo', 'size' => 'all']));
+
+        // A ? that is part of a query param value should be encoded
+        $this->assertSame('http://www.foo.com/page/99?q=foo%3Fbar', $url->route('page', ['id' => 99, 'q' => 'foo?bar']));
+    }
+
     public function testSignedUrl()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Fixes #61499.

The `encodeParameter()` method added in #61475 was encoding `?` → `%3F` and `#` → `%23` inside route parameter values. However, those two characters are already in the `$dontEncode` map, so after `rawurlencode()` runs on the full URI they get decoded back anyway — meaning the pre-encoding of `?` was having no effect on path segments but was causing the query string delimiter `?` to end up as `%3F` in certain circumstances.

The only character that actually needs pre-encoding is `%`, since a raw `%` in a parameter value would otherwise be treated as the start of an already-encoded sequence. `?` and `#` don't need it.

Removed `?` and `#` from `encodeParameter()` and added a regression test.