### PR TITLE
[13.x] Fix `assertDownload()` for non-ASCII filenames 

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -26,6 +26,7 @@ use Illuminate\Testing\TestResponseAssert as PHPUnit;
 use LogicException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -452,7 +453,9 @@ class TestResponse implements ArrayAccess
      */
     public function assertDownload($filename = null)
     {
-        $contentDisposition = explode(';', $this->headers->get('content-disposition', ''));
+        $header = $this->headers->get('content-disposition', '');
+
+        $contentDisposition = explode(';', $header);
 
         if (trim($contentDisposition[0]) !== 'attachment') {
             PHPUnit::withResponse($this)->fail(
@@ -463,7 +466,7 @@ class TestResponse implements ArrayAccess
 
         if (! is_null($filename)) {
             if (isset($contentDisposition[1]) &&
-                trim(explode('=', $contentDisposition[1])[0]) !== 'filename') {
+                ! in_array(trim(explode('=', $contentDisposition[1])[0]), ['filename', 'filename*'])) {
                 PHPUnit::withResponse($this)->fail(
                     'Unsupported Content-Disposition header provided.'.PHP_EOL.
                     'Disposition ['.trim(explode('=', $contentDisposition[1])[0]).'] found in header, [filename] expected.'
@@ -475,11 +478,9 @@ class TestResponse implements ArrayAccess
             if (! isset($contentDisposition[1])) {
                 PHPUnit::withResponse($this)->fail($message);
             } else {
-                PHPUnit::withResponse($this)->assertSame(
+                PHPUnit::withResponse($this)->assertContains(
                     $filename,
-                    isset(explode('=', $contentDisposition[1])[1])
-                        ? trim(explode('=', $contentDisposition[1])[1], " \"'")
-                        : '',
+                    $this->contentDispositionFilenames($header),
                     $message
                 );
 
@@ -490,6 +491,33 @@ class TestResponse implements ArrayAccess
 
             return $this;
         }
+    }
+
+    /**
+     * Get the filenames declared by the given Content-Disposition header.
+     *
+     * @param  string  $header
+     * @return array
+     */
+    protected function contentDispositionFilenames($header)
+    {
+        $parameters = HeaderUtils::combine(array_slice(HeaderUtils::split($header, ';='), 1));
+
+        $filenames = [];
+
+        if (is_string($parameters['filename*'] ?? null)) {
+            $value = explode("'", $parameters['filename*'], 3);
+
+            if (count($value) === 3) {
+                $filenames[] = rawurldecode($value[2]);
+            }
+        }
+
+        if (is_string($parameters['filename'] ?? null)) {
+            $filenames[] = trim($parameters['filename'], "'");
+        }
+
+        return $filenames;
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2638,6 +2638,56 @@ EOT
         $files->deleteDirectory($tempDir);
     }
 
+    public function testAssertDownloadOfferedWithANonAsciiFileName(): void
+    {
+        $response = new Response;
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+            'attachment', 'Rechnung-Müller.pdf', 'Rechnung-Muller.pdf'
+        ));
+
+        TestResponse::fromBaseResponse($response)->assertDownload('Rechnung-Müller.pdf');
+    }
+
+    public function testAssertDownloadOfferedWithANonAsciiFileNameAcceptsTheAsciiFallback(): void
+    {
+        $response = new Response;
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+            'attachment', 'Rechnung-Müller.pdf', 'Rechnung-Muller.pdf'
+        ));
+
+        TestResponse::fromBaseResponse($response)->assertDownload('Rechnung-Muller.pdf');
+    }
+
+    public function testAssertDownloadOfferedWithOnlyAnEncodedFileName(): void
+    {
+        $testResponse = TestResponse::fromBaseResponse(new Response('', 200, [
+            'Content-Disposition' => "attachment; filename*=utf-8''r%C3%A9sum%C3%A9.pdf",
+        ]));
+
+        $testResponse->assertDownload('résumé.pdf');
+    }
+
+    public function testAssertDownloadOfferedWithASingleQuotedFileName(): void
+    {
+        $testResponse = TestResponse::fromBaseResponse(new Response('', 200, [
+            'Content-Disposition' => "attachment; filename='single quoted.txt'",
+        ]));
+
+        $testResponse->assertDownload('single quoted.txt');
+    }
+
+    public function testAssertDownloadOfferedFailsWithAnUnexpectedFileName(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = new Response;
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+            'attachment', 'Rechnung-Müller.pdf', 'Rechnung-Muller.pdf'
+        ));
+
+        TestResponse::fromBaseResponse($response)->assertDownload('Rechnung-Schmidt.pdf');
+    }
+
     public function testMacroable(): void
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
  `response()->download($path, 'Müller.pdf')` sends:                                                                                                                                                                       
                                                                                                                                                                                                                           
  ```http                                                                                                                                                                                                                  
  Content-Disposition: attachment; filename=Muller.pdf; filename*=utf-8''M%C3%BCller.pdf 
  ```                                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  `assertDownload('Müller.pdf')` fails on it. It splits the header on `;` and `=` and only reads `filename`, the ASCII fallback. It never looks at `filename*`, which is the name the browser uses. For `发票.pdf` the     
  fallback is just `.pdf`, so no argument matches at all. `Storage::download()` is the same.