### PR TITLE
[13.x] Update SupportBinaryCodecTest

### DIFF
--- a/tests/Support/SupportBinaryCodecTest.php
+++ b/tests/Support/SupportBinaryCodecTest.php
@@ -170,6 +170,6 @@ class SupportBinaryCodecTest extends TestCase
 
         // Invalid UTF-8 sequences
         $this->assertTrue(BinaryCodec::isBinary("\xFF\xFE"));
-        $this->assertTrue(BinaryCodec::isBinary(random_bytes(16)));
+        $this->assertTrue(BinaryCodec::isBinary("\xE3\x81"));
     }
 }


### PR DESCRIPTION
This flaked on me here https://github.com/laravel/framework/actions/runs/34403846162/job/102641947163?pr=61511#step:5:287 

random_bytes(16) can actually return valid UTF8, so, this PR makes sure it doesn't flake

`\xE3\x81` is just part of a (japanese) byte sequence so, this always be true... (could argue we could remove it, but at least this covers more than 1 set)