### PR TITLE
[13.x] Fix collapseWithKeys() crashing when the outer collection has string keys

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -167,14 +167,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $results = [];
 
-        foreach ($this->items as $key => $values) {
+        foreach ($this->items as $values) {
             if ($values instanceof Collection) {
                 $values = $values->all();
             } elseif (! is_array($values)) {
                 continue;
             }
 
-            $results[$key] = $values;
+            $results[] = $values;
         }
 
         if (! $results) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1967,6 +1967,17 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testCollapseWithKeysWithStringKeys($collection)
+    {
+        $data = new $collection(['first' => ['a' => 1, 'b' => 2], 'second' => ['c' => 3]]);
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $data->collapseWithKeys()->all());
+
+        // Case with mixed integer and string keys
+        $data = new $collection([5 => ['a' => 1], 'second' => new $collection(['b' => 2, 'a' => 3])]);
+        $this->assertSame(['a' => 3, 'b' => 2], $data->collapseWithKeys()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testJoin($collection)
     {
         $this->assertSame('a, b, c', (new $collection(['a', 'b', 'c']))->join(', '));


### PR DESCRIPTION
`Collection::collapseWithKeys()` throws when the outer collection has string keys, because the nested arrays are unpacked into `array_replace()` with their original keys, and PHP treats string keys in an unpacked array as named arguments:

```php
collect([
    'mail' => ['mail.driver' => 'smtp', 'mail.port' => 587],
    'queue' => ['queue.default' => 'redis'],
])->collapseWithKeys();

// ArgumentCountError: array_replace() expects at least 1 argument, 0 given
```

Mixing integer and string keys fails too, with `array_replace() does not accept unknown named parameters`.

Since the outer keys get thrown away anyway, I've changed it to collect the nested arrays into a plain list before passing them to `array_replace()`. That's what `Arr::collapse()` already does. Collections with integer keys behave exactly as before.

`LazyCollection::collapseWithKeys()` already handles string keys, so the new test runs against both implementations to keep them consistent.