### PR TITLE
[13.x] Fix a stored image variant overwriting the original

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -593,6 +593,7 @@ class Image implements Responsable, Stringable
 
         $clone->pipeline = clone $this->pipeline;
         $clone->processed = false;
+        $clone->hashName = null;
 
         return $clone;
     }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -673,10 +673,9 @@ class ImageTest extends TestCase
         $name1 = $image->hashName();
 
         $clone = $image->blur(1);
-        $name2 = $image->hashName();
 
-        // Same instance returns cached name
-        $this->assertSame($name1, $name2);
+        $this->assertNull($this->getHashName($clone));
+        $this->assertSame($name1, $image->hashName());
     }
 
     public function test_hash_name_is_consistent_on_same_instance()
@@ -1242,5 +1241,10 @@ class ImageTest extends TestCase
     protected function getPipeline(Image $image): ImagePipeline
     {
         return (new \ReflectionProperty($image, 'pipeline'))->getValue($image);
+    }
+
+    protected function getHashName(Image $image): ?string
+    {
+        return (new \ReflectionProperty($image, 'hashName'))->getValue($image);
     }
 }

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -285,6 +285,19 @@ class ImageTest extends TestCase
         $this->assertSame($file, $large->file());
     }
 
+    public function test_storing_a_variant_does_not_overwrite_the_original()
+    {
+        Storage::fake('local');
+
+        $image = new Image($this->fakeImageContents(800, 600));
+
+        $original = $image->store('photos', 'local');
+        $thumbnail = $image->cover(100, 100)->store('photos', 'local');
+
+        $this->assertNotSame($original, $thumbnail);
+        $this->assertCount(2, Storage::disk('local')->files('photos'));
+    }
+
     public function test_two_variants_from_request_image()
     {
         Storage::fake('local');


### PR DESCRIPTION
  `Image::store()` names the file with `hashName()`, which caches a random string on the instance. `newClone()` doesn't reset that cache, so a variant derived after the original was stored gets the original's name and  
  overwrites it:                                                                                                                                                                                                           
                                                                                                                                                                                                                           
  ```php
  $image = Image::fromUpload($request->file('photo'));
                                                                                              
  $original  = $image->store('photos');                   // photos/EEwe….jpg
  $thumbnail = $image->cover(200, 200)->store('photos');  // photos/EEwe….jpg
  ```