### PR TITLE
[13.x] Fix TypeError in SessionGuard::userFromRecaller() when getAuthPassword() is null

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -233,6 +233,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         $userPassword = $user->getAuthPassword();
 
+        if (! is_string($userPassword)) {
+            return;
+        }
+
         $recallerHash = $recaller->hash();
 
         return (hash_equals($this->hashPasswordForCookie($userPassword), $recallerHash)

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -635,6 +635,19 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->viaRemember());
     }
 
+    public function testUserReturnsNullWhenRecallerUserHasNullPassword()
+    {
+        $guard = $this->getGuard();
+        [$session, $provider, $request, $cookie] = $this->getMocks();
+        $request = Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
+        $guard = new SessionGuard('default', $provider, $session, $request);
+        $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
+        $user = Mockery::mock(Authenticatable::class);
+        $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
+        $this->assertNull($guard->user());
+    }
+
     public function testLoginOnceSetsUser()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();


### PR DESCRIPTION

- Fixes #61527: `SessionGuard::userFromRecaller()` threw a `TypeError` instead of failing authentication gracefully when the resolved user's `getAuthPassword()` returns `null` (e.g. passwordless/OTP/magic-link auth models) and a "remember me" cookie is present.
- `hash_hmac()` and `hash_equals()` both require `string` arguments; passing `null` crashes on PHP 8. The fix adds an `is_string()` guard before those calls and returns early (no match) when the password isn't a string, consistent with the other early-return guards already in this method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
