### PR TITLE
[13.x] Use native copy and move for same-disk `copyToDisk()` and `moveToDisk()`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -678,12 +678,16 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function copyToDisk($disk, $from, $to = null)
     {
-        $destination = $disk instanceof FilesystemContract
-            ? $disk
-            : Container::getInstance()->make(FilesystemFactory::class)->disk($disk);
+        $destination = $this->resolveDisk($disk);
 
-        if ($destination === $this && ($to ?? $from) === $from) {
-            throw new InvalidArgumentException('Cannot copy a file to the same disk and path.');
+        $to ??= $from;
+
+        if ($destination === $this) {
+            if ($to === $from) {
+                throw new InvalidArgumentException('Cannot copy a file to the same disk and path.');
+            }
+
+            return $this->copy($from, $to);
         }
 
         $stream = $this->readStream($from);
@@ -693,7 +697,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         try {
-            return $destination->writeStream($to ?? $from, $stream);
+            return $destination->writeStream($to, $stream);
         } finally {
             if (is_resource($stream)) {
                 fclose($stream);
@@ -711,7 +715,26 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function moveToDisk($disk, $from, $to = null)
     {
-        return $this->copyToDisk($disk, $from, $to) && $this->delete($from);
+        $destination = $this->resolveDisk($disk);
+
+        if ($destination === $this && ($to ?? $from) !== $from) {
+            return $this->move($from, $to);
+        }
+
+        return $this->copyToDisk($destination, $from, $to) && $this->delete($from);
+    }
+
+    /**
+     * Resolve the given disk into a filesystem instance.
+     *
+     * @param  string|\Illuminate\Contracts\Filesystem\Filesystem  $disk
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected function resolveDisk($disk)
+    {
+        return $disk instanceof FilesystemContract
+            ? $disk
+            : Container::getInstance()->make(FilesystemFactory::class)->disk($disk);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -429,6 +429,43 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter->copyToDisk($filesystemAdapter, 'file.txt');
     }
 
+    public function testCopyToDiskUsesNativeCopyOnSameDisk()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $filesystemAdapter = Mockery::mock(FilesystemAdapter::class, [$this->filesystem, $this->adapter])->makePartial();
+        $filesystemAdapter->shouldNotReceive('readStream');
+
+        $this->assertTrue($filesystemAdapter->copyToDisk($filesystemAdapter, 'file.txt', 'copy.txt'));
+
+        $this->assertFileExists($this->tempDir.'/file.txt');
+        $this->assertSame('Hello World', file_get_contents($this->tempDir.'/copy.txt'));
+    }
+
+    public function testMoveToDiskUsesNativeMoveOnSameDisk()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $filesystemAdapter = Mockery::mock(FilesystemAdapter::class, [$this->filesystem, $this->adapter])->makePartial();
+        $filesystemAdapter->shouldNotReceive('readStream', 'delete');
+
+        $this->assertTrue($filesystemAdapter->moveToDisk($filesystemAdapter, 'file.txt', 'copy.txt'));
+
+        Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
+        $this->assertSame('Hello World', file_get_contents($this->tempDir.'/copy.txt'));
+    }
+
+    public function testMoveToDiskRejectsSameDiskAndPath()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $filesystemAdapter->moveToDisk($filesystemAdapter, 'file.txt');
+    }
+
     public function testStream()
     {
         $this->filesystem->write('file.txt', $original_content = 'Hello World');


### PR DESCRIPTION
`copyToDisk()` and `moveToDisk()` (#61511, #61519) always stream the file through PHP `readStream()` on the source, `writeStream()` on the destination, and then a `delete()` for moves. That's required when copying between disks, but when the destination is the same disk it means pulling the whole file into the application and writing it straight back.

A developer can easily target the same disk by mistake when the destination is resolved dynamically, such as:

```php
// config/media.php
'archive_disk' => env('MEDIA_ARCHIVE_DISK', 'uploads'),

// Before: when archive_disk resolves to "uploads", the file is streamed
// through PHP and back to the same disk, then the original is deleted
Storage::disk('uploads')->moveToDisk(config('media.archive_disk'), 'tmp/video.mp4', 'videos/video.mp4');
```

This PR defers to the adapter's existing `copy()` and `move()` methods when the destination is the same disk instance. Disks resolved by name are cached by the `FilesystemManager`, so passing the disk's own name is detected as well as passing the instance:

- S3 and other object stores perform a server-side copy instead of transferring the file through the application.
- Local disks use `rename()`, so `moveToDisk()` is atomic rather than copy-then-delete.
- Error handling is unchanged, since `copy()` and `move()` respect the disk's `throw` option just like `readStream()` and `writeStream()`.

One subtle difference, a same-disk copy now follows Flysystem's `retain_visibility` behaviour (enabled by default), so the new file keeps the source file's visibility, matching `Storage::copy()`, rather than receiving the disk's default visibility.

Copying between different disks is unchanged, and copying to the same disk and path still throws an `InvalidArgumentException`. Additionally I've added a test covering that case for `moveToDisk()`.