### PR TITLE
[13.x] Resolve custom messages for rule objects when the attribute is…

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\File as FileRule;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -103,7 +104,7 @@ trait FormatsMessages
 
         $keys = ["{$attribute}.{$lowerRule}", $lowerRule, $attribute];
 
-        if ($this->getAttributeType($attribute) !== 'file') {
+        if (! is_a($lowerRule, FileRule::class, true)) {
             $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
 
             if (! in_array($shortRule, $keys)) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4456,6 +4456,22 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testCustomMessagesForRuleObjectsAreUsedWhenAttributeIsAFile()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $file = new UploadedFile(__FILE__, '', null, null, true);
+
+        $rule = new VirusFree;
+
+        $v = new Validator($trans, ['avatar' => $file], ['avatar' => [$rule]], ['avatar.virus_free' => 'The avatar failed the virus scan.']);
+        $this->assertTrue($v->fails());
+        $this->assertSame(['The avatar failed the virus scan.'], $v->messages()->all());
+
+        $v = new Validator($trans, ['avatar' => 'not-a-file'], ['avatar' => [$rule]], ['avatar.virus_free' => 'The avatar failed the virus scan.']);
+        $this->assertTrue($v->fails());
+        $this->assertSame(['The avatar failed the virus scan.'], $v->messages()->all());
+    }
+
     public function testValidateNotIn()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -10424,6 +10440,14 @@ class ExplicitTableAndConnectionModel extends Model
     protected $guarded = [];
 
     public $timestamps = false;
+}
+
+class VirusFree implements \Illuminate\Contracts\Validation\ValidationRule
+{
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    {
+        $fail('validation.virus_free');
+    }
 }
 
 class NonEloquentModel


### PR DESCRIPTION
### Problem

#61146 switched the `in` rule to a strict `in_array()` check to stop loose-comparison bypasses:

```php
return ! is_array($value) && in_array((string) $value, $parameters, true);

That works for the string rule syntax ('in:1,2,3') because the parser always produces string parameters. With the array rule syntax, ValidationRuleParser::parseArrayRule() passes the parameters through untouched, so integer parameters never strictly match the string-cast value:

Validator::make(['x' => 1], ['x' => [['in', 1, 2, 3]]])->passes();     // false, expected true
Validator::make(['x' => 1], ['x' => [['not_in', 1, 2, 3]]])->passes(); // true,  expected false
Validator::make(['x' => '1'], ['x' => [['not_in', 1, 2, 3]]])->passes(); // true, expected false

Because validateNotIn() is simply ! validateIn(), this fails open: a not_in denylist written with the array syntax now accepts every value it is meant to reject.

Fix

Cast the parameters to strings before the strict comparison so both rule syntaxes behave the same:

return ! is_array($value) && in_array((string) $value, array_map(strval(...), $parameters), true);

This keeps the strict comparison from #61146 intact. Values such as '01', ' 1' or '1.0' are still rejected against a parameter of 1.

Tests

Added testValidateInWithArrayRuleSyntaxAndNonStringParameters covering in and not_in with integer parameters for matching, non-matching and loosely-equal values. The test fails on 13.x without the change and passes with it. The existing ValidationInRuleTest::testInRuleIsNotLoosyBypassed cases continue to pass.
```

✻ Cogitated for 11s · done 1:20 PM

❯ fix/validation-rule-object-messages-file description for pr

Title

[13.x] Resolve custom messages for rule objects when the attribute value is a file

Description

### Problem

#57656 made custom messages work for the `File` rule by skipping the short `attribute.rule_name` key in `FormatsMessages::getFromLocalArray()`:

```php
if ($this->getAttributeType($attribute) !== 'file') {
    $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
    // ...
}

The intent was to stop an attribute.file custom message from overriding the messages produced by the File rule's nested validator. However, the condition keys off the value type (the attribute currently holds an UploadedFile), not off the rule being formatted. As a result, every custom ValidationRule object loses its attribute.rule_name custom message as soon as the attribute contains a file, which is exactly where file-related custom rules live:

class VirusFree implements ValidationRule
{
    public function validate(string $attribute, mixed $value, Closure $fail): void
    {
        $fail('validation.virus_free');
    }
}

$messages = ['avatar.virus_free' => 'The avatar failed the virus scan.'];

Validator::make(['avatar' => $uploadedFile], ['avatar' => [new VirusFree]], $messages)->messages()->all();
// ['validation.virus_free']              <- custom message ignored

Validator::make(['avatar' => 'not-a-file'], ['avatar' => [new VirusFree]], $messages)->messages()->all();
// ['The avatar failed the virus scan.']  <- works only because the value is not a file

Fix

Gate the short key on the rule instead of the value. The key is skipped only when the rule being formatted is Illuminate\Validation\Rules\File or a subclass such as ImageFile:

if (! is_a($lowerRule, FileRule::class, true)) {
    $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
    // ...
}

This preserves the behaviour #57656 introduced for the File rule while letting every other rule object resolve its custom message regardless of the attribute's value type.

Tests

Added testCustomMessagesForRuleObjectsAreUsedWhenAttributeIsAFile, which asserts the same custom message is returned for a rule object whether the attribute holds an UploadedFile or a plain string. It fails on 13.x without the change and passes with it. The existing FileValidationTest custom message cases from #57656 continue to pass.
```