### PR TITLE
[13.x] Don't pass the service provider array by reference when booting

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1135,9 +1135,20 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // finished. This is useful when ordering the boot-up processes we run.
         $this->fireAppCallbacks($this->bootingCallbacks);
 
-        array_walk($this->serviceProviders, function ($p) {
-            $this->bootProvider($p);
-        });
+        // Providers are allowed to register additional providers while booting, so we
+        // will keep looping until every registered provider has been booted. The
+        // provider array must not be passed by reference here, as PHP would then
+        // turn the property into a reference that every clone of the application
+        // would share, letting a write on one clone empty the other's array.
+        $booted = [];
+
+        while (($pending = array_diff_key($this->serviceProviders, $booted)) !== []) {
+            foreach ($pending as $key => $provider) {
+                $booted[$key] = true;
+
+                $this->bootProvider($provider);
+            }
+        }
 
         $this->booted = true;
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -383,6 +383,18 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals(4, $counter);
     }
 
+    public function testProvidersRegisteredWhileBootingAreBooted()
+    {
+        ApplicationLateRegisteredServiceProviderStub::$booted = false;
+
+        $application = new Application;
+        $application->register(new ApplicationProviderRegisteringAnotherProviderStub($application));
+
+        $application->boot();
+
+        $this->assertTrue(ApplicationLateRegisteredServiceProviderStub::$booted);
+    }
+
     public function testGetNamespace()
     {
         $app1 = new Application(realpath(__DIR__.'/Fixtures/laravel1'));
@@ -672,6 +684,24 @@ class ApplicationBasicServiceProviderStub extends ServiceProvider
     public function register()
     {
         //
+    }
+}
+
+class ApplicationLateRegisteredServiceProviderStub extends ServiceProvider
+{
+    public static $booted = false;
+
+    public function boot()
+    {
+        static::$booted = true;
+    }
+}
+
+class ApplicationProviderRegisteringAnotherProviderStub extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->app->register(new ApplicationLateRegisteredServiceProviderStub($this->app));
     }
 }
 


### PR DESCRIPTION
`Application::boot()` passes `$this->serviceProviders` by reference to `array_walk()`. If anything retains a stack trace containing that frame while the providers boot, the reference outlives the call and the property stays a PHP reference. Every `clone` of the application then shares the array, so a write on one clone lands on the original too.

Octane does exactly that. It clones the application for each request in `Worker::handle()` and calls `$sandbox->flush()` once the request is done. `flush()` runs `$this->serviceProviders = []`, which writes through the shared reference and empties the real application's provider list for good. From the second request onwards, for the rest of that worker's life, `getProvider()` returns `null` and `getProviders()` returns `[]` for every provider.

Nothing complains until something reads those methods. In my case that was Octane's own `FlushLocaleState`:

```php
collect($event->sandbox->getProviders($provider))
    ->values()
    ->whenNotEmpty(fn ($providers) => $providers->first()->setAppGetter(fn () => $event->sandbox));
```

With an empty provider list `whenNotEmpty()` never fires, so Carbon's service provider keeps the app getter it received on the first request, a sandbox that has since been flushed. The next `App::setLocale()` reaches Carbon's `LocaleUpdated` listener, which calls `getLocale()` on that dead container, and the request dies with:

```
Illuminate\Contracts\Container\BindingResolutionException
Target class [config] does not exist.

at vendor/nesbot/carbon/src/Carbon/Laravel/ServiceProvider.php:142
```

### Reproducing

Pinning the reference needs Xdebug in `develop` mode, which attaches collected arguments to exception objects, plus something that keeps an exception created while the providers boot. `barryvdh/laravel-debugbar` keeps one, which is how I ran into this in a plain dev setup. Minimal repro, no Laravel:

```php
class A {
    protected $p = ['a' => 1, 'b' => 2];
    public static $kept = null;

    public function walk(): void {
        array_walk($this->p, function ($v, $k) {
            if ($k === 'a') {
                try { throw new RuntimeException; } catch (Throwable $e) { self::$kept = $e; }
            }
        });
    }

    public function wipe(): void { $this->p = []; }
    public function n(): int { return count($this->p); }
}

$a = new A;
$a->walk();

$b = clone $a;
$b->wipe();

echo $a->n(); // 0 with xdebug.mode=develop, 2 otherwise
```

I also confirmed the mechanism in the real application. `ReflectionReference::fromArrayElement()` on the property reports a reference as soon as `array_walk()` returns, and a tripwire inside `flush()` shows it only ever runs on the sandboxes. The root application still loses all 91 of its providers.

### The fix

`array_walk()` is there on purpose. It keeps walking the array as elements are appended to it, so a provider registered inside another provider's `boot()` still gets booted. A plain `foreach` was tried in #37392, broke that (#37403) and was reverted in #37405.

This keeps that behaviour without taking the property by reference. It loops until every registered provider has booted, iterating over a copy on each pass. Providers registered while booting are still picked up, and I added a test for it so #37403 cannot come back quietly.

I left out a test for the reference itself. Pinning it needs Xdebug's `develop` mode, so the test could never fail in CI and would only look like coverage.
