### PR TITLE
[14.x] Support a concurrency limit for process pools

### DIFF
--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -16,7 +16,7 @@ class ForkDriver implements Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null, ?int $concurrency = null): array
     {
         $tasks = Arr::wrap($tasks);
 
@@ -24,7 +24,13 @@ class ForkDriver implements Driver
         $values = array_values($tasks);
 
         /** @phpstan-ignore class.notFound (spatie/fork is not installed as it is practically incompatible with Windows) */
-        $results = Fork::new()->run(...$values);
+        $fork = Fork::new();
+
+        if ($concurrency > 0) {
+            $fork = $fork->concurrent($concurrency);
+        }
+
+        $results = $fork->run(...$values);
 
         ksort($results);
 

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -30,11 +30,11 @@ class ProcessDriver implements Driver
      *
      * @throws \Throwable
      */
-    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null, ?int $concurrency = null): array
     {
         $command = Application::formatCommandString('invoke-serialized-closure');
 
-        $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
+        $pool = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
             foreach (Arr::wrap($tasks) as $key => $task) {
                 $process = $pool->as($key)->path(base_path())->env([
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
@@ -46,9 +46,13 @@ class ProcessDriver implements Driver
                     $process->timeout($timeout);
                 }
             }
-        })->start()->wait();
+        });
 
-        return $results->collect()->mapWithKeys(function ($result, $key) {
+        if ($concurrency > 0) {
+            $pool->concurrency($concurrency);
+        }
+
+        return $pool->wait()->collect()->mapWithKeys(function ($result, $key) {
             if ($result->failed()) {
                 throw new Exception('Concurrent process failed with exit code ['.$result->exitCode().']. Message: '.$result->errorOutput());
             }

--- a/src/Illuminate/Concurrency/SyncDriver.php
+++ b/src/Illuminate/Concurrency/SyncDriver.php
@@ -15,7 +15,7 @@ class SyncDriver implements Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null, ?int $concurrency = null): array
     {
         return Collection::wrap($tasks)->map(
             fn ($task) => $task()

--- a/src/Illuminate/Contracts/Concurrency/Driver.php
+++ b/src/Illuminate/Contracts/Concurrency/Driver.php
@@ -11,7 +11,7 @@ interface Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array;
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null, ?int $concurrency = null): array;
 
     /**
      * Defer the execution of the given tasks.

--- a/src/Illuminate/Process/Pool.php
+++ b/src/Illuminate/Process/Pool.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Process;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Sleep;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * @mixin \Illuminate\Process\Factory
@@ -33,6 +35,13 @@ class Pool
     protected $pendingProcesses = [];
 
     /**
+     * The maximum number of processes that may run at the same time.
+     *
+     * @var int
+     */
+    protected $concurrency = 0;
+
+    /**
      * Create a new process pool.
      *
      * @param  \Illuminate\Process\Factory  $factory
@@ -58,24 +67,35 @@ class Pool
     }
 
     /**
+     * Specify the maximum number of processes that may run at the same time.
+     *
+     * @param  int  $concurrency
+     * @return $this
+     */
+    public function concurrency(int $concurrency)
+    {
+        $this->concurrency = $concurrency;
+
+        return $this;
+    }
+
+    /**
      * Start all of the processes in the pool.
      *
      * @param  callable|null  $output
      * @return \Illuminate\Process\InvokedProcessPool
      *
      * @throws \InvalidArgumentException
+     * @throws \LogicException
      */
     public function start(?callable $output = null)
     {
-        call_user_func($this->callback, $this);
+        if ($this->concurrency > 0) {
+            throw new LogicException('Process pools with a concurrency limit must be run instead of started.');
+        }
 
         return new InvokedProcessPool(
-            (new Collection($this->pendingProcesses))
-                ->each(function ($pendingProcess) {
-                    if (! $pendingProcess instanceof PendingProcess) {
-                        throw new InvalidArgumentException('Process pool must only contain pending processes.');
-                    }
-                })
+            $this->resolvePendingProcesses()
                 ->mapWithKeys(function ($pendingProcess, $key) use ($output) {
                     return [$key => $pendingProcess->start(output: $output ? function ($type, $buffer) use ($key, $output) {
                         $output($type, $buffer, $key);
@@ -102,7 +122,73 @@ class Pool
      */
     public function wait()
     {
-        return $this->start()->wait();
+        if ($this->concurrency <= 0) {
+            return $this->start()->wait();
+        }
+
+        return new ProcessPoolResults($this->waitForPendingProcesses());
+    }
+
+    /**
+     * Run the pending processes, never running more than the pool's concurrency at once.
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function waitForPendingProcesses()
+    {
+        $pending = $this->resolvePendingProcesses()->all();
+
+        $results = array_fill_keys(array_keys($pending), null);
+
+        $running = [];
+
+        while (! empty($pending) || ! empty($running)) {
+            while (! empty($pending) && count($running) < $this->concurrency) {
+                $key = array_key_first($pending);
+
+                $running[$key] = $pending[$key]->start();
+
+                unset($pending[$key]);
+            }
+
+            foreach ($running as $key => $process) {
+                if ($process->running()) {
+                    $process->ensureNotTimedOut();
+
+                    continue;
+                }
+
+                $results[$key] = $process->wait();
+
+                unset($running[$key]);
+            }
+
+            if (! empty($running)) {
+                Sleep::usleep(1000);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Resolve the pending processes that have been added to the pool.
+     *
+     * @return \Illuminate\Support\Collection<array-key, \Illuminate\Process\PendingProcess>
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolvePendingProcesses()
+    {
+        call_user_func($this->callback, $this);
+
+        return (new Collection($this->pendingProcesses))->each(function ($pendingProcess) {
+            if (! $pendingProcess instanceof PendingProcess) {
+                throw new InvalidArgumentException('Process pool must only contain pending processes.');
+            }
+        });
     }
 
     /**

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -111,6 +111,56 @@ PHP);
         });
     }
 
+    public function testProcessDriverRunMayLimitTheNumberOfSimultaneousProcesses()
+    {
+        $log = tempnam(sys_get_temp_dir(), 'concurrency');
+
+        $task = function () use ($log) {
+            file_put_contents($log, 'start'.PHP_EOL, FILE_APPEND | LOCK_EX);
+
+            usleep(300000);
+
+            file_put_contents($log, 'end'.PHP_EOL, FILE_APPEND | LOCK_EX);
+
+            return 'done';
+        };
+
+        try {
+            $results = Concurrency::driver('process')->run(array_fill(0, 4, $task), concurrency: 2);
+
+            $this->assertSame(['done', 'done', 'done', 'done'], $results);
+
+            $running = 0;
+            $simultaneous = 0;
+
+            foreach (file($log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $event) {
+                $running += $event === 'start' ? 1 : -1;
+
+                $simultaneous = max($simultaneous, $running);
+            }
+
+            $this->assertLessThanOrEqual(2, $simultaneous);
+        } finally {
+            @unlink($log);
+        }
+    }
+
+    #[DataProvider('getConcurrencyDrivers')]
+    public function testRunWithConcurrencyLimitPreservesKeysAndOrder(string $driver)
+    {
+        $results = Concurrency::driver($driver)->run([
+            'first' => function () {
+                usleep(300000);
+
+                return 1 + 1;
+            },
+            5 => fn () => 2 + 2,
+            'third' => fn () => 3 + 3,
+        ], concurrency: 2);
+
+        $this->assertSame(['first' => 2, 5 => 4, 'third' => 6], $results);
+    }
+
     public function testDriverCanBeResolvedUsingBackedEnum()
     {
         $this->assertInstanceOf(

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -8,6 +8,7 @@ use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessIdleTimedOutException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
+use LogicException;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -52,6 +53,117 @@ class ProcessTest extends TestCase
         $this->assertStringContainsString('ProcessTest.php', $results[1]->output());
 
         $this->assertTrue($results->successful());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testProcessPoolMayLimitConcurrency()
+    {
+        $factory = new Factory;
+
+        $log = tempnam(sys_get_temp_dir(), 'pool');
+
+        try {
+            $results = $factory->pool(function ($pool) use ($log) {
+                foreach (range(1, 4) as $ignored) {
+                    $pool->path(__DIR__)->command("echo start >> {$log}; sleep 0.3; echo end >> {$log}");
+                }
+            })->concurrency(2)->wait();
+
+            $this->assertCount(4, $results->collect());
+            $this->assertTrue($results->successful());
+            $this->assertSame(2, $this->maximumSimultaneousProcesses($log));
+        } finally {
+            @unlink($log);
+        }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testProcessPoolConcurrencyOfZeroDoesNotLimitTheProcesses()
+    {
+        $factory = new Factory;
+
+        $log = tempnam(sys_get_temp_dir(), 'pool');
+
+        try {
+            $factory->pool(function ($pool) use ($log) {
+                foreach (range(1, 4) as $ignored) {
+                    $pool->path(__DIR__)->command("echo start >> {$log}; sleep 0.3; echo end >> {$log}");
+                }
+            })->concurrency(0)->wait();
+
+            $this->assertSame(4, $this->maximumSimultaneousProcesses($log));
+        } finally {
+            @unlink($log);
+        }
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testProcessPoolWithConcurrencyLimitPreservesKeysAndOrder()
+    {
+        $factory = new Factory;
+
+        $results = $factory->pool(function ($pool) {
+            $pool->as('first')->path(__DIR__)->command('sleep 0.3; echo first');
+            $pool->as('second')->path(__DIR__)->command('echo second');
+        })->concurrency(1)->wait();
+
+        $this->assertSame(['first', 'second'], array_keys($results->collect()->all()));
+        $this->assertStringContainsString('first', $results['first']->output());
+        $this->assertStringContainsString('second', $results['second']->output());
+    }
+
+    public function testProcessPoolWithConcurrencyLimitMayNotBeStarted()
+    {
+        $factory = new Factory;
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Process pools with a concurrency limit must be run instead of started.');
+
+        $factory->pool(function ($pool) {
+            $pool->path(__DIR__)->command($this->ls());
+        })->concurrency(2)->start();
+    }
+
+    public function testProcessPoolWithConcurrencyLimitMayBeFaked()
+    {
+        $factory = new Factory;
+
+        $factory->fake(function () use ($factory) {
+            return $factory->describe()
+                ->output('DONE')
+                ->runsFor(iterations: 3);
+        });
+
+        $results = $factory->pool(function ($pool) {
+            $pool->command('first');
+            $pool->command('second');
+            $pool->command('third');
+        })->concurrency(2)->wait();
+
+        $this->assertCount(3, $results->collect());
+        $this->assertTrue($results->successful());
+        $this->assertStringContainsString('DONE', $results[0]->output());
+        $this->assertStringContainsString('DONE', $results[2]->output());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testProcessPoolWithConcurrencyLimitEnforcesTimeouts()
+    {
+        $factory = new Factory;
+
+        $startedAt = microtime(true);
+
+        try {
+            $factory->pool(function ($pool) {
+                $pool->timeout(1)->path(__DIR__)->command('exec sleep 20');
+            })->concurrency(1)->wait();
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (ProcessTimedOutException $e) {
+            $this->assertNotInstanceOf(ProcessIdleTimedOutException::class, $e);
+            $this->assertStringContainsString('exceeded the timeout of 1 seconds', $e->getMessage());
+            $this->assertLessThan(10, microtime(true) - $startedAt);
+        }
     }
 
     public function testProcessPoolFailed()
@@ -1425,6 +1537,23 @@ class ProcessTest extends TestCase
         $factory->assertRanTimes(function ($process) {
             return str_contains($process->command, 'printenv TEST_VAR OTHER_VAR');
         }, 2);
+    }
+
+    /**
+     * Get the highest number of processes that were running at the same time.
+     */
+    protected function maximumSimultaneousProcesses(string $log): int
+    {
+        $running = 0;
+        $maximum = 0;
+
+        foreach (file($log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $event) {
+            $running += $event === 'start' ? 1 : -1;
+
+            $maximum = max($maximum, $running);
+        }
+
+        return $maximum;
     }
 
     protected function ls()


### PR DESCRIPTION
`Process::pool()` starts every process it was given at once, and `Concurrency::run()` does the same. With a few hundred of them the machine runs out of memory or CPU before the work is done, so anyone who needs a cap 
  ends up writing the same loop by hand:                                                                                                                                                                                   
                                                                                                                                                                                                                           
  ```php
  foreach (array_chunk($commands, $concurrency) as $batch) {
      Process::pool(function ($pool) use ($batch) {
          foreach ($batch as $command) {
              $pool->command($command);
          }
      })->wait();
  }
  ```                                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  That works, but every batch waits for its slowest command before the next batch starts, and the results back together. 
  
  This puts the limit on the pool itself, so it's one pool with no barrier — the next process starts the moment one finishes, and the results come back keyed and in the order they were added:                            
                                                                                                                                                                                                                           
  ```php
  $results = Process::pool(function ($pool) use ($commands) {
      foreach ($commands as $key => $command) {
          $pool->as($key)->command($command);
      }
  })->concurrency($concurrency)->wait();
  ```
                                                                                                                                                                                                                           
  The concurrency drivers build on the same pool, so they take the option too. Here the tasks are closures rather than commands, and the results come back under the tenant ids they were keyed with:                      
                                                                                                                                                                                                                           
  ```php                                                                                                                                                                                                                   
  $tasks = $tenants->mapWithKeys(fn ($tenant) => [
      $tenant->id => fn () => $tenant->rebuildReport(),
  ])->all();

  $results = Concurrency::run($tasks, concurrency: 8);
  ```
                                                                                                                                                                                                                           
  A limit of `0` means no limit, same as `Http::pool()`. Starting a pool that has a limit throws, since `start()` hands back before anything has finished and has nothing left to hold the limit with.    