### PR TITLE
[13.x] Compare lowercased index names in hasIndex

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -444,6 +444,7 @@ class Builder
     public function hasIndex($table, $index, $type = null)
     {
         $type = is_null($type) ? $type : strtolower($type);
+
         $index = is_string($index) ? strtolower($index) : $index;
 
         foreach ($this->getIndexes($table) as $value) {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -444,6 +444,7 @@ class Builder
     public function hasIndex($table, $index, $type = null)
     {
         $type = is_null($type) ? $type : strtolower($type);
+        $index = is_string($index) ? strtolower($index) : $index;
 
         foreach ($this->getIndexes($table) as $value) {
             $typeMatches = is_null($type)

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -418,6 +418,17 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertFalse(Schema::hasIndex('foo', ['bar'], 'unique'));
     }
 
+    public function testHasIndexNameIsCaseInsensitive()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->string('bar')->index('IDX_MyIndex');
+        });
+
+        $this->assertTrue(Schema::hasIndex('foo', 'IDX_MyIndex'));
+        $this->assertTrue(Schema::hasIndex('foo', 'idx_myindex'));
+        $this->assertSame('idx_myindex', Schema::getIndexes('foo')[0]['name']);
+    }
+
     public function testGetUniqueIndexes()
     {
         Schema::create('foo', function (Blueprint $table) {


### PR DESCRIPTION
`Schema::hasIndex()` already lowercases `$type`, and the query processors lowercase index names in `processIndexes()`. The name argument was still compared with `===`, so mixed-case names missed.

This matches the other schema existence checks, which already compare case-insensitively:

- `hasTable()`
- `hasView()`
- `hasColumn()` / `hasColumns()`
- `getColumnType()` ([#51431](https://github.com/laravel/framework/pull/51431))

String index names are lowercased the same way `$type` is in `hasIndex()`.