### PR TITLE
[13.x] Ensure failed jobs from the sync, deferred, and background connections are recorded

### DIFF
--- a/src/Illuminate/Queue/BackgroundQueue.php
+++ b/src/Illuminate/Queue/BackgroundQueue.php
@@ -18,8 +18,31 @@ class BackgroundQueue extends SyncQueue
      */
     public function push($job, $data = '', $queue = null)
     {
+        $connection = $this->connectionName;
+
         Concurrency::driver('process')->defer(
-            fn () => \Illuminate\Support\Facades\Queue::connection('sync')->push($job, $data, $queue)
+            fn () => \Illuminate\Support\Facades\Queue::connection('sync')
+                ->setConnectionName($connection)
+                ->push($job, $data, $queue)
+        );
+    }
+
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string|null  $queue
+     * @param  array  $options
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        $connection = $this->connectionName;
+
+        Concurrency::driver('process')->defer(
+            fn () => \Illuminate\Support\Facades\Queue::connection('sync')
+                ->setConnectionName($connection)
+                ->pushRaw($payload, $queue, $options)
         );
     }
 }

--- a/src/Illuminate/Queue/DeferredQueue.php
+++ b/src/Illuminate/Queue/DeferredQueue.php
@@ -18,4 +18,17 @@ class DeferredQueue extends SyncQueue
     {
         return \Illuminate\Support\defer(fn () => parent::push($job, $data, $queue));
     }
+
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string|null  $queue
+     * @param  array  $options
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        return \Illuminate\Support\defer(fn () => parent::pushRaw($payload, $queue, $options));
+    }
 }

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -15,11 +15,13 @@ use Illuminate\Queue\Connectors\NullConnector;
 use Illuminate\Queue\Connectors\RedisConnector;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Connectors\SyncConnector;
+use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
+use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
@@ -44,6 +46,37 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->registerListener();
         $this->registerRoutes();
         $this->registerFailedJobServices();
+    }
+
+    /**
+     * Boot the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->listenForFailedSyncJobs();
+    }
+
+    /**
+     * Listen for failed sync jobs events and store them.
+     *
+     * @return void
+     */
+    protected function listenForFailedSyncJobs()
+    {
+        $this->app['events']->listen(JobFailed::class, function ($event) {
+            if (! $event->job instanceof SyncJob) {
+                return;
+            }
+
+            $this->app['queue.failer']->log(
+                $event->connectionName,
+                $event->job->getQueue(),
+                $event->job->getRawBody(),
+                $event->exception
+            );
+        });
     }
 
     /**

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
+use Throwable;
 
 class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
 {
@@ -70,12 +71,16 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return;
             }
 
-            $this->app['queue.failer']->log(
-                $event->connectionName,
-                $event->job->getQueue(),
-                $event->job->getRawBody(),
-                $event->exception
-            );
+            try {
+                $this->app['queue.failer']->log(
+                    $event->connectionName,
+                    $event->job->getQueue(),
+                    $event->job->getRawBody(),
+                    $event->exception
+                );
+            } catch (Throwable $e) {
+                $this->app[ExceptionHandler::class]->report($e);
+            }
         });
     }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -218,7 +218,21 @@ class SyncQueue extends Queue implements QueueContract
      */
     protected function executeJob($job, $data = '', $queue = null)
     {
-        $queueJob = $this->resolveJob($this->createPayload($job, $queue, $data), $queue);
+        return $this->executePayload($this->createPayload($job, $queue, $data), $queue);
+    }
+
+    /**
+     * Execute a given raw payload synchronously.
+     *
+     * @param  string  $payload
+     * @param  string|null  $queue
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    protected function executePayload($payload, $queue = null)
+    {
+        $queueJob = $this->resolveJob($payload, $queue);
 
         try {
             $this->raiseBeforeJobEvent($queueJob);
@@ -331,7 +345,7 @@ class SyncQueue extends Queue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        //
+        return $this->executePayload($payload, $queue);
     }
 
     /**

--- a/tests/Integration/Queue/SyncQueueFailedJobsTest.php
+++ b/tests/Integration/Queue/SyncQueueFailedJobsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\Attributes\WithMigration;
 use RuntimeException;
@@ -14,6 +15,8 @@ use function Illuminate\Support\defer;
 #[WithMigration('queue')]
 class SyncQueueFailedJobsTest extends QueueTestCase
 {
+    use DatabaseMigrations;
+
     public function test_failed_sync_jobs_are_recorded()
     {
         SyncQueueFailedJob::$attempts = 0;

--- a/tests/Integration/Queue/SyncQueueFailedJobsTest.php
+++ b/tests/Integration/Queue/SyncQueueFailedJobsTest.php
@@ -49,10 +49,12 @@ class SyncQueueFailedJobsTest extends QueueTestCase
         SyncQueueFailedJob::$attempts = 0;
 
         try {
-            SyncQueueFailedJob::dispatch();
+            SyncQueueFailedJob::dispatch()->onConnection('sync');
         } catch (RuntimeException) {
             //
         }
+
+        $this->assertSame(1, DB::table('failed_jobs')->count());
 
         $this->artisan('queue:retry', ['id' => ['all']])->assertSuccessful();
 

--- a/tests/Integration/Queue/SyncQueueFailedJobsTest.php
+++ b/tests/Integration/Queue/SyncQueueFailedJobsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Attributes\WithMigration;
+use RuntimeException;
+
+use function Illuminate\Support\defer;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class SyncQueueFailedJobsTest extends QueueTestCase
+{
+    public function test_failed_sync_jobs_are_recorded()
+    {
+        SyncQueueFailedJob::$attempts = 0;
+
+        try {
+            SyncQueueFailedJob::dispatch()->onConnection('sync');
+        } catch (RuntimeException) {
+            //
+        }
+
+        $this->assertSame(1, DB::table('failed_jobs')->count());
+        $this->assertSame('sync', DB::table('failed_jobs')->value('connection'));
+    }
+
+    public function test_failed_deferred_jobs_are_recorded()
+    {
+        SyncQueueFailedJob::$attempts = 0;
+
+        SyncQueueFailedJob::dispatch()->onConnection('deferred');
+
+        defer()->invoke();
+
+        $this->assertSame(1, SyncQueueFailedJob::$attempts);
+        $this->assertSame(1, DB::table('failed_jobs')->count());
+        $this->assertSame('deferred', DB::table('failed_jobs')->value('connection'));
+    }
+
+    public function test_failed_sync_jobs_can_be_retried()
+    {
+        SyncQueueFailedJob::$attempts = 0;
+
+        try {
+            SyncQueueFailedJob::dispatch();
+        } catch (RuntimeException) {
+            //
+        }
+
+        $this->artisan('queue:retry', ['id' => ['all']])->assertSuccessful();
+
+        $this->assertSame(2, SyncQueueFailedJob::$attempts);
+        $this->assertSame(0, DB::table('failed_jobs')->count());
+    }
+}
+
+class SyncQueueFailedJob implements ShouldQueue
+{
+    use Queueable;
+
+    public static int $attempts = 0;
+
+    public $tries = 1;
+
+    public function handle()
+    {
+        if (++static::$attempts === 1) {
+            throw new RuntimeException('Job failed.');
+        }
+    }
+}


### PR DESCRIPTION
## Introduction
Whenever I use the deferred/background queue, a voice in my head always says, "If this job fails, we'd probably never know or have a way to retry it."

`queue.failer` currently has exactly one writer in the whole framework: [WorkCommand::logFailedJob()](https://github.com/laravel/framework/blob/41807417bb85908412b67ff7ec4132a026d603c7/src/Illuminate/Queue/Console/WorkCommand.php#L421). If a job doesn't go through `queue:work`, nothing records its failure.

That was a fair assumption when `sync` was the only non-worker connection. But `deferred` and `background` changed that. These are connections you reach for precisely because you want fire-and-forget work without standing up a worker.

When a deferred/background job fails today, that's the end of it. You get an entry in your log, Nightwatch, etc., and no realistic way to act on it. The job is simply gone.

Anyone who has shipped on the deferred connection knows the feeling: if this fails, I will never know, and even if I do, I can't do much about it.

## The fix

Failures on sync, deferred, and background are now written to the configured failed-job store, so they behave like every other failed job:

```bash
php artisan queue:failed    # they're listed
php artisan queue:retry all # they run again
```

They are essentially discovered by the `php artisan queue:*` commands.

> The `JobFailed` listener writes to `queue.failer`. Then `queue:retry` re-dispatches on the original connection.

This also adds the implementation for `Queue::pushRaw()` on `SyncQueue`, `DeferredQueue` and `BackgroundQueue`, since it is necessary for `queue:retry` to work.

---
One last note: If the service provider can record failures for any connection, `WorkCommand::logFailedJob()` is then a bit redundant. So dropping the conditional statement for `SyncJob` and deleting that method would make the provider the single source of truth for logging failed jobs. Happy to open it as a follow-up if you think so too.

Thanks!