### PR TITLE
fix: join_paths not rtrimming basePath separator

### DIFF
--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -19,6 +19,6 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
             }
         }
 
-        return $basePath.implode('', $paths);
+        return rtrim($basePath ?? '', DIRECTORY_SEPARATOR).implode('', $paths);
     }
 }

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -22,7 +22,6 @@ class JoinPathsHelperTest extends TestCase
         yield ['very/Basic/Functionality.php', join_paths('very', 'Basic', 'Functionality.php')];
         yield ['segments/get/ltrimed/by_directory/separator.php', join_paths('segments', '/get/ltrimed', '/by_directory/separator.php')];
         yield ['only/\\os_separator\\/\\get_ltrimmed.php', join_paths('only', '\\os_separator\\', '\\get_ltrimmed.php')];
-        yield ['/base_path//does_not/get_trimmed.php', join_paths('/base_path/', '/does_not', '/get_trimmed.php')];
         yield ['Empty/0/1/Segments/00/Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1/2/3', join_paths(1, 0, 2, 3)];
@@ -54,7 +53,6 @@ class JoinPathsHelperTest extends TestCase
         yield ['app\Basic\Functionality.php', join_paths('app', 'Basic', 'Functionality.php')];
         yield ['segments\get\ltrimed\by_directory\separator.php', join_paths('segments', '\get\ltrimed', '\by_directory\separator.php')];
         yield ['only\\/os_separator/\\/get_ltrimmed.php', join_paths('only', '/os_separator/', '/get_ltrimmed.php')];
-        yield ['\base_path\\\\does_not\get_trimmed.php', join_paths('\\base_path\\', '\does_not', '\get_trimmed.php')];
         yield ['Empty\0\1\Segments\00\Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1\2\3', join_paths(1, 2, 3)];


### PR DESCRIPTION
Currently if you use join_paths and the base path ends with a '/' you'll have a '//' in the output e.g

echo join_paths('/my/cool/path/', 'awesome.png'); // /my/cool/path//awesome.png

Is there any reason not to trim the base path since we're always appending a DIRECTORY_SEPARATOR to the $paths?