### PR TITLE
[13.x] Fix `in` / `not_in` rules ignoring non-string parameters with the array rule syntax

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1567,7 +1567,7 @@ trait ValidatesAttributes
             return array_diff($value, $parameters) === [];
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters, true);
+        return ! is_array($value) && in_array((string) $value, array_map(strval(...), $parameters), true);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4456,6 +4456,32 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateInWithArrayRuleSyntaxAndNonStringParameters()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['name' => 1], ['name' => [['in', 1, 2, 3]]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => '1'], ['name' => [['in', 1, 2, 3]]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 4], ['name' => [['in', 1, 2, 3]]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => '01'], ['name' => [['in', 1, 2, 3]]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 1], ['name' => [['not_in', 1, 2, 3]]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => '1'], ['name' => [['not_in', 1, 2, 3]]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 4], ['name' => [['not_in', 1, 2, 3]]]);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateNotIn()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
### Problem

#61146 switched the `in` rule to a strict `in_array()` check to stop loose-comparison bypasses:

```php
return ! is_array($value) && in_array((string) $value, $parameters, true);

That works for the string rule syntax ('in:1,2,3') because the parser always produces string parameters. With the array rule syntax, ValidationRuleParser::parseArrayRule() passes the parameters through untouched, so integer parameters never strictly match the string-cast value:

Validator::make(['x' => 1], ['x' => [['in', 1, 2, 3]]])->passes();     //
Validator::make(['x' => 1], ['x' => [['not_in', 1, 2, 3]]])->passes(); // true,  expected false
Validator::make(['x' => '1'], ['x' => [['not_in', 1, 2, 3]]])->passes(); /

Because validateNotIn() is simply ! validateIn(), this fails open: a not_ie array syntax now accepts every value it is meant to reject.

Fix

Cast the parameters to strings before the strict comparison so both rule s

return ! is_array($value) && in_array((string) $value, array_map(strval(..

This keeps the strict comparison from #61146 intact. Values such as '01', jected against a parameter of 1.

Tests

Added testValidateInWithArrayRuleSyntaxAndNonStringParameters covering in rameters for matching, non-matching and loosely-equal values. The testfails on 13.x without the change and passes with it. The existing ValidationInRuleTest::testInRuleIsNotLoosyBypassed cases continue to pass.
```