### PR TITLE
Added the option to have a REVERB_INTERNAL_HOST as well as a REVERB_HOST

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -35,11 +35,12 @@ return [
             'key' => env('REVERB_APP_KEY'),
             'secret' => env('REVERB_APP_SECRET'),
             'app_id' => env('REVERB_APP_ID'),
+            'host_header' => env('REVERB_HOST'),
             'options' => [
-                'host' => env('REVERB_HOST'),
-                'port' => env('REVERB_PORT', 443),
-                'scheme' => env('REVERB_SCHEME', 'https'),
-                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                'host' => env('REVERB_INTERNAL_HOST', env('REVERB_HOST')),
+                'port' => env('REVERB_INTERNAL_PORT', env('REVERB_PORT', 443)),
+                'scheme' => env('REVERB_INTERNAL_SCHEME', env('REVERB_SCHEME', 'https')),
+                'useTLS' => env('REVERB_INTERNAL_SCHEME', env('REVERB_SCHEME', 'https')) === 'https',
             ],
             'client_options' => [
                 // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -5,6 +5,8 @@ namespace Illuminate\Broadcasting;
 use Ably\AblyRest;
 use Closure;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use Illuminate\Broadcasting\Broadcasters\AblyBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
@@ -25,6 +27,7 @@ use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use Illuminate\Support\RebindsCallbacksToSelf;
 use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
 use ReflectionException;
@@ -362,16 +365,7 @@ class BroadcastManager implements FactoryContract
      */
     public function pusher(array $config)
     {
-        $guzzleClient = new GuzzleClient(
-            array_merge(
-                [
-                    'connect_timeout' => 10,
-                    'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-                    'timeout' => 30,
-                ],
-                $config['client_options'] ?? [],
-            ),
-        );
+        $guzzleClient = new GuzzleClient($this->pusherClientOptions($config));
 
         $pusher = new Pusher(
             $config['key'],
@@ -386,6 +380,60 @@ class BroadcastManager implements FactoryContract
         }
 
         return $pusher;
+    }
+
+    /**
+     * Get the Guzzle client options for the Pusher SDK.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function pusherClientOptions(array $config)
+    {
+        $clientOptions = array_merge(
+            [
+                'connect_timeout' => 10,
+                'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+                'timeout' => 30,
+            ],
+            $config['client_options'] ?? [],
+        );
+
+        $hostHeader = $config['host_header'] ?? null;
+
+        if (! empty($hostHeader) && $hostHeader !== ($config['options']['host'] ?? null)) {
+            $clientOptions = $this->withHostHeaderClientOptions($clientOptions, $hostHeader);
+        }
+
+        return $clientOptions;
+    }
+
+    /**
+     * Configure the Guzzle client to send a custom Host header.
+     *
+     * @param  array  $clientOptions
+     * @param  string  $hostHeader
+     * @return array
+     */
+    protected function withHostHeaderClientOptions(array $clientOptions, string $hostHeader)
+    {
+        $handler = $clientOptions['handler'] ?? null;
+
+        // Clone an existing stack so we do not mutate a caller-owned HandlerStack.
+        $handlerStack = $handler instanceof HandlerStack
+            ? clone $handler
+            : HandlerStack::create($handler);
+
+        $handlerStack->push(
+            Middleware::mapRequest(
+                static fn (RequestInterface $request): RequestInterface => $request->withHeader('Host', $hostHeader),
+            ),
+            'broadcasting-host-header',
+        );
+
+        $clientOptions['handler'] = $handlerStack;
+
+        return $clientOptions;
     }
 
     /**

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -2,6 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Broadcasting;
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Broadcasting\Broadcasters\MercureBroadcaster;
 use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\BroadcastManager;
@@ -18,7 +22,9 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionMethod;
 use RuntimeException;
 use stdClass;
 
@@ -509,6 +515,123 @@ class BroadcastManagerTest extends TestCase
             rtrim(strtr(base64_encode(hash_hmac('sha256', $header.'.'.$payload, $secret, true)), '+/', '-_'), '='),
             $signature
         );
+    }
+
+    public function testPusherClientOverridesHostHeaderWhenConfigured()
+    {
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $client = $this->pusherGuzzleClient($manager, [
+            'host_header' => 'public-reverb.example.test',
+            'options' => [
+                'host' => '10.0.0.1',
+                'port' => 8080,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $client->get('http://10.0.0.1:8080/test');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('public-reverb.example.test', $requests[0]->getHeaderLine('Host'));
+    }
+
+    public function testPusherClientDoesNotOverrideHostHeaderWhenHostHeaderMatchesConnectionHost()
+    {
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $client = $this->pusherGuzzleClient($manager, [
+            'host_header' => 'reverb.example.test',
+            'options' => [
+                'host' => 'reverb.example.test',
+                'port' => 8080,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $client->get('http://reverb.example.test:8080/test');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('reverb.example.test:8080', $requests[0]->getHeaderLine('Host'));
+    }
+
+    public function testPusherClientDoesNotOverrideHostHeaderWhenNotConfigured()
+    {
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $client = $this->pusherGuzzleClient($manager, [
+            'options' => [
+                'host' => '10.0.0.1',
+                'port' => 8080,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $client->get('http://10.0.0.1:8080/test');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('10.0.0.1:8080', $requests[0]->getHeaderLine('Host'));
+    }
+
+    public function testPusherClientDoesNotMutateProvidedHandlerStack()
+    {
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+        $handlerStack = new HandlerStack(function (RequestInterface $request) use (&$requests) {
+            $requests[] = $request;
+
+            return Create::promiseFor(new Response(200, [], '{}'));
+        });
+
+        $client = $this->pusherGuzzleClient($manager, [
+            'host_header' => 'public-reverb.example.test',
+            'options' => [
+                'host' => '10.0.0.1',
+                'port' => 8080,
+            ],
+            'client_options' => [
+                'handler' => $handlerStack,
+            ],
+        ]);
+
+        $client->get('http://10.0.0.1:8080/test');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('public-reverb.example.test', $requests[0]->getHeaderLine('Host'));
+
+        $requests = [];
+        (new GuzzleClient(['handler' => $handlerStack]))->get('http://10.0.0.1:8080/test');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('10.0.0.1:8080', $requests[0]->getHeaderLine('Host'));
+    }
+
+    protected function pusherGuzzleClient(BroadcastManager $manager, array $config): GuzzleClient
+    {
+        $method = new ReflectionMethod($manager, 'pusherClientOptions');
+
+        return new GuzzleClient($method->invoke($manager, $config));
     }
 
     protected function getApp(array $userConfig)


### PR DESCRIPTION
This has no breaking changes.

You can now set an internal host name for Reverb, in case your app server wants to call it inside a local network, and you want to use a different host name than what the front end (browsers) should use.

Currently an .env file might look like this:
```
REVERB_HOST=reverb.example.com
REVERB_PORT=443
REVERB_SCHEME=https
```

Now you can do this:
```
REVERB_HOST=reverb.example.com
REVERB_PORT=443
REVERB_SCHEME=https

REVERB_INTERNAL_HOST=10.0.0.1
REVERB_INTERNAL_PORT=8080
REVERB_INTERNAL_SCHEME=http
```

It is completely optional.

**Note**

These values are used in config/broadcasting.php, so if someone's broadcasting.php config file is already published, it will have to be modified in order to use this nifty new feature.