### PR TITLE
Fix duplicated word in BroadcastsEvents docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -121,7 +121,7 @@ trait BroadcastsEvents
     }
 
     /**
-     * Create a new broadcastable model event event.
+     * Create a new broadcastable model event.
      *
      * @param  string  $event
      * @return mixed


### PR DESCRIPTION
Removes a duplicated 'event' in the docblock for newBroadcastableModelEvent()