### PR TITLE
[13.x] Add no_alias email validation to reject plus-addressed emails

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -988,10 +988,9 @@ trait ValidatesAttributes
         $parameters = (new Collection($parameters))->unique()->values()->all();
 
         if (in_array('no_alias', $parameters, true) || in_array('no-alias', $parameters, true)) {
-            $stringValue = (string) $value;
-            $atPosition = strrpos($stringValue, '@');
+            $localPart = strstr((string) $value, '@', true);
 
-            if ($atPosition !== false && str_contains(substr($stringValue, 0, $atPosition), '+')) {
+            if ($localPart !== false && str_contains($localPart, '+')) {
                 return false;
             }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -985,6 +985,21 @@ trait ValidatesAttributes
             return false;
         }
 
+        $parameters = (new Collection($parameters))->unique()->values()->all();
+
+        if (in_array('no_alias', $parameters, true) || in_array('no-alias', $parameters, true)) {
+            $stringValue = (string) $value;
+            $atPosition = strrpos($stringValue, '@');
+
+            if ($atPosition !== false && str_contains(substr($stringValue, 0, $atPosition), '+')) {
+                return false;
+            }
+
+            $parameters = array_values(array_filter(
+                $parameters, fn ($parameter) => $parameter !== 'no_alias' && $parameter !== 'no-alias'
+            ));
+        }
+
         $validations = (new Collection($parameters))
             ->unique()
             ->map(fn ($validation) => match (true) {

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -21,6 +21,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     public bool $nativeValidationWithUnicodeAllowed = false;
     public bool $rfcCompliant = false;
     public bool $strictRfcCompliant = false;
+    public bool $withoutAliases = false;
 
     /**
      * The validator performing the validation.
@@ -148,6 +149,20 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Ensure that the email address does not contain a plus alias (sub-address).
+     *
+     * For example, "username+alias@gmail.com" will fail validation.
+     *
+     * @return $this
+     */
+    public function withoutAliases()
+    {
+        $this->withoutAliases = true;
+
+        return $this;
+    }
+
+    /**
      * Ensure the email address is valid using PHP's native email validation functions.
      *
      * @param  bool  $allowUnicode
@@ -235,6 +250,10 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 
         if ($this->nativeValidationWithUnicodeAllowed) {
             $rules[] = 'filter_unicode';
+        }
+
+        if ($this->withoutAliases) {
+            $rules[] = 'no_alias';
         }
 
         if ($rules) {

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -269,6 +269,64 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    public function testWithoutAliases()
+    {
+        $this->fails(
+            (new Email())->withoutAliases(),
+            'username+alias@gmail.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->withoutAliases(),
+            'username+alias@gmail.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            (new Email())->withoutAliases(),
+            ['taylor+test@laravel.com', 'user.name+tag@example.co.uk', '+user@example.com', 'user+@example.com'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->passes(
+            (new Email())->withoutAliases(),
+            'taylor@laravel.com'
+        );
+
+        $this->passes(
+            Rule::email()->withoutAliases(),
+            'taylor@laravel.com'
+        );
+
+        $this->passes(
+            (new Email())->withoutAliases(),
+            ['taylor@laravel.com', 'admin@example.com', 'user.name@example.com']
+        );
+
+        $this->fails(
+            (new Email())->rfcCompliant()->withoutAliases(),
+            'username+alias@gmail.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->rfcCompliant()->withoutAliases(),
+            'username+alias@gmail.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->passes(
+            (new Email())->rfcCompliant()->withoutAliases(),
+            'taylor@laravel.com'
+        );
+
+        $this->passes(
+            Rule::email()->rfcCompliant()->withoutAliases(),
+            'taylor@laravel.com'
+        );
+    }
+
     public function testWithNativeValidation()
     {
         $this->fails(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5026,6 +5026,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateEmailWithNoAliasCheck()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example@example.com'], ['x' => 'email:no_alias']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example+alias@example.com'], ['x' => 'email:no_alias']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example@example.com'], ['x' => 'email:no-alias']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example+alias@example.com'], ['x' => 'email:no-alias']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example@example.com'], ['x' => 'email:rfc,no_alias']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example+alias@example.com'], ['x' => 'email:rfc,no_alias']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo'], ['x' => 'email:no_alias']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateEmailWithCustomClassCheck()
     {
         $container = Mockery::mock(Container::class);


### PR DESCRIPTION
Basically, this adds a new option to the email validation rule, which looks something like `email:no-alias`. Using this, we can block/invalidate emails like `username+alias@gmail.com` to stop users which registers from the same email with a different alias in apps where it is restricted. It can also be combined with other options, ex. `email:rfc,no_alias`. 

example.
```php
[
  'email' => 'email:no_alias',
  Rule::email()->withoutAliases(),
  email:rfc,no_alias, 
  Rule::email()->rfcCompliant()->withoutAliases(),
]
```