### PR TITLE
[13.x] Fix Str::password() returning extra characters and throwing Va…

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
@@ -1103,13 +1104,21 @@ class Str
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
         ]))
-            ->filter()
-            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
-            ->flatten();
+            ->filter();
 
-        $length = $length - $password->count();
+        if ($options->isEmpty()) {
+            throw new InvalidArgumentException('At least one character pool must be enabled.');
+        }
 
-        return $password->merge($options->pipe(
+        $allCharacters = $options->flatten();
+
+        $options->shuffle()
+            ->take(max(0, $length))
+            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]));
+
+        $length = max(0, $length - $password->count());
+
+        return $password->merge($allCharacters->pipe(
             fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -7,6 +7,7 @@ use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -2012,6 +2013,26 @@ class SupportStrTest extends TestCase
         $this->assertTrue(
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
+    }
+
+    public function testPasswordReturnsExactLengthWhenBelowPoolCount()
+    {
+        $this->assertSame(1, strlen(Str::password(1)));
+        $this->assertSame(2, strlen(Str::password(2)));
+        $this->assertSame(3, strlen(Str::password(3)));
+    }
+
+    public function testPasswordWithZeroOrNegativeLengthReturnsEmptyString()
+    {
+        $this->assertSame('', Str::password(0));
+        $this->assertSame('', Str::password(-2));
+    }
+
+    public function testPasswordThrowsWhenNoPoolsEnabled()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Str::password(32, false, false, false, false);
     }
 
     public function testToBase64()


### PR DESCRIPTION
### Description
This PR fixes two bugs in `Str::password()`: returning more characters than requested for short lengths, and an unhandled `ValueError` when all character pools are disabled.

### Problem

**1. Length smaller than active pool count:**  
When `$length` is smaller than the number of active character pools, `Str::password()` previously iterated over every active pool via `each()` and unconditionally pushed a character from each pool before calculating the remainder:

```php
// Active pools: letters, numbers, symbols (3 pools)
Str::password(1); // Returned 3 characters instead of 1
Str::password(2); // Returned 3 characters instead of 2
```

**2. All character pools disabled:**  
Disabling all pools caused an unhandled PHP engine `ValueError`:

```php
Str::password(32, false, false, false, false);
// ValueError: random_int(): Argument #1 ($min) must be less than or equal to argument #2 ($max)
```

### Solution

* Available pools are now shuffled and capped using `take(max(0, $length))` before pushing initial characters, ensuring the count never exceeds `$length`.
* Added an `$options->isEmpty()` check that throws an explicit `InvalidArgumentException('At least one character pool must be enabled.')`.
* Ensured non-positive lengths (`<= 0`) safely return an empty string.

### Tests
* Passwords with lengths smaller than active pool count return the exact requested length.
* Zero and negative lengths return an empty string.
* Throws `InvalidArgumentException` when all pools are disabled.