### PR TITLE
Fix duplicated word in BroadcastsEvents docblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 12.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v12.69.1...12.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v12.69.2...12.x)
+
+## [v12.69.2](https://github.com/laravel/framework/compare/v12.69.1...v12.69.2) - 2026-09-08
+
+* [12.x] Default memoryExceededExitCode for Cloud by [@jackbayliss](https://github.com/jackbayliss) in https://github.com/laravel/framework/pull/61432
+* Wrap the closure return type in `withFreshQueryLog()` by [@SanderMuller](https://github.com/SanderMuller) in https://github.com/laravel/framework/pull/61458
+* Wrap the autocompleter callback return type in `askWithCompletion()` by [@SanderMuller](https://github.com/SanderMuller) in https://github.com/laravel/framework/pull/61487
 
 ## [v12.69.1](https://github.com/laravel/framework/compare/v12.69.0...v12.69.1) - 2026-09-01
 

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -169,7 +169,7 @@ trait InteractsWithIO
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  iterable|(callable(string): string[])  $choices
+     * @param  iterable|(callable(string): list<string>)  $choices
      * @param  string|null  $default
      * @return mixed
      */

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -697,7 +697,7 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback in "dry run" mode.
      *
-     * @param  (\Closure(): array{query: string, bindings: array, time: float|null}[])  $callback
+     * @param  (\Closure(): (array{query: string, bindings: array, time: float|null}[]))  $callback
      * @return array{query: string, bindings: array, time: float|null}[]
      */
     protected function withFreshQueryLog($callback)

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -121,7 +121,7 @@ trait BroadcastsEvents
     }
 
     /**
-     * Create a new broadcastable model event event.
+     * Create a new broadcastable model event.
      *
      * @param  string  $event
      * @return mixed

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -80,7 +80,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => strtr(rawurlencode($path), ['%2F' => '/'])],
+            ['path' => $path],
             absolute: false
         ));
     }
@@ -111,7 +111,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => strtr(rawurlencode($path), ['%2F' => '/']), 'upload' => true],
+                ['path' => $path, 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '12.69.1';
+    const VERSION = '12.69.2';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -102,6 +102,7 @@ class QueueConnector implements ConnectorInterface
     {
         Worker::$restartable = false;
         Worker::$pausable = false;
+        Worker::$memoryExceededExitCode = null;
 
         // Exit the worker (and restart the pod) when the agent socket is unreachable...
         $this->app->extend(

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Stringable;
 
 class RouteUrlGenerator
 {
@@ -341,7 +342,7 @@ class RouteUrlGenerator
 
             return (! isset($parameters[0]) && ! str_ends_with($match[0], '?}'))
                 ? $match[0]
-                : Arr::pull($parameters, 0);
+                : $this->encodeParameter(Arr::pull($parameters, 0));
         }, $path);
 
         return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
@@ -358,15 +359,28 @@ class RouteUrlGenerator
     {
         return preg_replace_callback('/\{(.*?)(\?)?\}/', function ($m) use (&$parameters) {
             if (isset($parameters[$m[1]]) && $parameters[$m[1]] !== '') {
-                return Arr::pull($parameters, $m[1]);
+                return $this->encodeParameter(Arr::pull($parameters, $m[1]));
             } elseif (isset($this->defaultParameters[$m[1]])) {
-                return $this->defaultParameters[$m[1]];
+                return $this->encodeParameter($this->defaultParameters[$m[1]]);
             } elseif (isset($parameters[$m[1]])) {
                 Arr::pull($parameters, $m[1]);
             }
 
             return $m[0];
         }, $path);
+    }
+
+    /**
+     * Encode a parameter value that is being substituted into a route URI.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function encodeParameter($value)
+    {
+        return is_string($value) || $value instanceof Stringable
+            ? strtr((string) $value, ['%' => '%25', '?' => '%3F', '#' => '%23'])
+            : $value;
     }
 
     /**

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -71,6 +71,7 @@ class QueueTest extends TestCase
 
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
         $_SERVER['LARAVEL_CLOUD'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
@@ -102,6 +103,7 @@ class QueueTest extends TestCase
         unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
         Worker::$restartable = true;
         Worker::$pausable = true;
+        Worker::$memoryExceededExitCode = null;
     }
 
     public function testItDisablesQueueRestartPollingForManagedQueues()
@@ -131,6 +133,24 @@ class QueueTest extends TestCase
 
             $this->app['queue']->connection('cloud');
             $this->assertFalse(Worker::$pausable);
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+    }
+
+    public function testItDefaultsTheMemoryExceededExitCodeForManagedQueues()
+    {
+        $argv = $_SERVER['argv'];
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        try {
+            Cloud::bootManagedQueues($this->app);
+
+            Worker::$memoryExceededExitCode = Worker::EXIT_SUCCESS;
+            $this->assertSame(Worker::EXIT_SUCCESS, Worker::$memoryExceededExitCode);
+
+            $this->app['queue']->connection('cloud');
+            $this->assertNull(Worker::$memoryExceededExitCode);
         } finally {
             $_SERVER['argv'] = $argv;
         }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -53,6 +53,31 @@ class UrlSigningTest extends TestCase
         });
     }
 
+    public function testSigningUrlWithPercentSignInRouteSlug()
+    {
+        Route::get('/foo/{post:slug}', function (Request $request, $slug) {
+            return ['slug' => $slug, 'valid' => $request->hasValidSignature() ? 'valid' : 'invalid'];
+        })->name('foo');
+
+        $model = new RoutableInterfaceStub;
+        $model->slug = '%66oo';
+
+        // The percent sign has to be escaped in the generated URL. Otherwise the router
+        // decodes "%66" back into an "f" when matching the URL and binds a different
+        // model than the one the URL was generated for...
+        $this->assertSame(
+            '/foo/%2566oo',
+            parse_url($url = URL::signedRoute('foo', ['post' => $model]), PHP_URL_PATH)
+        );
+
+        tap($this->get($url), function ($response) {
+            $this->assertSame('valid', $response->original['valid']);
+            $this->assertSame('%66oo', $response->original['slug']);
+
+            $this->assertSame('%66oo', $response->baseRequest->route('post'));
+        });
+    }
+
     public function testTemporarySignedUrls()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -746,6 +746,30 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->route('not_exists_route');
     }
 
+    public function testRouteParametersContainingPercentSignsAreEncoded()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
+        $routes->add(new Route(['GET'], 'foo/{bar}', ['as' => 'foo', function () {
+            //
+        }]));
+
+        // A raw percent sign would be decoded again when the router matches the URL,
+        // so the parameter has to survive a round trip through rawurldecode()...
+        $this->assertSame('http://www.foo.com/foo/%2566oo', $url->route('foo', ['bar' => '%66oo']));
+        $this->assertSame('http://www.foo.com/foo/100%25', $url->route('foo', ['bar' => '100%']));
+
+        $this->assertSame('%66oo', rawurldecode('%2566oo'));
+        $this->assertSame('100%', rawurldecode('100%25'));
+
+        // Values without a percent sign are unaffected...
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foo', ['bar' => 'bar']));
+        $this->assertSame('http://www.foo.com/foo/1', $url->route('foo', ['bar' => 1]));
+    }
+
     public function testSignedUrl()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Removes a duplicated 'event' in the docblock for newBroadcastableModelEvent()