### PR TITLE
[13.x] Pass the exception to Eloquent violation callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -520,11 +520,13 @@ trait HasAttributes
         if ($this->exists &&
             ! $this->wasRecentlyCreated &&
             static::preventsAccessingMissingAttributes()) {
+            $exception = new MissingAttributeException($this, $key);
+
             if (isset(static::$missingAttributeViolationCallback)) {
-                return call_user_func(static::$missingAttributeViolationCallback, $this, $key);
+                return call_user_func(static::$missingAttributeViolationCallback, $this, $key, $exception);
             }
 
-            throw new MissingAttributeException($this, $key);
+            throw $exception;
         }
 
         return null;
@@ -613,15 +615,19 @@ trait HasAttributes
      */
     protected function handleLazyLoadingViolation($key)
     {
+        $exception = new LazyLoadingViolationException($this, $key);
+
         if (isset(static::$lazyLoadingViolationCallback)) {
-            return call_user_func(static::$lazyLoadingViolationCallback, $this, $key);
+            return call_user_func(
+                static::$lazyLoadingViolationCallback, $this, $key, $exception
+            );
         }
 
         if (! $this->exists || $this->wasRecentlyCreated) {
             return;
         }
 
-        throw new LazyLoadingViolationException($this, $key);
+        throw $exception;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -593,7 +593,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling lazy loading violations.
      *
-     * @param  (callable(self, string): mixed)|null  $callback
+     * @param  (callable(self, string, \Illuminate\Database\LazyLoadingViolationException): mixed)|null  $callback
      * @return void
      */
     public static function handleLazyLoadingViolationUsing(?callable $callback)
@@ -615,7 +615,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling discarded attribute violations.
      *
-     * @param  (callable(self, array): mixed)|null  $callback
+     * @param  (callable(self, array, \Illuminate\Database\Eloquent\MassAssignmentException): mixed)|null  $callback
      * @return void
      */
     public static function handleDiscardedAttributeViolationUsing(?callable $callback)
@@ -637,7 +637,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling missing attribute violations.
      *
-     * @param  (callable(self, string): mixed)|null  $callback
+     * @param  (callable(self, string, \Illuminate\Database\Eloquent\MissingAttributeException): mixed)|null  $callback
      * @return void
      */
     public static function handleMissingAttributeViolationUsing(?callable $callback)
@@ -687,13 +687,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             } elseif ($totallyGuarded || static::preventsSilentlyDiscardingAttributes()) {
+                $exception = new MassAssignmentException(sprintf(
+                    'Add [%s] to fillable property to allow mass assignment on [%s].',
+                    $key, get_class($this)
+                ));
+
                 if (isset(static::$discardedAttributeViolationCallback)) {
-                    call_user_func(static::$discardedAttributeViolationCallback, $this, [$key]);
+                    call_user_func(static::$discardedAttributeViolationCallback, $this, [$key], $exception);
                 } else {
-                    throw new MassAssignmentException(sprintf(
-                        'Add [%s] to fillable property to allow mass assignment on [%s].',
-                        $key, get_class($this)
-                    ));
+                    throw $exception;
                 }
             }
         }
@@ -702,14 +704,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             static::preventsSilentlyDiscardingAttributes()) {
             $keys = array_diff(array_keys($attributes), array_keys($fillable));
 
+            $exception = new MassAssignmentException(sprintf(
+                'Add fillable property [%s] to allow mass assignment on [%s].',
+                implode(', ', $keys),
+                get_class($this)
+            ));
+
             if (isset(static::$discardedAttributeViolationCallback)) {
-                call_user_func(static::$discardedAttributeViolationCallback, $this, $keys);
+                call_user_func(static::$discardedAttributeViolationCallback, $this, $keys, $exception);
             } else {
-                throw new MassAssignmentException(sprintf(
-                    'Add fillable property [%s] to allow mass assignment on [%s].',
-                    implode(', ', $keys),
-                    get_class($this)
-                ));
+                throw $exception;
             }
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1930,9 +1930,11 @@ class DatabaseEloquentModelTest extends TestCase
 
         $callbackModel = null;
         $callbackKeys = null;
-        Model::handleDiscardedAttributeViolationUsing(function ($model, $keys) use (&$callbackModel, &$callbackKeys) {
+        $callbackException = null;
+        Model::handleDiscardedAttributeViolationUsing(function ($model, $keys, $exception) use (&$callbackModel, &$callbackKeys, &$callbackException) {
             $callbackModel = $model;
             $callbackKeys = $keys;
+            $callbackException = $exception;
         });
 
         $model = new EloquentModelStub;
@@ -1941,6 +1943,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertInstanceOf(EloquentModelStub::class, $callbackModel);
         $this->assertEquals(['Foo'], $callbackKeys);
+        $this->assertInstanceOf(MassAssignmentException::class, $callbackException);
+        $this->assertSame('Add [Foo] to fillable property to allow mass assignment on ['.EloquentModelStub::class.'].', $callbackException->getMessage());
 
         Model::preventSilentlyDiscardingAttributes(false);
         Model::handleDiscardedAttributeViolationUsing(null);
@@ -3545,10 +3549,12 @@ class DatabaseEloquentModelTest extends TestCase
 
         $callbackModel = null;
         $callbackKey = null;
+        $callbackException = null;
 
-        Model::handleMissingAttributeViolationUsing(function ($model, $key) use (&$callbackModel, &$callbackKey) {
+        Model::handleMissingAttributeViolationUsing(function ($model, $key, $exception) use (&$callbackModel, &$callbackKey, &$callbackException) {
             $callbackModel = $model;
             $callbackKey = $key;
+            $callbackException = $exception;
         });
 
         $model = new EloquentModelStub(['id' => 1]);
@@ -3560,6 +3566,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertInstanceOf(EloquentModelStub::class, $callbackModel);
         $this->assertSame('this_attribute_does_not_exist', $callbackKey);
+        $this->assertInstanceOf(MissingAttributeException::class, $callbackException);
 
         Model::preventAccessingMissingAttributes($originalMode);
         Model::handleMissingAttributeViolationUsing(null);

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -119,7 +119,11 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     {
         Event::fake();
 
-        Model::handleLazyLoadingViolationUsing(function ($model, $key) {
+        $callbackException = null;
+
+        Model::handleLazyLoadingViolationUsing(function ($model, $key, $exception) use (&$callbackException) {
+            $callbackException = $exception;
+
             event(new ViolatedLazyLoadingEvent($model, $key));
         });
 
@@ -131,6 +135,8 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
         $models[0]->modelTwos;
 
         Event::assertDispatched(ViolatedLazyLoadingEvent::class);
+        $this->assertInstanceOf(LazyLoadingViolationException::class, $callbackException);
+        $this->assertSame(EloquentStrictLoadingTestModel1::class, $callbackException->model);
     }
 
     public function testStrictModeWithOverriddenHandlerOnLazyLoading()


### PR DESCRIPTION
We currently use a bunch of strict mode callbacks, such as `handleLazyLoadingViolationUsing` & `handleMissingAttributeViolationUsing`  

Today, we reconstruct the exception copying the framework based on the environment:

```php
  Model::handleMissingAttributeViolationUsing(function (Model $model, string $key): void {
      $exception = new MissingAttributeException($model, $key);

      app()->environment('xxx')
          ? Log::error('Missing attribute', [
               'exception' => $exception
          ])
          : throw $exception;
  });
```  

This PR makes it so we can access the exception, so we no longer need to worry about reconstructing it..
```php
  Model::handleMissingAttributeViolationUsing(function (Model $model, string $key, $exception): void {
      app()->environment('xxx')
          ? Log::error('Missing attribute', ['exception' => $exception])
          : throw $exception;
  });
``` 

I can move this to 14.x if you prefer but there's no b/c afaik, so sent here.