### PR TITLE
[13.x] Preserve unchanged values when encrypting readable environment files

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -26,6 +26,7 @@ class EnvironmentEncryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
                     {--readable : Encrypt each variable individually with readable, plain-text variable names}
+                    {--incremental : Update a readable encrypted file, preserving unchanged values}
                     {--prune : Delete the original environment file}
                     {--force : Overwrite the existing encrypted environment file}';
 
@@ -62,9 +63,25 @@ class EnvironmentEncryptCommand extends Command
      */
     public function handle()
     {
+        if ($this->option('incremental') && ! $this->option('readable')) {
+            $this->fail('The --incremental option requires --readable.');
+        }
+
         $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
+        $environmentFile = $this->option('env')
+            ? Str::finish($this->laravel->environmentPath(), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
+            : $this->laravel->environmentFilePath();
+
+        $encryptedFile = $environmentFile.'.encrypted';
+
+        $encryptedFileExists = $this->option('incremental') ? $this->files->exists($encryptedFile) : null;
+
         $key = $this->option('key');
+
+        if (! $key && $this->input->isInteractive() && $this->option('incremental') && $encryptedFileExists) {
+            $key = password('What is the encryption key?');
+        }
 
         if (! $key && $this->input->isInteractive()) {
             $ask = select(
@@ -83,12 +100,6 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
-        $environmentFile = $this->option('env')
-            ? Str::finish($this->laravel->environmentPath(), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
-            : $this->laravel->environmentFilePath();
-
-        $encryptedFile = $environmentFile.'.encrypted';
-
         if (! $keyPassed) {
             $key = Encrypter::generateKey($cipher);
         }
@@ -97,20 +108,35 @@ class EnvironmentEncryptCommand extends Command
             $this->fail('Environment file not found.');
         }
 
-        if ($this->files->exists($encryptedFile) && ! $this->option('force')) {
+        $encryptedFileExists ??= $this->files->exists($encryptedFile);
+
+        if ($encryptedFileExists && ! $this->option('force') && ! $this->option('incremental')) {
             $this->fail('Encrypted environment file already exists.');
+        }
+
+        if ($encryptedFileExists && $this->option('incremental') && ! $keyPassed) {
+            $this->fail('The existing encryption key is required for incremental encryption.');
         }
 
         try {
             $encrypter = new Encrypter($this->parseKey($key), $cipher);
 
             $contents = $this->files->get($environmentFile);
+            $previous = $this->option('incremental') && $encryptedFileExists
+                ? $this->files->get($encryptedFile)
+                : null;
 
             $encrypted = $this->option('readable')
-                ? $this->encryptReadableFormat($contents, $encrypter)
+                ? $this->encryptReadableFormat($contents, $encrypter, $previous)
                 : $encrypter->encrypt($contents);
 
-            $this->files->put($encryptedFile, $encrypted);
+            if ($encrypted !== $previous) {
+                $written = $this->files->put($encryptedFile, $encrypted);
+
+                if ($this->option('incremental') && $written === false) {
+                    $this->fail('Unable to write the encrypted environment file.');
+                }
+            }
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
@@ -133,11 +159,13 @@ class EnvironmentEncryptCommand extends Command
      *
      * @param  string  $contents
      * @param  \Illuminate\Encryption\Encrypter  $encrypter
+     * @param  string|null  $previous
      * @return string
      */
-    protected function encryptReadableFormat(string $contents, Encrypter $encrypter): string
+    protected function encryptReadableFormat(string $contents, Encrypter $encrypter, ?string $previous = null): string
     {
         $result = '';
+        $existing = $previous === null ? [] : $this->readEncryptedEntries($previous, $encrypter);
 
         foreach (Lines::process(preg_split('/\r\n|\r|\n/', $contents)) as $entry) {
             $pos = strpos($entry, '=');
@@ -149,10 +177,54 @@ class EnvironmentEncryptCommand extends Command
             $name = substr($entry, 0, $pos);
             $value = substr($entry, $pos + 1);
 
-            $result .= $name.'='.$encrypter->encryptString($value)."\n";
+            $entry = empty($existing[$name]) ? null : array_shift($existing[$name]);
+
+            $result .= $name.'='.($entry !== null && $entry['value'] === $value
+                ? $entry['encrypted']
+                : $encrypter->encryptString($value))."\n";
         }
 
         return $result;
+    }
+
+    /**
+     * Authenticate the existing readable entries, preserving duplicate names.
+     *
+     * @param  string  $contents
+     * @param  \Illuminate\Encryption\Encrypter  $encrypter
+     * @return array
+     */
+    protected function readEncryptedEntries(string $contents, Encrypter $encrypter): array
+    {
+        if (Encrypter::appearsEncrypted($contents)) {
+            $this->fail('Incremental encryption requires an existing file in readable format.');
+        }
+
+        $entries = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', $contents) as $index => $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            $pos = strpos($line, '=');
+
+            if ($pos === false || $pos === 0) {
+                $this->fail('Invalid encrypted environment entry on line '.($index + 1).'.');
+            }
+
+            $encrypted = substr($line, $pos + 1);
+
+            try {
+                $value = $encrypter->decryptString($encrypted);
+            } catch (Exception $e) {
+                $this->fail('Unable to decrypt the encrypted environment entry on line '.($index + 1).'.');
+            }
+
+            $entries[substr($line, 0, $pos)][] = compact('value', 'encrypted');
+        }
+
+        return $entries;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -75,15 +75,17 @@ class EnvironmentEncryptCommand extends Command
 
         $encryptedFile = $environmentFile.'.encrypted';
 
+        if (! $this->files->exists($environmentFile)) {
+            $this->fail('Environment file not found.');
+        }
+
         $encryptedFileExists = $this->option('incremental') ? $this->files->exists($encryptedFile) : null;
 
         $key = $this->option('key');
 
         if (! $key && $this->input->isInteractive() && $this->option('incremental') && $encryptedFileExists) {
             $key = password('What is the encryption key?');
-        }
-
-        if (! $key && $this->input->isInteractive()) {
+        } elseif (! $key && $this->input->isInteractive()) {
             $ask = select(
                 label: 'What encryption key would you like to use?',
                 options: [
@@ -98,24 +100,20 @@ class EnvironmentEncryptCommand extends Command
             }
         }
 
+        if ($encryptedFileExists && $this->option('incremental') && ($key === null || $key === '')) {
+            $this->fail('The existing encryption key is required for incremental encryption.');
+        }
+
         $keyPassed = $key !== null;
 
         if (! $keyPassed) {
             $key = Encrypter::generateKey($cipher);
         }
 
-        if (! $this->files->exists($environmentFile)) {
-            $this->fail('Environment file not found.');
-        }
-
         $encryptedFileExists ??= $this->files->exists($encryptedFile);
 
         if ($encryptedFileExists && ! $this->option('force') && ! $this->option('incremental')) {
             $this->fail('Encrypted environment file already exists.');
-        }
-
-        if ($encryptedFileExists && $this->option('incremental') && ! $keyPassed) {
-            $this->fail('The existing encryption key is required for incremental encryption.');
         }
 
         try {
@@ -165,7 +163,13 @@ class EnvironmentEncryptCommand extends Command
     protected function encryptReadableFormat(string $contents, Encrypter $encrypter, ?string $previous = null): string
     {
         $result = '';
-        $existing = $previous === null ? [] : $this->readEncryptedEntries($previous, $encrypter);
+        $existing = [];
+        $previousOutput = '';
+
+        foreach ($previous === null ? [] : $this->readEncryptedEntries($previous, $encrypter) as $entry) {
+            $existing[$entry['name']][] = $entry;
+            $previousOutput .= $entry['name'].'='.$entry['encrypted']."\n";
+        }
 
         foreach (Lines::process(preg_split('/\r\n|\r|\n/', $contents)) as $entry) {
             $pos = strpos($entry, '=');
@@ -177,18 +181,18 @@ class EnvironmentEncryptCommand extends Command
             $name = substr($entry, 0, $pos);
             $value = substr($entry, $pos + 1);
 
-            $entry = empty($existing[$name]) ? null : array_shift($existing[$name]);
+            $existingEntry = empty($existing[$name]) ? null : array_shift($existing[$name]);
 
-            $result .= $name.'='.($entry !== null && $entry['value'] === $value
-                ? $entry['encrypted']
+            $result .= $name.'='.($existingEntry !== null && $existingEntry['value'] === $value
+                ? $existingEntry['encrypted']
                 : $encrypter->encryptString($value))."\n";
         }
 
-        return $result;
+        return $previous !== null && $result === $previousOutput ? $previous : $result;
     }
 
     /**
-     * Authenticate the existing readable entries, preserving duplicate names.
+     * Authenticate the existing readable entries, preserving order and duplicate names.
      *
      * @param  string  $contents
      * @param  \Illuminate\Encryption\Encrypter  $encrypter
@@ -203,7 +207,7 @@ class EnvironmentEncryptCommand extends Command
         $entries = [];
 
         foreach (preg_split('/\r\n|\r|\n/', $contents) as $index => $line) {
-            if ($line === '') {
+            if (trim($line) === '' || str_starts_with(ltrim($line), '#')) {
                 continue;
             }
 
@@ -221,7 +225,9 @@ class EnvironmentEncryptCommand extends Command
                 $this->fail('Unable to decrypt the encrypted environment entry on line '.($index + 1).'.');
             }
 
-            $entries[substr($line, 0, $pos)][] = compact('value', 'encrypted');
+            $name = substr($line, 0, $pos);
+
+            $entries[] = compact('name', 'value', 'encrypted');
         }
 
         return $entries;

--- a/tests/Console/Fixtures/command_signatures.php
+++ b/tests/Console/Fixtures/command_signatures.php
@@ -2148,6 +2148,17 @@ return [
                 'description' => 'Encrypt each variable individually with readable, plain-text variable names',
             ],
             [
+                'name' => 'incremental',
+                'shortcut' => null,
+                'negatable' => false,
+                'valueRequired' => false,
+                'valueOptional' => false,
+                'isArray' => false,
+                'acceptValue' => false,
+                'default' => false,
+                'description' => 'Update a readable encrypted file, preserving unchanged values',
+            ],
+            [
                 'name' => 'prune',
                 'shortcut' => null,
                 'negatable' => false,

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -76,7 +76,6 @@ class EnvironmentEncryptCommandTest extends TestCase
         $this->filesystem->expects('exists')->andReturn(false);
 
         $this->artisan('env:encrypt')
-            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -104,6 +104,37 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->with(base_path('.env.encrypted'), Mockery::any());
     }
 
+    public function testItReencryptsReadableValuesWithANewKeyWhenForcing(): void
+    {
+        $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+        $oldEncrypter = new Encrypter(str_repeat('x', 32), 'AES-256-CBC');
+        $encryptedOutput = null;
+
+        File::swap(Mockery::mock(Filesystem::class));
+
+        File::expects('exists')
+            ->with(base_path('.env'))
+            ->andReturn(true);
+        File::expects('exists')
+            ->with(base_path('.env.encrypted'))
+            ->andReturn(true);
+        File::expects('get')
+            ->with(base_path('.env'))
+            ->andReturn('DB_PASSWORD=1');
+        File::shouldReceive('get')
+            ->with(base_path('.env.encrypted'))
+            ->andReturn('DB_PASSWORD='.$oldEncrypter->encryptString('1')."\n");
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $key])
+            ->assertExitCode(0);
+
+        $encrypter = new Encrypter($key, 'AES-256-CBC');
+        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
+    }
+
     public function testItEncryptsWithGivenKeyAndDisplaysIt(): void
     {
         $this->filesystem->expects('exists')->andReturn(true);

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -34,7 +34,21 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $host = $encrypter->encryptString('localhost');
         $password = $encrypter->encryptString('1');
         $app = $encrypter->encryptString('production');
-        $this->mockFiles("DB_HOST=localhost\nDB_PASSWORD=2\nAPP_ENV=production\n", "DB_HOST=$host\nDB_PASSWORD=$password\nAPP_ENV=$app\n");
+        $source = <<<'ENV'
+DB_HOST=localhost
+DB_PASSWORD=2
+APP_ENV=production
+
+ENV;
+
+        $previous = <<<ENV
+DB_HOST=$host
+DB_PASSWORD=$password
+APP_ENV=$app
+
+ENV;
+
+        $this->mockFiles($source, $previous);
 
         $output = null;
         File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
@@ -58,15 +72,35 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
     public function testItDoesNotWriteWhenRawValuesAreUnchanged(): void
     {
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $values = ['DUP' => ['1', '2'], 'MULTILINE' => ["\"first\nsecond\""], 'REF' => ['"${DUP}"'], 'EMPTY' => ['']];
-        $source = $previous = '';
+        $source = <<<'ENV'
+DUP=1
+DUP=2
+MULTILINE="first
+second"
+REF="${DUP}"
+EMPTY=
 
-        foreach ($values as $name => $entries) {
-            foreach ($entries as $value) {
-                $source .= $name.'='.$value."\n";
-                $previous .= $name.'='.$encrypter->encryptString($value)."\n";
-            }
-        }
+ENV;
+
+        $multilineValue = <<<'VALUE'
+"first
+second"
+VALUE;
+
+        $first = $encrypter->encryptString('1');
+        $second = $encrypter->encryptString('2');
+        $multiline = $encrypter->encryptString($multilineValue);
+        $reference = $encrypter->encryptString('"${DUP}"');
+        $empty = $encrypter->encryptString('');
+
+        $previous = <<<ENV
+DUP=$first
+DUP=$second
+MULTILINE=$multiline
+REF=$reference
+EMPTY=$empty
+
+ENV;
 
         $this->mockFiles($source, $previous);
         File::shouldReceive('put')->never();
@@ -79,7 +113,21 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
         $removed = $encrypter->encryptString('secret');
-        $this->mockFiles("NEW=3\nDUP=1\nDUP=changed\n", "DUP=$first\nREMOVED=$removed\nDUP=$second\n");
+        $source = <<<'ENV'
+NEW=3
+DUP=1
+DUP=changed
+
+ENV;
+
+        $previous = <<<ENV
+DUP=$first
+REMOVED=$removed
+DUP=$second
+
+ENV;
+
+        $this->mockFiles($source, $previous);
         $output = null;
         File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
 
@@ -213,7 +261,13 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
         $previous = $prefix."FIRST=$first".$separator."SECOND=$second".$suffix;
-        $this->mockFiles("FIRST=1\nSECOND=2\n", $previous);
+        $source = <<<'ENV'
+FIRST=1
+SECOND=2
+
+ENV;
+
+        $this->mockFiles($source, $previous);
         File::shouldReceive('put')->never();
         $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
     }
@@ -233,7 +287,21 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
-        $this->mockFiles("FIRST=1\nSECOND=3\n", " # comment\r\nFIRST=$first\r\n\t\r\nSECOND=$second\r\n");
+        $source = <<<'ENV'
+FIRST=1
+SECOND=3
+
+ENV;
+
+        $previous = <<<ENV
+ # comment
+FIRST=$first
+\t
+SECOND=$second
+
+ENV;
+
+        $this->mockFiles($source, str_replace("\n", "\r\n", $previous));
         $output = null;
         File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
         $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
@@ -246,7 +314,14 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
 
     public function testItRejectsCorruptionAfterIgnorableBaselineLines(): void
     {
-        $this->mockFiles('FIRST=1', "  # comment\r\n\t\r\nREMOVED=invalid\r\n");
+        $previous = <<<ENV
+  # comment
+\t
+REMOVED=invalid
+
+ENV;
+
+        $this->mockFiles('FIRST=1', str_replace("\n", "\r\n", $previous));
         File::shouldReceive('put')->never();
         File::shouldReceive('delete')->never();
         $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
@@ -259,12 +334,30 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
-        $this->mockFiles("SECOND=2\nFIRST=1\n", "FIRST=$first\r\nSECOND=$second\r\n");
+        $source = <<<'ENV'
+SECOND=2
+FIRST=1
+
+ENV;
+
+        $previous = <<<ENV
+FIRST=$first
+SECOND=$second
+
+ENV;
+
+        $this->mockFiles($source, str_replace("\n", "\r\n", $previous));
         $output = null;
         File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
         $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
 
-        $this->assertSame("SECOND=$second\nFIRST=$first\n", $output);
+        $expected = <<<ENV
+SECOND=$second
+FIRST=$first
+
+ENV;
+
+        $this->assertSame($expected, $output);
     }
 
     public function testItRejectsAnEmptyInteractiveKeyWithoutOfferingGeneration(): void

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class EnvironmentEncryptIncrementalCommandTest extends TestCase
+{
+    protected string $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+
+    protected function mockFiles(?string $source, ?string $previous, string $env = '.env'): void
+    {
+        File::swap(Mockery::mock(Filesystem::class));
+        File::shouldReceive('exists')->with(base_path($env))->andReturn($source !== null);
+        File::shouldReceive('exists')->with(base_path($env.'.encrypted'))->andReturn($previous !== null);
+        File::shouldReceive('get')->with(base_path($env))->andReturn($source);
+        File::shouldReceive('get')->with(base_path($env.'.encrypted'))->andReturn($previous);
+    }
+
+    protected function incrementalOptions(array $options = []): array
+    {
+        return array_merge(['--readable' => true, '--incremental' => true, '--key' => $this->key], $options);
+    }
+
+    #[DataProvider('ciphers')]
+    public function testItChangesOnlyTheEditedValue(string $cipher): void
+    {
+        $encrypter = new Encrypter($this->key, $cipher);
+        $host = $encrypter->encryptString('localhost');
+        $password = $encrypter->encryptString('1');
+        $app = $encrypter->encryptString('production');
+        $this->mockFiles("DB_HOST=localhost\nDB_PASSWORD=2\nAPP_ENV=production\n", "DB_HOST=$host\nDB_PASSWORD=$password\nAPP_ENV=$app\n");
+
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter, $host, $password, $app) {
+            $lines = explode("\n", $output);
+            $this->assertSame("DB_HOST=$host", $lines[0]);
+            $this->assertSame("APP_ENV=$app", $lines[2]);
+            $this->assertSame('', $lines[3]);
+            $payload = substr($lines[1], strlen('DB_PASSWORD='));
+            $this->assertNotSame($password, $payload);
+            $this->assertSame('2', $encrypter->decryptString($payload));
+
+            return true;
+        }))->andReturn(100);
+
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--cipher' => $cipher]))->assertExitCode(0);
+    }
+
+    public static function ciphers(): array
+    {
+        return [['AES-256-CBC'], ['AES-256-GCM']];
+    }
+
+    public function testItDoesNotWriteWhenRawValuesAreUnchanged(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $values = ['DUP' => ['1', '2'], 'MULTILINE' => ["\"first\nsecond\""], 'REF' => ['"${DUP}"'], 'EMPTY' => ['']];
+        $source = $previous = '';
+
+        foreach ($values as $name => $entries) {
+            foreach ($entries as $value) {
+                $source .= $name.'='.$value."\n";
+                $previous .= $name.'='.$encrypter->encryptString($value)."\n";
+            }
+        }
+
+        $this->mockFiles($source, $previous);
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+    }
+
+    public function testItPreservesOccurrencesWhileAddingDeletingAndReordering(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $first = $encrypter->encryptString('1');
+        $second = $encrypter->encryptString('2');
+        $removed = $encrypter->encryptString('secret');
+        $this->mockFiles("NEW=3\nDUP=1\nDUP=changed\n", "DUP=$first\nREMOVED=$removed\nDUP=$second\n");
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter, $first) {
+            $lines = explode("\n", $output);
+            $this->assertCount(4, $lines);
+            $this->assertSame('3', $encrypter->decryptString(substr($lines[0], 4)));
+            $this->assertSame("DUP=$first", $lines[1]);
+            $this->assertSame('changed', $encrypter->decryptString(substr($lines[2], 4)));
+            $this->assertStringNotContainsString('REMOVED=', $output);
+
+            return true;
+        }))->andReturn(100);
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+    }
+
+    public function testItCreatesAMissingTargetForTheSelectedEnvironment(): void
+    {
+        $this->mockFiles("DB_PASSWORD=1\n", null, '.env.production');
+        File::expects('put')->with(base_path('.env.production.encrypted'), Mockery::on(function ($output) {
+            $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+            $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+
+            return true;
+        }))->andReturn(100);
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--env' => 'production', '--key' => 'base64:'.base64_encode($this->key)]))->assertExitCode(0);
+    }
+
+    public function testItTreatsQuoteChangesAsRawValueChanges(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $old = $encrypter->encryptString('1');
+        $this->mockFiles('DB_PASSWORD="1"', 'DB_PASSWORD='.$old."\n");
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter) {
+            $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+
+            return true;
+        }))->andReturn(100);
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+    }
+
+    public function testForceStillReencryptsAllValuesUnderANewKey(): void
+    {
+        $oldEncrypter = new Encrypter(str_repeat('x', 32), 'AES-256-CBC');
+        $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$oldEncrypter->encryptString('1')."\n");
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) {
+            $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+            $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+
+            return true;
+        }))->andReturn(100);
+        $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $this->key])->assertExitCode(0);
+    }
+
+    public function testItCanDeleteAllEntries(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $this->mockFiles('', 'DB_PASSWORD='.$encrypter->encryptString('1')."\n");
+        File::expects('put')->with(base_path('.env.encrypted'), '')->andReturn(0);
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+    }
+
+    #[DataProvider('invalidBaselines')]
+    public function testItRejectsInvalidBaselinesWithoutWritingOrPruning(string $kind): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $previous = match ($kind) {
+            'blob' => $encrypter->encrypt("DB_PASSWORD=1\n"),
+            'wrong-key' => 'DB_PASSWORD='.(new Encrypter(str_repeat('x', 32), 'AES-256-CBC'))->encryptString('1'),
+            'wrong-cipher' => 'DB_PASSWORD='.(new Encrypter($this->key, 'AES-256-GCM'))->encryptString('1'),
+            'malformed' => '<<<<<<< HEAD',
+            'corrupt-deleted-entry' => 'REMOVED=invalid',
+        };
+        $this->mockFiles("DB_PASSWORD=1\n", $previous);
+        File::shouldReceive('put')->never();
+        File::shouldReceive('delete')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--force' => true, '--prune' => true]))->assertExitCode(1);
+    }
+
+    public static function invalidBaselines(): array
+    {
+        return array_map(fn ($kind) => [$kind], ['blob', 'wrong-key', 'wrong-cipher', 'malformed', 'corrupt-deleted-entry']);
+    }
+
+    public function testItRequiresReadable(): void
+    {
+        $this->artisan('env:encrypt', ['--incremental' => true])
+            ->expectsOutputToContain('The --incremental option requires --readable.')
+            ->assertExitCode(1);
+    }
+
+    public function testItRejectsAMissingSource(): void
+    {
+        $this->mockFiles(null, 'existing');
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions())
+            ->expectsOutputToContain('Environment file not found.')
+            ->assertExitCode(1);
+    }
+
+    public function testItRequiresTheExistingKeyInsteadOfGeneratingOne(): void
+    {
+        $this->mockFiles('DB_PASSWORD=1', 'existing');
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--no-interaction' => true])
+            ->expectsOutputToContain('The existing encryption key is required')
+            ->assertExitCode(1);
+    }
+
+    public function testItAsksForTheExistingKeyWhenUpdatingInteractively(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$encrypter->encryptString('1')."\n");
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
+            ->expectsQuestion('What is the encryption key?', $this->key)
+            ->assertExitCode(0);
+    }
+
+    public function testItDoesNotPruneAfterAFailedWrite(): void
+    {
+        $this->mockFiles('DB_PASSWORD=1', null);
+        File::expects('put')->andReturn(false);
+        File::shouldReceive('delete')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
+            ->expectsOutputToContain('Unable to write the encrypted environment file.')
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -182,23 +182,6 @@ ENV;
         $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
     }
 
-    public function testForceStillReencryptsAllValuesUnderANewKey(): void
-    {
-        $oldEncrypter = new Encrypter(str_repeat('x', 32), 'AES-256-CBC');
-        $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$oldEncrypter->encryptString('1')."\n");
-        $encryptedOutput = null;
-
-        File::expects('put')
-            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
-            ->andReturn(100);
-
-        $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $this->key])
-            ->assertExitCode(0);
-
-        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
-    }
-
     public function testItCanDeleteAllEntries(): void
     {
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -13,18 +13,22 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
 {
     protected string $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
 
-    protected function mockFiles(?string $source, ?string $previous, string $env = '.env'): void
+    protected function mockFiles(?string $originalContent, ?string $encryptedContent, string $env = '.env'): void
     {
         File::swap(Mockery::mock(Filesystem::class));
-        File::shouldReceive('exists')->with(base_path($env))->andReturn($source !== null);
-        File::shouldReceive('exists')->with(base_path($env.'.encrypted'))->andReturn($previous !== null);
-        File::shouldReceive('get')->with(base_path($env))->andReturn($source);
-        File::shouldReceive('get')->with(base_path($env.'.encrypted'))->andReturn($previous);
-    }
 
-    protected function incrementalOptions(array $options = []): array
-    {
-        return array_merge(['--readable' => true, '--incremental' => true, '--key' => $this->key], $options);
+        File::shouldReceive('exists')
+            ->with(base_path($env))
+            ->andReturn($originalContent !== null);
+        File::shouldReceive('exists')
+            ->with(base_path($env.'.encrypted'))
+            ->andReturn($encryptedContent !== null);
+        File::shouldReceive('get')
+            ->with(base_path($env))
+            ->andReturn($originalContent);
+        File::shouldReceive('get')
+            ->with(base_path($env.'.encrypted'))
+            ->andReturn($encryptedContent);
     }
 
     #[DataProvider('ciphers')]
@@ -34,28 +38,32 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $host = $encrypter->encryptString('localhost');
         $password = $encrypter->encryptString('1');
         $app = $encrypter->encryptString('production');
-        $source = <<<'ENV'
+        $originalContent = <<<'ENV'
 DB_HOST=localhost
 DB_PASSWORD=2
 APP_ENV=production
 
 ENV;
 
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
 DB_HOST=$host
 DB_PASSWORD=$password
 APP_ENV=$app
 
 ENV;
 
-        $this->mockFiles($source, $previous);
+        $this->mockFiles($originalContent, $encryptedContent);
 
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $encryptedOutput = null;
 
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--cipher' => $cipher]))->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
 
-        $lines = explode("\n", $output);
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key, '--cipher' => $cipher])
+            ->assertExitCode(0);
+
+        $lines = explode("\n", $encryptedOutput);
         $this->assertSame("DB_HOST=$host", $lines[0]);
         $this->assertSame("APP_ENV=$app", $lines[2]);
         $this->assertSame('', $lines[3]);
@@ -72,7 +80,7 @@ ENV;
     public function testItDoesNotWriteWhenRawValuesAreUnchanged(): void
     {
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $source = <<<'ENV'
+        $originalContent = <<<'ENV'
 DUP=1
 DUP=2
 MULTILINE="first
@@ -93,7 +101,7 @@ VALUE;
         $reference = $encrypter->encryptString('"${DUP}"');
         $empty = $encrypter->encryptString('');
 
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
 DUP=$first
 DUP=$second
 MULTILINE=$multiline
@@ -102,9 +110,11 @@ EMPTY=$empty
 
 ENV;
 
-        $this->mockFiles($source, $previous);
+        $this->mockFiles($originalContent, $encryptedContent);
         File::shouldReceive('put')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
     }
 
     public function testItPreservesOccurrencesWhileAddingDeletingAndReordering(): void
@@ -113,44 +123,52 @@ ENV;
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
         $removed = $encrypter->encryptString('secret');
-        $source = <<<'ENV'
+        $originalContent = <<<'ENV'
 NEW=3
 DUP=1
 DUP=changed
 
 ENV;
 
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
 DUP=$first
 REMOVED=$removed
 DUP=$second
 
 ENV;
 
-        $this->mockFiles($source, $previous);
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $this->mockFiles($originalContent, $encryptedContent);
+        $encryptedOutput = null;
 
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
 
-        $lines = explode("\n", $output);
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
+
+        $lines = explode("\n", $encryptedOutput);
         $this->assertCount(4, $lines);
-        $this->assertSame('3', $encrypter->decryptString(substr($lines[0], 4)));
+        $this->assertSame('3', $encrypter->decryptString(substr($lines[0], strlen('NEW='))));
         $this->assertSame("DUP=$first", $lines[1]);
-        $this->assertSame('changed', $encrypter->decryptString(substr($lines[2], 4)));
-        $this->assertStringNotContainsString('REMOVED=', $output);
+        $this->assertSame('changed', $encrypter->decryptString(substr($lines[2], strlen('DUP='))));
+        $this->assertStringNotContainsString('REMOVED=', $encryptedOutput);
     }
 
     public function testItCreatesAMissingTargetForTheSelectedEnvironment(): void
     {
         $this->mockFiles("DB_PASSWORD=1\n", null, '.env.production');
-        $output = null;
-        File::expects('put')->with(base_path('.env.production.encrypted'), Mockery::capture($output))->andReturn(100);
+        $encryptedOutput = null;
 
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--env' => 'production', '--key' => 'base64:'.base64_encode($this->key)]))->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.production.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--env' => 'production', '--key' => 'base64:'.base64_encode($this->key)])
+            ->assertExitCode(0);
 
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
     }
 
     public function testItTreatsQuoteChangesAsRawValueChanges(): void
@@ -158,50 +176,64 @@ ENV;
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $old = $encrypter->encryptString('1');
         $this->mockFiles('DB_PASSWORD="1"', 'DB_PASSWORD='.$old."\n");
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $encryptedOutput = null;
 
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
 
-        $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
+
+        $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
     }
 
     public function testForceStillReencryptsAllValuesUnderANewKey(): void
     {
         $oldEncrypter = new Encrypter(str_repeat('x', 32), 'AES-256-CBC');
         $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$oldEncrypter->encryptString('1')."\n");
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $encryptedOutput = null;
 
-        $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $this->key])->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $this->key])
+            ->assertExitCode(0);
 
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($encryptedOutput), strlen('DB_PASSWORD='))));
     }
 
     public function testItCanDeleteAllEntries(): void
     {
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $this->mockFiles('', 'DB_PASSWORD='.$encrypter->encryptString('1')."\n");
-        File::expects('put')->with(base_path('.env.encrypted'), '')->andReturn(0);
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), '')
+            ->andReturn(0);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
     }
 
     #[DataProvider('invalidBaselines')]
     public function testItRejectsInvalidBaselinesWithoutWritingOrPruning(string $kind): void
     {
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-        $previous = match ($kind) {
+        $encryptedContent = match ($kind) {
             'blob' => $encrypter->encrypt("DB_PASSWORD=1\n"),
             'wrong-key' => 'DB_PASSWORD='.(new Encrypter(str_repeat('x', 32), 'AES-256-CBC'))->encryptString('1'),
             'wrong-cipher' => 'DB_PASSWORD='.(new Encrypter($this->key, 'AES-256-GCM'))->encryptString('1'),
             'malformed' => '<<<<<<< HEAD',
             'corrupt-deleted-entry' => 'REMOVED=invalid',
         };
-        $this->mockFiles("DB_PASSWORD=1\n", $previous);
+        $this->mockFiles("DB_PASSWORD=1\n", $encryptedContent);
         File::shouldReceive('put')->never();
         File::shouldReceive('delete')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--force' => true, '--prune' => true]))->assertExitCode(1);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key, '--force' => true, '--prune' => true])
+            ->assertExitCode(1);
     }
 
     public static function invalidBaselines(): array
@@ -220,7 +252,8 @@ ENV;
     {
         $this->mockFiles(null, 'existing');
         File::shouldReceive('put')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions())
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }
@@ -229,6 +262,7 @@ ENV;
     {
         $this->mockFiles('DB_PASSWORD=1', 'existing');
         File::shouldReceive('put')->never();
+
         $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--no-interaction' => true])
             ->expectsOutputToContain('The existing encryption key is required')
             ->assertExitCode(1);
@@ -239,6 +273,7 @@ ENV;
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$encrypter->encryptString('1')."\n");
         File::shouldReceive('put')->never();
+
         $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
             ->expectsQuestion('What is the encryption key?', $this->key)
             ->assertExitCode(0);
@@ -249,7 +284,8 @@ ENV;
         $this->mockFiles('DB_PASSWORD=1', null);
         File::expects('put')->andReturn(false);
         File::shouldReceive('delete')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key, '--prune' => true])
             ->expectsOutputToContain('Unable to write the encrypted environment file.')
             ->assertExitCode(1);
     }
@@ -260,16 +296,18 @@ ENV;
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
-        $previous = $prefix."FIRST=$first".$separator."SECOND=$second".$suffix;
-        $source = <<<'ENV'
+        $encryptedContent = $prefix."FIRST=$first".$separator."SECOND=$second".$suffix;
+        $originalContent = <<<'ENV'
 FIRST=1
 SECOND=2
 
 ENV;
 
-        $this->mockFiles($source, $previous);
+        $this->mockFiles($originalContent, $encryptedContent);
         File::shouldReceive('put')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
     }
 
     public static function baselineFormatting(): array
@@ -287,13 +325,13 @@ ENV;
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
-        $source = <<<'ENV'
+        $originalContent = <<<'ENV'
 FIRST=1
 SECOND=3
 
 ENV;
 
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
  # comment
 FIRST=$first
 \t
@@ -301,12 +339,17 @@ SECOND=$second
 
 ENV;
 
-        $this->mockFiles($source, str_replace("\n", "\r\n", $previous));
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+        $this->mockFiles($originalContent, str_replace("\n", "\r\n", $encryptedContent));
+        $encryptedOutput = null;
 
-        $lines = explode("\n", $output);
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
+
+        $lines = explode("\n", $encryptedOutput);
         $this->assertCount(3, $lines);
         $this->assertSame("FIRST=$first", $lines[0]);
         $this->assertSame('3', $encrypter->decryptString(substr($lines[1], strlen('SECOND='))));
@@ -314,17 +357,18 @@ ENV;
 
     public function testItRejectsCorruptionAfterIgnorableBaselineLines(): void
     {
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
   # comment
 \t
 REMOVED=invalid
 
 ENV;
 
-        $this->mockFiles('FIRST=1', str_replace("\n", "\r\n", $previous));
+        $this->mockFiles('FIRST=1', str_replace("\n", "\r\n", $encryptedContent));
         File::shouldReceive('put')->never();
         File::shouldReceive('delete')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key, '--prune' => true])
             ->expectsOutputToContain('Unable to decrypt the encrypted environment entry on line 3.')
             ->assertExitCode(1);
     }
@@ -334,22 +378,27 @@ ENV;
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $first = $encrypter->encryptString('1');
         $second = $encrypter->encryptString('2');
-        $source = <<<'ENV'
+        $originalContent = <<<'ENV'
 SECOND=2
 FIRST=1
 
 ENV;
 
-        $previous = <<<ENV
+        $encryptedContent = <<<ENV
 FIRST=$first
 SECOND=$second
 
 ENV;
 
-        $this->mockFiles($source, str_replace("\n", "\r\n", $previous));
-        $output = null;
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
-        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+        $this->mockFiles($originalContent, str_replace("\n", "\r\n", $encryptedContent));
+        $encryptedOutput = null;
+
+        File::expects('put')
+            ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
+            ->andReturn(100);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
+            ->assertExitCode(0);
 
         $expected = <<<ENV
 SECOND=$second
@@ -357,13 +406,14 @@ FIRST=$first
 
 ENV;
 
-        $this->assertSame($expected, $output);
+        $this->assertSame($expected, $encryptedOutput);
     }
 
     public function testItRejectsAnEmptyInteractiveKeyWithoutOfferingGeneration(): void
     {
         $this->mockFiles('FIRST=1', 'existing');
         File::shouldReceive('put')->never();
+
         $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
             ->expectsQuestion('What is the encryption key?', '')
             ->expectsOutputToContain('The existing encryption key is required for incremental encryption.')
@@ -374,7 +424,8 @@ ENV;
     {
         $this->mockFiles('FIRST=1', 'existing');
         File::shouldReceive('put')->never();
-        $this->artisan('env:encrypt', $this->incrementalOptions(['--key' => '', '--no-interaction' => true]))
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => '', '--no-interaction' => true])
             ->expectsOutputToContain('The existing encryption key is required for incremental encryption.')
             ->assertExitCode(1);
     }
@@ -383,6 +434,7 @@ ENV;
     {
         $this->mockFiles(null, 'existing');
         File::shouldReceive('put')->never();
+
         $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -36,19 +36,18 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $app = $encrypter->encryptString('production');
         $this->mockFiles("DB_HOST=localhost\nDB_PASSWORD=2\nAPP_ENV=production\n", "DB_HOST=$host\nDB_PASSWORD=$password\nAPP_ENV=$app\n");
 
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter, $host, $password, $app) {
-            $lines = explode("\n", $output);
-            $this->assertSame("DB_HOST=$host", $lines[0]);
-            $this->assertSame("APP_ENV=$app", $lines[2]);
-            $this->assertSame('', $lines[3]);
-            $payload = substr($lines[1], strlen('DB_PASSWORD='));
-            $this->assertNotSame($password, $payload);
-            $this->assertSame('2', $encrypter->decryptString($payload));
-
-            return true;
-        }))->andReturn(100);
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
 
         $this->artisan('env:encrypt', $this->incrementalOptions(['--cipher' => $cipher]))->assertExitCode(0);
+
+        $lines = explode("\n", $output);
+        $this->assertSame("DB_HOST=$host", $lines[0]);
+        $this->assertSame("APP_ENV=$app", $lines[2]);
+        $this->assertSame('', $lines[3]);
+        $payload = substr($lines[1], strlen('DB_PASSWORD='));
+        $this->assertNotSame($password, $payload);
+        $this->assertSame('2', $encrypter->decryptString($payload));
     }
 
     public static function ciphers(): array
@@ -81,29 +80,29 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $second = $encrypter->encryptString('2');
         $removed = $encrypter->encryptString('secret');
         $this->mockFiles("NEW=3\nDUP=1\nDUP=changed\n", "DUP=$first\nREMOVED=$removed\nDUP=$second\n");
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter, $first) {
-            $lines = explode("\n", $output);
-            $this->assertCount(4, $lines);
-            $this->assertSame('3', $encrypter->decryptString(substr($lines[0], 4)));
-            $this->assertSame("DUP=$first", $lines[1]);
-            $this->assertSame('changed', $encrypter->decryptString(substr($lines[2], 4)));
-            $this->assertStringNotContainsString('REMOVED=', $output);
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
 
-            return true;
-        }))->andReturn(100);
         $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $lines = explode("\n", $output);
+        $this->assertCount(4, $lines);
+        $this->assertSame('3', $encrypter->decryptString(substr($lines[0], 4)));
+        $this->assertSame("DUP=$first", $lines[1]);
+        $this->assertSame('changed', $encrypter->decryptString(substr($lines[2], 4)));
+        $this->assertStringNotContainsString('REMOVED=', $output);
     }
 
     public function testItCreatesAMissingTargetForTheSelectedEnvironment(): void
     {
         $this->mockFiles("DB_PASSWORD=1\n", null, '.env.production');
-        File::expects('put')->with(base_path('.env.production.encrypted'), Mockery::on(function ($output) {
-            $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-            $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $output = null;
+        File::expects('put')->with(base_path('.env.production.encrypted'), Mockery::capture($output))->andReturn(100);
 
-            return true;
-        }))->andReturn(100);
         $this->artisan('env:encrypt', $this->incrementalOptions(['--env' => 'production', '--key' => 'base64:'.base64_encode($this->key)]))->assertExitCode(0);
+
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
     }
 
     public function testItTreatsQuoteChangesAsRawValueChanges(): void
@@ -111,25 +110,25 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $old = $encrypter->encryptString('1');
         $this->mockFiles('DB_PASSWORD="1"', 'DB_PASSWORD='.$old."\n");
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) use ($encrypter) {
-            $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
 
-            return true;
-        }))->andReturn(100);
         $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $this->assertSame('"1"', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
     }
 
     public function testForceStillReencryptsAllValuesUnderANewKey(): void
     {
         $oldEncrypter = new Encrypter(str_repeat('x', 32), 'AES-256-CBC');
         $this->mockFiles('DB_PASSWORD=1', 'DB_PASSWORD='.$oldEncrypter->encryptString('1')."\n");
-        File::expects('put')->with(base_path('.env.encrypted'), Mockery::on(function ($output) {
-            $encrypter = new Encrypter($this->key, 'AES-256-CBC');
-            $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
 
-            return true;
-        }))->andReturn(100);
         $this->artisan('env:encrypt', ['--readable' => true, '--force' => true, '--key' => $this->key])->assertExitCode(0);
+
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $this->assertSame('1', $encrypter->decryptString(substr(rtrim($output), strlen('DB_PASSWORD='))));
     }
 
     public function testItCanDeleteAllEntries(): void
@@ -204,6 +203,95 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
         File::shouldReceive('delete')->never();
         $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
             ->expectsOutputToContain('Unable to write the encrypted environment file.')
+            ->assertExitCode(1);
+    }
+
+    #[DataProvider('baselineFormatting')]
+    public function testItPreservesBaselineBytesWhenEntriesAreUnchanged(string $separator, string $prefix, string $suffix): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $first = $encrypter->encryptString('1');
+        $second = $encrypter->encryptString('2');
+        $previous = $prefix."FIRST=$first".$separator."SECOND=$second".$suffix;
+        $this->mockFiles("FIRST=1\nSECOND=2\n", $previous);
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+    }
+
+    public static function baselineFormatting(): array
+    {
+        return [
+            'CRLF' => ["\r\n", '', "\r\n"],
+            'CR' => ["\r", '', "\r"],
+            'no final newline' => ["\n", '', ''],
+            'comments and whitespace' => ["\r\n  # between\r\n \t\r\n", "  # before\r\n\t\r\n", "\r\n# after\r\n"],
+        ];
+    }
+
+    public function testItUpdatesEntriesInABaselineContainingComments(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $first = $encrypter->encryptString('1');
+        $second = $encrypter->encryptString('2');
+        $this->mockFiles("FIRST=1\nSECOND=3\n", " # comment\r\nFIRST=$first\r\n\t\r\nSECOND=$second\r\n");
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $lines = explode("\n", $output);
+        $this->assertCount(3, $lines);
+        $this->assertSame("FIRST=$first", $lines[0]);
+        $this->assertSame('3', $encrypter->decryptString(substr($lines[1], strlen('SECOND='))));
+    }
+
+    public function testItRejectsCorruptionAfterIgnorableBaselineLines(): void
+    {
+        $this->mockFiles('FIRST=1', "  # comment\r\n\t\r\nREMOVED=invalid\r\n");
+        File::shouldReceive('put')->never();
+        File::shouldReceive('delete')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--prune' => true]))
+            ->expectsOutputToContain('Unable to decrypt the encrypted environment entry on line 3.')
+            ->assertExitCode(1);
+    }
+
+    public function testItWritesAReorderedBaselineEvenWhenEveryValueIsUnchanged(): void
+    {
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
+        $first = $encrypter->encryptString('1');
+        $second = $encrypter->encryptString('2');
+        $this->mockFiles("SECOND=2\nFIRST=1\n", "FIRST=$first\r\nSECOND=$second\r\n");
+        $output = null;
+        File::expects('put')->with(base_path('.env.encrypted'), Mockery::capture($output))->andReturn(100);
+        $this->artisan('env:encrypt', $this->incrementalOptions())->assertExitCode(0);
+
+        $this->assertSame("SECOND=$second\nFIRST=$first\n", $output);
+    }
+
+    public function testItRejectsAnEmptyInteractiveKeyWithoutOfferingGeneration(): void
+    {
+        $this->mockFiles('FIRST=1', 'existing');
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
+            ->expectsQuestion('What is the encryption key?', '')
+            ->expectsOutputToContain('The existing encryption key is required for incremental encryption.')
+            ->assertExitCode(1);
+    }
+
+    public function testItRejectsAnExplicitEmptyKeyNoninteractively(): void
+    {
+        $this->mockFiles('FIRST=1', 'existing');
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', $this->incrementalOptions(['--key' => '', '--no-interaction' => true]))
+            ->expectsOutputToContain('The existing encryption key is required for incremental encryption.')
+            ->assertExitCode(1);
+    }
+
+    public function testItRejectsAMissingSourceBeforeAskingForAKey(): void
+    {
+        $this->mockFiles(null, 'existing');
+        File::shouldReceive('put')->never();
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true])
+            ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }
 }

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -215,7 +215,13 @@ ENV;
 
     public static function invalidBaselines(): array
     {
-        return array_map(fn ($kind) => [$kind], ['blob', 'wrong-key', 'wrong-cipher', 'malformed', 'corrupt-deleted-entry']);
+        return [
+            'blob' => ['blob'],
+            'wrong-key' => ['wrong-key'],
+            'wrong-cipher' => ['wrong-cipher'],
+            'malformed' => ['malformed'],
+            'corrupt-deleted-entry' => ['corrupt-deleted-entry'],
+        ];
     }
 
     public function testItRequiresReadable(): void

--- a/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptIncrementalCommandTest.php
@@ -31,10 +31,9 @@ class EnvironmentEncryptIncrementalCommandTest extends TestCase
             ->andReturn($encryptedContent);
     }
 
-    #[DataProvider('ciphers')]
-    public function testItChangesOnlyTheEditedValue(string $cipher): void
+    public function testItChangesOnlyTheEditedValue(): void
     {
-        $encrypter = new Encrypter($this->key, $cipher);
+        $encrypter = new Encrypter($this->key, 'AES-256-CBC');
         $host = $encrypter->encryptString('localhost');
         $password = $encrypter->encryptString('1');
         $app = $encrypter->encryptString('production');
@@ -60,7 +59,7 @@ ENV;
             ->with(base_path('.env.encrypted'), Mockery::capture($encryptedOutput))
             ->andReturn(100);
 
-        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key, '--cipher' => $cipher])
+        $this->artisan('env:encrypt', ['--readable' => true, '--incremental' => true, '--key' => $this->key])
             ->assertExitCode(0);
 
         $lines = explode("\n", $encryptedOutput);
@@ -70,11 +69,6 @@ ENV;
         $payload = substr($lines[1], strlen('DB_PASSWORD='));
         $this->assertNotSame($password, $payload);
         $this->assertSame('2', $encrypter->decryptString($payload));
-    }
-
-    public static function ciphers(): array
-    {
-        return [['AES-256-CBC'], ['AES-256-GCM']];
     }
 
     public function testItDoesNotWriteWhenRawValuesAreUnchanged(): void


### PR DESCRIPTION
When updating a readable encrypted environment file, `env:encrypt --readable` now preserves encrypted values that have not changed. Previously, overwriting an existing encrypted file required `--force`, which encrypted every value again and made pull request diffs harder to review.

New or changed values are encrypted, and variables removed from `.env` are also removed from the encrypted file. The command creates the encrypted file if it does not exist. Existing readable files are updated without requiring `--force`; no additional option is needed.

### Before / after

For example, changing only `DB_PASSWORD=1` to `DB_PASSWORD=2` produces these diffs in the encrypted file. Encrypted values are shown as placeholders for readability.

**Before**, updating the existing file with `--readable --force` changed every encrypted value:

```diff
-APP_NAME=<previous encrypted app name>
-DB_HOST=<previous encrypted host>
-DB_PASSWORD=<previous encrypted password>
+APP_NAME=<new encrypted app name>
+DB_HOST=<new encrypted host>
+DB_PASSWORD=<new encrypted password>
```

**After**, updating it with `--readable` changes only the password entry:

```shell
php artisan env:encrypt --readable --key=3UVsEgGVK36XN82KKeyLFMhvosbZN1aF
```

```diff
 APP_NAME=<unchanged encrypted app name>
 DB_HOST=<unchanged encrypted host>
-DB_PASSWORD=<previous encrypted password>
+DB_PASSWORD=<new encrypted password>
```

Updating an existing file requires its encryption key and cipher. If the file is not readable, contains an invalid entry, or cannot be decrypted, the command fails without overwriting it.

`--readable --force` always encrypts all values again using the contents of `.env`, without reading the existing encrypted file. This allows key or cipher rotation and replacement of invalid encrypted files. Encryption without `--readable` retains its existing overwrite behavior.

A write returning `false` now fails the command before pruning in every encryption mode.

Validation: 190 tests passed with 1,060 assertions across the environment encryption, decryption, and command signature tests. Formatting checks passed.

Docs: https://github.com/laravel/docs/pull/11357.
