### PR TITLE
[13.x] Add missing implementation for `SessionHandlerInterface` for PHP 9

### DIFF
--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -55,13 +55,23 @@ class ArraySessionHandler implements SessionHandlerInterface
     }
 
     /**
-     * Create a new session ID.
+     * {@inheritdoc}
      *
      * @return string
      */
     public function create_sid(): string
     {
         return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return isset($this->storage[$id]);
     }
 
     /**

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -56,6 +56,16 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return $this->cache->has($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function read($sessionId): string

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Contracts\Cache\Repository as CacheContract;
+use RuntimeException;
 use SessionHandlerInterface;
 
 class CacheBasedSessionHandler implements SessionHandlerInterface
@@ -51,6 +52,16 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     public function close(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -4,6 +4,7 @@ namespace Illuminate\Session;
 
 use Illuminate\Contracts\Cookie\QueueingFactory as CookieJar;
 use Illuminate\Support\InteractsWithTime;
+use RuntimeException;
 use SessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -71,6 +72,16 @@ class CookieSessionHandler implements SessionHandlerInterface
     public function close(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -76,6 +76,16 @@ class CookieSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return $this->request->cookies->has($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string|false
      */
     public function read($sessionId): string|false

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -9,6 +9,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
+use RuntimeException;
 use SessionHandlerInterface;
 
 class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerInterface
@@ -84,6 +85,16 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     public function close(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -89,6 +89,16 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     /**
      * {@inheritdoc}
      *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return ! is_null($this->getQuery()->find($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string|false
      */
     public function read($sessionId): string|false

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -4,6 +4,7 @@ namespace Illuminate\Session;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
+use RuntimeException;
 use SessionHandlerInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -62,6 +63,16 @@ class FileSessionHandler implements SessionHandlerInterface
     public function close(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -67,6 +67,16 @@ class FileSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return $this->files->isFile($this->path.'/'.$id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string|false
      */
     public function read($sessionId): string|false

--- a/src/Illuminate/Session/NullSessionHandler.php
+++ b/src/Illuminate/Session/NullSessionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use RuntimeException;
 use SessionHandlerInterface;
 
 class NullSessionHandler implements SessionHandlerInterface
@@ -24,6 +25,16 @@ class NullSessionHandler implements SessionHandlerInterface
     public function close(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function create_sid(): string
+    {
+        return session_create_id() ?: throw new RuntimeException('Unable to create a session ID.');
     }
 
     /**

--- a/src/Illuminate/Session/NullSessionHandler.php
+++ b/src/Illuminate/Session/NullSessionHandler.php
@@ -29,6 +29,16 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      *
+     * @return bool
+     */
+    public function validateId($id): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function read($sessionId): string

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -29,6 +29,17 @@ class ArraySessionHandlerTest extends TestCase
         $this->assertTrue($handler->open('', ''));
     }
 
+    public function test_it_validates_session_ids()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertFalse($handler->validateId('foo'));
+
+        $handler->write('foo', 'bar');
+
+        $this->assertTrue($handler->validateId('foo'));
+    }
+
     public function test_it_closes_the_session()
     {
         $handler = new ArraySessionHandler(10);

--- a/tests/Session/CacheBasedSessionHandlerTest.php
+++ b/tests/Session/CacheBasedSessionHandlerTest.php
@@ -31,6 +31,14 @@ class CacheBasedSessionHandlerTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function test_it_creates_session_ids()
+    {
+        $sessionId = $this->sessionHandler->create_sid();
+
+        $this->assertIsString($sessionId);
+        $this->assertNotEmpty($sessionId);
+    }
+
     public function test_validate_id_checks_cache()
     {
         $this->cacheMock->expects('has')->with('session_id')->andReturn(true);

--- a/tests/Session/CacheBasedSessionHandlerTest.php
+++ b/tests/Session/CacheBasedSessionHandlerTest.php
@@ -31,6 +31,13 @@ class CacheBasedSessionHandlerTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function test_validate_id_checks_cache()
+    {
+        $this->cacheMock->expects('has')->with('session_id')->andReturn(true);
+
+        $this->assertTrue($this->sessionHandler->validateId('session_id'));
+    }
+
     public function test_read_returns_data_from_cache()
     {
         $this->cacheMock->expects('get')->with('session_id', '')->andReturn('session_data');

--- a/tests/Session/FileSessionHandlerTest.php
+++ b/tests/Session/FileSessionHandlerTest.php
@@ -35,6 +35,14 @@ class FileSessionHandlerTest extends TestCase
         $this->assertTrue($this->sessionHandler->close());
     }
 
+    public function test_it_creates_session_ids()
+    {
+        $sessionId = $this->sessionHandler->create_sid();
+
+        $this->assertIsString($sessionId);
+        $this->assertNotEmpty($sessionId);
+    }
+
     public function test_validate_id_checks_file_exists()
     {
         $sessionId = 'session_id';

--- a/tests/Session/FileSessionHandlerTest.php
+++ b/tests/Session/FileSessionHandlerTest.php
@@ -35,6 +35,16 @@ class FileSessionHandlerTest extends TestCase
         $this->assertTrue($this->sessionHandler->close());
     }
 
+    public function test_validate_id_checks_file_exists()
+    {
+        $sessionId = 'session_id';
+        $path = '/path/to/sessions/'.$sessionId;
+
+        $this->files->expects('isFile')->with($path)->andReturn(true);
+
+        $this->assertTrue($this->sessionHandler->validateId($sessionId));
+    }
+
     public function test_read_returns_data_when_file_exists_and_is_valid()
     {
         $sessionId = 'session_id';


### PR DESCRIPTION
Fix PHP 8.6 deprecations

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
