### PR TITLE
[13.x] Add scheduler assertions

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -17,6 +17,8 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
@@ -457,6 +459,166 @@ class Schedule
             $this->events(),
             static fn (Event $event) => array_any($environments, $event->runsInEnvironment(...))
         ));
+    }
+
+    /**
+     * Assert that the given command or job has been scheduled.
+     *
+     * Jobs may be asserted by their class name unless the event has been renamed.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|object|string  $command
+     * @param  string|null  $expression
+     * @return $this
+     */
+    public function assertScheduled($command, $expression = null)
+    {
+        $command = $this->normalizeScheduledCommand($command);
+
+        $events = $this->scheduledEventsFor($command);
+
+        PHPUnit::assertTrue(
+            $events->isNotEmpty(),
+            "The expected [{$command}] command was not scheduled.".$this->scheduledCommandsForDisplay()
+        );
+
+        if (! is_null($expression)) {
+            PHPUnit::assertTrue(
+                $events->contains(fn (Event $event) => $event->getExpression() === $expression && is_null($event->repeatSeconds)),
+                sprintf(
+                    'The [%s] command was scheduled, but not with the [%s] frequency. Found [%s].',
+                    $command,
+                    $expression,
+                    $events->map(fn (Event $event) => $this->frequencyForDisplay($event))->join('], [')
+                )
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given command or job has not been scheduled.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|object|string  $command
+     * @return $this
+     */
+    public function assertNotScheduled($command)
+    {
+        $command = $this->normalizeScheduledCommand($command);
+
+        PHPUnit::assertTrue(
+            $this->scheduledEventsFor($command)->isEmpty(),
+            "The unexpected [{$command}] command was scheduled."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that no commands or jobs have been scheduled.
+     *
+     * @return $this
+     */
+    public function assertNothingScheduled()
+    {
+        PHPUnit::assertEmpty(
+            $this->events(),
+            'Commands were scheduled unexpectedly.'.$this->scheduledCommandsForDisplay()
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get the scheduled events matching the given command.
+     *
+     * @param  string  $command
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Console\Scheduling\Event>
+     */
+    protected function scheduledEventsFor($command)
+    {
+        $binary = Application::phpBinary().' '.Application::artisanBinary();
+
+        return (new Collection($this->events()))
+            ->filter(function (Event $event) use ($command, $binary) {
+                $scheduled = $this->scheduledCommandName($event, $binary);
+
+                return $scheduled === $command || str_starts_with($scheduled, $command.' ');
+            })
+            ->values();
+    }
+
+    /**
+     * Resolve the given command into the name it is scheduled under.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|object|string  $command
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function normalizeScheduledCommand($command)
+    {
+        if ($command instanceof SymfonyCommand) {
+            $name = $command->getName();
+        } elseif (is_object($command)) {
+            $name = method_exists($command, 'displayName') ? $command->displayName() : $command::class;
+        } elseif (is_string($command) && is_a($command, SymfonyCommand::class, true)) {
+            $name = Container::getInstance()->make($command)->getName();
+        } else {
+            $name = $command;
+        }
+
+        if (! is_string($name) || $name === '') {
+            throw new InvalidArgumentException('Unable to determine the name of the given command.');
+        }
+
+        return $name;
+    }
+
+    /**
+     * Get the name the given event is scheduled under.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  string  $binary
+     * @return string
+     */
+    protected function scheduledCommandName(Event $event, $binary)
+    {
+        return is_null($event->command)
+            ? $event->getSummaryForDisplay()
+            : trim(str_replace($binary, '', $event->command));
+    }
+
+    /**
+     * Get the frequency of the given event for display within a failure message.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    protected function frequencyForDisplay(Event $event)
+    {
+        return is_null($event->repeatSeconds)
+            ? $event->getExpression()
+            : $event->getExpression()." every {$event->repeatSeconds} seconds";
+    }
+
+    /**
+     * Get all of the scheduled commands for display within a failure message.
+     *
+     * @return string
+     */
+    protected function scheduledCommandsForDisplay()
+    {
+        $binary = Application::phpBinary().' '.Application::artisanBinary();
+
+        $scheduled = (new Collection($this->events()))
+            ->map(fn (Event $event) => $this->scheduledCommandName($event, $binary));
+
+        if ($scheduled->isEmpty()) {
+            return ' No commands have been scheduled.';
+        }
+
+        return ' The following commands have been scheduled: ['.$scheduled->join('], [').'].';
     }
 
     /**

--- a/tests/Console/Scheduling/ScheduleAssertionsTest.php
+++ b/tests/Console/Scheduling/ScheduleAssertionsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Scheduling\CacheEventMutex;
+use Illuminate\Console\Scheduling\CacheSchedulingMutex;
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
+use InvalidArgumentException;
+use Mockery as m;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+class ScheduleAssertionsTest extends TestCase
+{
+    protected Schedule $schedule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = Container::getInstance();
+
+        $container->instance(EventMutex::class, m::mock(CacheEventMutex::class));
+        $container->instance(SchedulingMutex::class, m::mock(CacheSchedulingMutex::class));
+
+        $this->schedule = new Schedule;
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testAssertScheduledMatchesCommandBySignature()
+    {
+        $this->schedule->command('foo:bar')->daily();
+
+        $this->schedule->assertScheduled('foo:bar');
+    }
+
+    public function testAssertScheduledMatchesCommandByClass()
+    {
+        $this->schedule->command(ScheduleAssertionsTestCommand::class)->daily();
+
+        $this->schedule->assertScheduled(ScheduleAssertionsTestCommand::class);
+        $this->schedule->assertScheduled('foo:bar');
+    }
+
+    public function testAssertScheduledMatchesCommandWithParameters()
+    {
+        $this->schedule->command('foo:bar', ['--force'])->daily();
+
+        $this->schedule->assertScheduled('foo:bar');
+    }
+
+    public function testAssertScheduledMatchesJobByClass()
+    {
+        $this->schedule->job(ScheduleAssertionsTestJob::class)->daily();
+
+        $this->schedule->assertScheduled(ScheduleAssertionsTestJob::class);
+    }
+
+    public function testAssertScheduledMatchesGivenExpression()
+    {
+        $this->schedule->command('foo:bar')->dailyAt('03:00');
+
+        $this->schedule->assertScheduled('foo:bar', '0 3 * * *');
+    }
+
+    public function testAssertScheduledFailsWhenExpressionDoesNotMatch()
+    {
+        $this->schedule->command('foo:bar')->hourly();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The [foo:bar] command was scheduled, but not with the [0 3 * * *] frequency. Found [0 * * * *].');
+
+        $this->schedule->assertScheduled('foo:bar', '0 3 * * *');
+    }
+
+    public function testAssertScheduledFailsWhenCommandIsNotScheduled()
+    {
+        $this->schedule->command('foo:bar')->daily();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The expected [baz:qux] command was not scheduled. The following commands have been scheduled: [foo:bar].');
+
+        $this->schedule->assertScheduled('baz:qux');
+    }
+
+    public function testAssertNotScheduled()
+    {
+        $this->schedule->command('foo:bar')->daily();
+
+        $this->schedule->assertNotScheduled('baz:qux');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The unexpected [foo:bar] command was scheduled.');
+
+        $this->schedule->assertNotScheduled('foo:bar');
+    }
+
+    public function testAssertNothingScheduled()
+    {
+        $this->schedule->assertNothingScheduled();
+
+        $this->schedule->command('foo:bar')->daily();
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->schedule->assertNothingScheduled();
+    }
+
+    public function testSubMinuteEventsDoNotSatisfyTheEveryMinuteExpression()
+    {
+        $this->schedule->command('foo:bar')->everyTenSeconds();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The [foo:bar] command was scheduled, but not with the [* * * * *] frequency. Found [* * * * * every 10 seconds].');
+
+        $this->schedule->assertScheduled('foo:bar', '* * * * *');
+    }
+
+    public function testUnnamedCallbackEventsAreListedWithinFailureMessages()
+    {
+        $this->schedule->call(fn () => null)->daily();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The expected [foo:bar] command was not scheduled. The following commands have been scheduled: [Callback].');
+
+        $this->schedule->assertScheduled('foo:bar');
+    }
+
+    public function testUnnamedCallbackEventsDoNotMatchANamelessCommand()
+    {
+        $this->schedule->call(fn () => null)->daily();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to determine the name of the given command.');
+
+        $this->schedule->assertScheduled(new SymfonyCommand);
+    }
+}
+
+class ScheduleAssertionsTestCommand extends Command
+{
+    protected $signature = 'foo:bar {--force}';
+
+    protected $description = 'A command used to test schedule assertions';
+}
+
+class ScheduleAssertionsTestJob
+{
+    //
+}

--- a/tests/Integration/Console/Scheduling/ScheduleAssertionsTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleAssertionsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schedule;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleAssertionsTest extends TestCase
+{
+    public function testAssertionsMayBeMadeThroughTheFacade()
+    {
+        Schedule::command(ScheduleAssertionsCommandStub::class)->dailyAt('03:00');
+
+        Schedule::assertScheduled(ScheduleAssertionsCommandStub::class, '0 3 * * *')
+            ->assertNotScheduled('missing:command');
+    }
+
+    public function testAssertNothingScheduled()
+    {
+        Schedule::assertNothingScheduled();
+    }
+}
+
+class ScheduleAssertionsCommandStub extends Command
+{
+    protected $signature = 'schedule-assertions:stub';
+
+    protected $description = 'A command used to test schedule assertions';
+}


### PR DESCRIPTION
  There is currently no way to test the schedule. To check that a command is registered and runs at the frequency you expect, you have to walk `Schedule::events()` yourself, strip the php and artisan binaries off       
  `$event->command`, and compare cron strings by hand.                                                                                                                                                                     
                                                                                                                                                                                                                           
  This adds three assertions to `Schedule`:                                                                                                                                                                                
                                                                                                                                                                                                                           
  ```php                                                                                                                                                                                                                   
  Schedule::assertScheduled('subscriptions:charge', '0 3 * * *');                                                                                                                                                          
  Schedule::assertScheduled(ChargeSubscriptions::class);                                                                                                                                                                   
  Schedule::assertNotScheduled('backup:run');                                                                                                                                                                              
  Schedule::assertNothingScheduled();                                                                                                                                                                                      
  ```                                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  The first argument accepts a command signature, a command class, or a job class. Matching strips the binaries the same way `schedule:test` already does, so a command scheduled with parameters still matches its        
  signature. The optional second argument checks the cron expression. Sub-minute events do not satisfy it, since `everySecond()` and `everyMinute()` both produce `* * * * *`, and the failure message lists what is       
  actually scheduled instead.