### PR TITLE
[13.x] Render the same message shape whether or not request exceptions are truncated

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Http\Client;
 
 use GuzzleHttp\Psr7\Message;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\ResponseInterface;
 
 class RequestException extends HttpClientException
 {
@@ -113,11 +115,34 @@ class RequestException extends HttpClientException
         $summary = null;
 
         if (is_int($truncateExceptionsAt)) {
-            $summary = Message::bodySummary($psrResponse, $truncateExceptionsAt);
+            $summary = $this->summarize($psrResponse, $truncateExceptionsAt);
         } elseif (($body = $psrResponse->getBody())->isSeekable() && $body->isReadable()) {
             $summary = Message::toString($psrResponse);
         }
 
         return is_null($summary) ? $message : $message.":\n{$summary}\n";
+    }
+
+    /**
+     * Summarize the response, truncating its body at the given length.
+     *
+     * The status line and the headers are always rendered in full. They are
+     * the part of the message that makes a failure diagnosable, they are
+     * bounded in practice, and truncating the body is what the truncation
+     * setting is asking for.
+     *
+     * @param  \Psr\Http\Message\ResponseInterface  $response
+     * @param  int  $truncateAt
+     * @return string|null
+     */
+    protected function summarize(ResponseInterface $response, int $truncateAt)
+    {
+        $body = Message::bodySummary($response, $truncateAt);
+
+        if (is_null($body)) {
+            return null;
+        }
+
+        return Message::toString($response->withBody(Utils::streamFor($body)));
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1758,12 +1758,12 @@ class HttpClientTest extends TestCase
         }
 
         // Ensure the exception message is truncated according to the request level truncation setting.
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $exception->report();
 
         // Ensure that the truncation level is not changed when reporting the exception.
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertEquals(60, RequestException::$truncateAt);
     }
@@ -1808,7 +1808,7 @@ class HttpClientTest extends TestCase
 
         $exception->report();
 
-        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertFalse(RequestException::$truncateAt);
     }
@@ -1825,8 +1825,57 @@ class HttpClientTest extends TestCase
         $exception->report();
 
         $this->assertInstanceOf(RequestException::class, $exception);
-        $this->assertSame("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"er (truncated...)\n", $exception->getMessage());
         $this->assertFalse(RequestException::$truncateAt);
+    }
+
+    public function testTruncatedExceptionMessageIncludesTheStatusLineAndHeaders()
+    {
+        RequestException::truncateAt(120);
+
+        $response = new Psr7Response(405, [
+            'Server' => 'nginx/1.20.1',
+            'Content-Type' => 'text/html; charset=utf-8',
+        ], str_repeat('a', 200));
+
+        $exception = new RequestException(new Response($response));
+
+        $this->assertSame(
+            "HTTP request returned status code 405:\nHTTP/1.1 405 Method Not Allowed\r\nServer: nginx/1.20.1\r\nContent-Type: text/html; charset=utf-8\r\n\r\n".str_repeat('a', 120)." (truncated...)\n",
+            $exception->getMessage()
+        );
+    }
+
+    public function testTruncatedAndUntruncatedExceptionMessagesOnlyDifferInTheBody()
+    {
+        $headers = ['Server' => 'nginx/1.20.1', 'Content-Type' => 'application/json'];
+
+        $body = str_repeat('a', 200);
+
+        RequestException::dontTruncate();
+        $untruncated = (new RequestException(new Response(new Psr7Response(405, $headers, $body))))->getMessage();
+
+        RequestException::truncateAt(120);
+        $truncated = (new RequestException(new Response(new Psr7Response(405, $headers, $body))))->getMessage();
+
+        $head = "HTTP request returned status code 405:\nHTTP/1.1 405 Method Not Allowed\r\nServer: nginx/1.20.1\r\nContent-Type: application/json\r\n\r\n";
+
+        $this->assertStringStartsWith($head, $untruncated);
+        $this->assertStringStartsWith($head, $truncated);
+    }
+
+    public function testHeadersAreNotCountedTowardsTheTruncationLimit()
+    {
+        RequestException::truncateAt(10);
+
+        $response = new Psr7Response(500, [
+            'X-Long-Header' => str_repeat('b', 500),
+        ], str_repeat('a', 200));
+
+        $exception = new RequestException(new Response($response));
+
+        $this->assertStringContainsString('X-Long-Header: '.str_repeat('b', 500), $exception->getMessage());
+        $this->assertStringEndsWith("\r\n\r\n".str_repeat('a', 10)." (truncated...)\n", $exception->getMessage());
     }
 
     public function testRequestExceptionEmptyBody()


### PR DESCRIPTION
Fixes #61216

## The problem

`RequestException::prepareMessage()` picks a different Guzzle formatter depending on whether truncation is enabled:

```php
if (is_int($truncateExceptionsAt)) {
    $summary = Message::bodySummary($psrResponse, $truncateExceptionsAt);
} elseif (($body = $psrResponse->getBody())->isSeekable() && $body->isReadable()) {
    $summary = Message::toString($psrResponse);
}
```

`Message::bodySummary()` only ever returns the body. `Message::toString()` serializes the whole raw HTTP message — status line, headers and body. So the same failure produces two different message shapes, and the truncated one, which is the default, silently drops everything above the body:

```
// RequestException::dontTruncate()
HTTP request returned status code 405:
HTTP/1.1 405 Method Not Allowed
Server: nginx/1.20.1
Content-Type: text/html; charset=utf-8
Content-Length: 906242

<!DOCTYPE html> ...

// RequestException::truncateAt(2048)
HTTP request returned status code 405:
<!DOCTYPE html> ...
```

## A note on the diagnosis

Credit where it is due: @moemadeldin identified the exact cause in the issue thread — two different Guzzle helpers rather than anything environment specific. This confirms that reading and fixes it.

The follow-up question there was whether headers should also be size limited. @alecpl laid out three options and @iz-ahmad preferred excluding headers from the limit. This PR implements that option, and the default truncation length settles it: at 120 characters, counting headers towards the limit would leave no room for the body at all, which is the part the setting exists to bound.

## The fix

Rather than reimplementing Guzzle's serialization for the truncated branch, feed the truncated body back through the same formatter:

```php
protected function summarize(ResponseInterface $response, int $truncateAt)
{
    $body = Message::bodySummary($response, $truncateAt);

    if (is_null($body)) {
        return null;
    }

    return Message::toString($response->withBody(Utils::streamFor($body)));
}
```

Both modes now emit an identical shape; only the body differs.

## Benefit to end users

The default exception message becomes diagnosable on its own. `Content-Type`, `Content-Length`, `Retry-After`, `X-Request-Id` and whatever else the upstream API returns now reach the logs and the error tracker on the first failure.

Today, working out why a third-party API returned a 4xx or 5xx means enabling `dontTruncate()` and reproducing the failure — and `dontTruncate()` then dumps the entire body, which is exactly what the truncation setting was added to avoid. This PR removes that trade-off: you keep bounded messages and still get the headers.

## Why this does not break existing behaviour

- **Guzzle stays the single source of formatting.** Reusing `Message::toString()` rather than hand-rolling the head means the `Set-Cookie` special case (one line per value) and the incomplete-UTF-8-character trimming in `bodySummary()` keep working, and will keep tracking Guzzle if either changes. Both are covered below.
- **The response is not mutated.** `withBody()` returns a PSR-7 clone. `bodySummary()` already restores the stream position, and I verified it explicitly: with the cursor at byte 42 before constructing the exception, it is still at 42 afterwards.
- **No public API change.** `summarize()` is a new `protected` method. The truncation settings, their precedence and `report()`'s idempotency are untouched.
- **Bodies shorter than the limit** now produce byte-for-byte identical messages in both modes.

## What this deliberately does not change

When `bodySummary()` returns `null` — an empty body, or a body that is not printable — the truncated message stays as it is today, with no summary at all, while `dontTruncate()` would show the headers. This PR is about the *shape* of the summary, not about *when* one is produced; changing that would also change `testRequestExceptionEmptyBody`, which asserts that intended behaviour. Happy to fold it in if you would rather close that gap too.

## Tests

`tests/Http` passes in full (614 tests). Three new tests, all of which fail on `13.x` without this change:

- `testTruncatedExceptionMessageIncludesTheStatusLineAndHeaders`
- `testTruncatedAndUntruncatedExceptionMessagesOnlyDifferInTheBody`
- `testHeadersAreNotCountedTowardsTheTruncationLimit` — a 500-byte header survives intact under `truncateAt(10)` while the body is cut to 10

Three existing assertions were updated to the new shape. They are the only assertions in the framework that pinned the old format; the `expectExceptionMessage()` cases match on substrings and were unaffected.
