### PR TITLE
[13.x] Fix Factory::raw() with a count of zero

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -250,6 +250,10 @@ abstract class Factory
             return $this->state($attributes)->getExpandedAttributes($parent);
         }
 
+        if ($this->count < 1) {
+            return [];
+        }
+
         return array_map(function () use ($attributes, $parent) {
             return $this->state($attributes)->getExpandedAttributes($parent);
         }, range(1, $this->count));

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -269,6 +269,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(10, $posts);
     }
 
+    public function test_model_attributes_can_be_created_with_a_count_of_zero()
+    {
+        $posts = FactoryTestPostFactory::new()->count(0)->raw();
+
+        $this->assertSame([], $posts);
+    }
+
     public function test_after_creating_and_making_callbacks_are_called()
     {
         $user = FactoryTestUserFactory::new()


### PR DESCRIPTION
  ### **The Problem:**
  The Factory raw() method returns a non-zero list in the following scenarios:
  
  
  ```
  // This returns a list of 2 elements while the expected is an empty list
  UserFactory::new()->count(0)->raw()
  ```
  ```
  // This returns a list of 5 elements while the expected is an empty list
  UserFactory::new()->count(-3)->raw();
  ```
  
  ### Why?
  The range() function is behaving this way:
  ```
  range(1,0) -> [1, 0]
  range(1,-3) -> [1, 0, -1, -2, -3]
  ```
  
  ### The Solution:
  Add this check in the raw() method implementation:
  ```
  if ($this->count < 1) {
        return [];
  }
  ```
  
  The Factory make() method already includes this condition.
  
  
  ### Test:
  vendor\bin\phpunit tests\Database\DatabaseEloquentFactoryTest.php --filter test_model_attributes_can_be_created_with_a_count_of_zero