### PR TITLE
[13.x] Keep `"0"` string keys when gathering `morphTo` eager load keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -189,7 +189,10 @@ class MorphTo extends BelongsTo
             ? array_keys($this->dictionary[$type])
             : array_map(function ($modelId) {
                 return (string) $modelId;
-            }, array_filter(array_keys($this->dictionary[$type])));
+            }, array_filter(
+                array_keys($this->dictionary[$type]),
+                fn ($modelId) => $modelId !== ''
+            ));
     }
 
     /**

--- a/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
+++ b/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
@@ -25,6 +25,10 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
             $table->string('id')->primary();
         });
 
+        Schema::create('codes', function (Blueprint $table) {
+            $table->string('id')->primary();
+        });
+
         Schema::create('comments', function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
@@ -34,6 +38,7 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
         $post = Post::create();
         $article = Article::create(['slug' => ArticleSlug::Review->value]);
         $video = Video::create(['id' => '550e8400-e29b-41d4-a716-446655440000']);
+        $code = Code::create(['id' => '0']);
 
         (new Comment)->commentable()->associate($post)->save();
         (new Comment)->commentable()->associate($article)->save();
@@ -42,6 +47,8 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
         $comment->commentable_type = Video::class;
         $comment->commentable_id = (string) $video->id;
         $comment->save();
+
+        (new Comment)->commentable()->associate($code)->save();
     }
 
     public function testEagerLoadingResolvesRelationWithPrimitivePrimaryKey(): void
@@ -63,6 +70,21 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
         $this->assertNotNull($comments[0]->commentable);
         $this->assertInstanceOf(Article::class, $comments[0]->commentable);
         $this->assertSame(ArticleSlug::Review, $comments[0]->commentable->slug);
+    }
+
+    public function testEagerLoadingResolvesRelationWithZeroStringPrimaryKey(): void
+    {
+        $comments = Comment::with('commentable')
+            ->where('commentable_type', Code::class)
+            ->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertInstanceOf(Code::class, $comments[0]->commentable);
+        $this->assertSame('0', $comments[0]->commentable->getKey());
+
+        $lazy = Comment::where('commentable_type', Code::class)->first();
+
+        $this->assertSame($lazy->commentable->getKey(), $comments[0]->commentable->getKey());
     }
 
     public function testEagerLoadingResolvesRelationWithUuidValueObjectPrimaryKey(): void
@@ -125,6 +147,17 @@ class UuidCast implements CastsAttributes
     {
         return (string) $value;
     }
+}
+
+class Code extends Model
+{
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = ['id'];
 }
 
 class Video extends Model


### PR DESCRIPTION
Eager loading a `morphTo` relation skips the owner when its primary key is the string `"0"`. Reading the same relation without eager loading resolves it, so the two paths disagree on identical data.

```php
$comment = Comment::with('commentable')->find(1);
$comment->commentable;              // null

$comment = Comment::find(1);
$comment->commentable;              // the related model
```

`MorphTo::gatherKeysByType()` filters the dictionary keys with no callback:

```php
return $keyType !== 'string'
    ? array_keys($this->dictionary[$type])
    : array_map(function ($modelId) {
        return (string) $modelId;
    }, array_filter(array_keys($this->dictionary[$type])));
```

A foreign key of `"0"` becomes the integer key `0` once PHP uses it as an array key, and `array_filter()` without a callback drops every falsey value, so that key never reaches the `whereIn` for the owners. The owner is not fetched, the dictionary lookup in `match()` finds nothing, and the relation is set to `null`.

Only the string branch filters, so an integer key of `0` is already kept. The disagreement is between the two branches as much as between eager and lazy loading.

## Fix

The filter is now explicit about what it removes:

```php
array_filter(
    array_keys($this->dictionary[$type]),
    fn ($modelId) => $modelId !== ''
)
```

The bare `array_filter()` came in with #36129, which made eager loading tolerate partially nullable `morphTo` relations. `buildDictionary()` already skips rows whose foreign key resolves to `null` before they reach the dictionary, so the only falsey key still worth removing is the empty string, which is what a null key collapses to. Keeping that behaviour and dropping the rest is enough to fix `"0"` without changing anything else.

## Scope

Keys that are not the empty string are now passed through. In practice that means `"0"`; every other key was already kept. Rows with a null foreign key are still excluded, by `buildDictionary()` as before.

## Tests

`EloquentMorphToEagerLoadTest` gained a `Code` model with a plain string primary key and a record keyed `"0"`, alongside the primitive, backed enum and value object cases the file already covers. The test asserts the relation resolves under `with()` and that it matches what lazy loading returns for the same record. It fails on the current branch with `Failed asserting that null is not null`.

## Credit

#58669 by @Tresor-Kasenda reported and fixed the same thing in February and takes the same approach. It targets `12.x`, which is outside the bug fix window now, and has been idle since the CI failure was raised. This is that fix against `13.x` with an integration test covering the eager and lazy paths; happy to close this if the original is picked up instead.
