### PR TITLE
[13.x] Add copyToDisk & moveToDisk to FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Filesystem\Cloud as CloudFilesystemContract;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Http\File;
 use Illuminate\Http\Request;
@@ -665,6 +666,46 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         return true;
+    }
+
+    /**
+     * Copy a file to another disk.
+     *
+     * @param  string  $from
+     * @param  string  $disk
+     * @param  string|null  $to
+     * @return bool
+     */
+    public function copyToDisk($from, $disk, $to = null)
+    {
+        $stream = $this->readStream($from);
+
+        if (! is_resource($stream)) {
+            return false;
+        }
+
+        try {
+            return Container::getInstance()->make(FilesystemFactory::class)->disk($disk)->writeStream(
+                $to ?? $from, $stream
+            );
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+
+    /**
+     * Move a file to another disk.
+     *
+     * @param  string  $from
+     * @param  string  $disk
+     * @param  string|null  $to
+     * @return bool
+     */
+    public function moveToDisk($from, $disk, $to = null)
+    {
+        return $this->copyToDisk($from, $disk, $to) && $this->delete($from);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -671,13 +671,19 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Copy a file to another disk.
      *
-     * @param  string  $from
      * @param  string  $disk
+     * @param  string  $from
      * @param  string|null  $to
      * @return bool
      */
-    public function copyToDisk($from, $disk, $to = null)
+    public function copyToDisk($disk, $from, $to = null)
     {
+        $destination = Container::getInstance()->make(FilesystemFactory::class)->disk($disk);
+
+        if ($destination === $this && ($to ?? $from) === $from) {
+            throw new InvalidArgumentException('Cannot copy a file to the same disk and path.');
+        }
+
         $stream = $this->readStream($from);
 
         if (! is_resource($stream)) {
@@ -685,9 +691,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         try {
-            return Container::getInstance()->make(FilesystemFactory::class)->disk($disk)->writeStream(
-                $to ?? $from, $stream
-            );
+            return $destination->writeStream($to ?? $from, $stream);
         } finally {
             if (is_resource($stream)) {
                 fclose($stream);
@@ -698,14 +702,14 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Move a file to another disk.
      *
-     * @param  string  $from
      * @param  string  $disk
+     * @param  string  $from
      * @param  string|null  $to
      * @return bool
      */
-    public function moveToDisk($from, $disk, $to = null)
+    public function moveToDisk($disk, $from, $to = null)
     {
-        return $this->copyToDisk($from, $disk, $to) && $this->delete($from);
+        return $this->copyToDisk($disk, $from, $to) && $this->delete($from);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -32,6 +32,8 @@ use function Illuminate\Support\enum_value;
  * @method static string|false putFile(\Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null $file = null, mixed $options = [])
  * @method static string|false putFileAs(\Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null $file, string|array|null $name = null, mixed $options = [])
  * @method static bool writeStream(string $path, resource $resource, array $options = [])
+ * @method static bool copyToDisk(string $disk, string $from, string|null $to = null)
+ * @method static bool moveToDisk(string $disk, string $from, string|null $to = null)
  * @method static string getVisibility(string $path)
  * @method static bool setVisibility(string $path, string $visibility)
  * @method static bool prepend(string $path, string $data)

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Filesystem;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
@@ -340,6 +341,40 @@ class FilesystemAdapterTest extends TestCase
 
         $this->assertFileExists($this->tempDir.'/foo/foo2.txt');
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
+    }
+
+    public function testCopyToDisk()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $backupFilesystem = new Filesystem($backupAdapter = new LocalFilesystemAdapter($this->tempDir.'/backup'));
+
+        Container::getInstance()->instance(FilesystemFactory::class, Mockery::mock(FilesystemFactory::class, [
+            'disk' => new FilesystemAdapter($backupFilesystem, $backupAdapter),
+        ]));
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $filesystemAdapter->copyToDisk('file.txt', 'backup');
+
+        $this->assertFileExists($this->tempDir.'/file.txt');
+        $this->assertFileExists($this->tempDir.'/backup/file.txt');
+    }
+
+    public function testMoveToDisk()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $backupFilesystem = new Filesystem($backupAdapter = new LocalFilesystemAdapter($this->tempDir.'/backup'));
+
+        Container::getInstance()->instance(FilesystemFactory::class, Mockery::mock(FilesystemFactory::class, [
+            'disk' => new FilesystemAdapter($backupFilesystem, $backupAdapter),
+        ]));
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $filesystemAdapter->moveToDisk('file.txt', 'backup', 'copy.txt');
+
+        Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
+        $this->assertFileExists($this->tempDir.'/backup/copy.txt');
     }
 
     public function testStream()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -354,7 +354,7 @@ class FilesystemAdapterTest extends TestCase
         ]));
 
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $filesystemAdapter->copyToDisk('file.txt', 'backup');
+        $filesystemAdapter->copyToDisk('backup', 'file.txt');
 
         $this->assertFileExists($this->tempDir.'/file.txt');
         $this->assertFileExists($this->tempDir.'/backup/file.txt');
@@ -371,10 +371,25 @@ class FilesystemAdapterTest extends TestCase
         ]));
 
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $filesystemAdapter->moveToDisk('file.txt', 'backup', 'copy.txt');
+        $filesystemAdapter->moveToDisk('backup', 'file.txt', 'copy.txt');
 
         Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
         $this->assertFileExists($this->tempDir.'/backup/copy.txt');
+    }
+
+    public function testCopyToDiskRejectsSameDiskAndPath()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        Container::getInstance()->instance(FilesystemFactory::class, Mockery::mock(FilesystemFactory::class, [
+            'disk' => $filesystemAdapter,
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $filesystemAdapter->copyToDisk('local', 'file.txt');
     }
 
     public function testStream()


### PR DESCRIPTION
Today moving / copying a file looks something like this:

```php
$stream = Storage::disk('local')->readStream('reports/report.csv');

Storage::disk('s3')->writeStream('reports/report.csv', $stream);

fclose($stream);

Storage::disk('local')->delete('reports/report.csv');
``` 

It's easy to forget to fclose, depending on the adapter type, and the logic gets duplicated over the place meaning it often bites you.

We've ended up macro'ing it, but, it got me thinking that it **would be cool** if the framework had a way to do disk to disk copy/move 

you miss 100% of shots you don't take, SO, this PR adds `copyToDisk` and `moveToDisk` 

```php
Storage::disk('local')->moveToDisk('backup', 'reports/report.csv'); // copies to the backup disk, deleting the file from local disk
Storage::disk('local')->copyToDisk('backup', 'reports/report.csv', ); // copies to the backup disk, retaining it on the local disk


// Or you can specify a completely different path...   
Storage::disk('local')->copyToDisk('s3', 'reports/report.csv', '2026/report.csv'); // copys to a new path on the archive disk
``` 
These new methods just stream the file, like the read through filesystem driver, but useful for when you need to do it in jobs, etc.

I went with just adding it into FilesystemAdapter but wasn't sure on the method names, but open to feedback if you like it 🤷🏻  

Windows tests are failing cos its flaky, not me 🗡️ 