### PR TITLE
[13.x] Fix limit and offset on union queries for SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -55,6 +55,10 @@ class SqlServerGrammar extends Grammar
             $query->orders[] = ['sql' => '(SELECT 0)'];
         }
 
+        if ($query->unions && (isset($query->unionLimit) || $query->unionOffset) && empty($query->unionOrders)) {
+            $query->unionOrders[] = ['sql' => '(SELECT 0)'];
+        }
+
         return parent::compileSelect($query);
     }
 
@@ -381,6 +385,35 @@ class SqlServerGrammar extends Grammar
     protected function compileLock(Builder $query, $value)
     {
         return '';
+    }
+
+    /**
+     * Compile the "union" queries attached to the main query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUnions(Builder $query)
+    {
+        $sql = '';
+
+        foreach ($query->unions as $union) {
+            $sql .= $this->compileUnion($union);
+        }
+
+        if (! empty($query->unionOrders)) {
+            $sql .= ' '.$this->compileOrders($query, $query->unionOrders);
+        }
+
+        if (isset($query->unionLimit) || $query->unionOffset) {
+            $sql .= ' offset '.((int) $query->unionOffset).' rows';
+
+            if ((int) $query->unionLimit > 0) {
+                $sql .= ' fetch next '.((int) $query->unionLimit).' rows only';
+            }
+        }
+
+        return ltrim($sql);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2239,6 +2239,39 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($expectedSql, $builder->toSql());
     }
 
+    public function testSqlServerUnionLimitsAndOffsets()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getSqlServerBuilder()->select('*')->from('dogs'));
+        $builder->orderBy('id')->offset(5)->limit(10);
+        $this->assertSame('select * from (select * from [users]) as [temp_table] union select * from (select * from [dogs]) as [temp_table] order by [id] asc offset 5 rows fetch next 10 rows only', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getSqlServerBuilder()->select('*')->from('dogs'));
+        $builder->orderBy('id')->limit(10);
+        $this->assertSame('select * from (select * from [users]) as [temp_table] union select * from (select * from [dogs]) as [temp_table] order by [id] asc offset 0 rows fetch next 10 rows only', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getSqlServerBuilder()->select('*')->from('dogs'));
+        $builder->orderBy('id')->offset(5);
+        $this->assertSame('select * from (select * from [users]) as [temp_table] union select * from (select * from [dogs]) as [temp_table] order by [id] asc offset 5 rows', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getSqlServerBuilder()->select('*')->from('dogs'));
+        $builder->forPage(2, 15);
+        $this->assertSame('select * from (select * from [users]) as [temp_table] union select * from (select * from [dogs]) as [temp_table] order by (SELECT 0) offset 15 rows fetch next 15 rows only', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->limit(11);
+        $builder->union($this->getSqlServerBuilder()->select('*')->from('dogs')->limit(22));
+        $builder->orderBy('id')->offset(5)->limit(10);
+        $this->assertSame('select * from (select top 11 * from [users]) as [temp_table] union select * from (select top 22 * from [dogs]) as [temp_table] order by [id] asc offset 5 rows fetch next 10 rows only', $builder->toSql());
+    }
+
     public function testUnionWithJoin()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Description

### Problem

SQL Server expresses `limit` as `top N`, which `SqlServerGrammar::compileColumns()` injects based on `$query->limit`. Union queries, however, store their limit and offset in `$query->unionLimit` / `$query->unionOffset`, and the base grammar hands those to `compileLimit()` and `compileOffset()`:

```php
// Grammar::compileUnions()
if (isset($query->unionLimit)) {
    $sql .= ' '.$this->compileLimit($query, $query->unionLimit);
}

SqlServerGrammar::compileLimit() only emits fetch next when $query->offset > 0. On a union query offset is null (the value lives in unionOffset), so the limit is silently discarded:

$users->union($admins)->orderBy('id')->limit(10)->offset(5)->toSql();
// ... order by [id] asc offset 5 rows                        <- no "fetch next 10 rows only"

$users->union($admins)->limit(10)->toSql();
// select * from ([users]) as [temp_table] union select ...  <- no limit at all

$users->union($admins)->offset(5)->toSql();
// ... offset 5 rows                                          <- invalid: OFFSET requires ORDER BY

The practical impact is that ->union(...)->paginate() (which uses forPage() and therefore unionLimit / unionOffset) returns every row from the offset onward on SQL Server, ignoring the page size, and ->union(...)->limit(n) returns the whole result set.

Fix

Override compileUnions() in SqlServerGrammar so union queries always emit an offset N rows [fetch next M rows only] clause. Since top cannot be attached to the union wrapper and fetch next cannot stand alone, the offset defaults to zero when none was requested:

... order by [id] asc offset 5 rows fetch next 10 rows only   -- limit + offset
... order by [id] asc offset 0 rows fetch next 10 rows only   -- limit only
... order by [id] asc offset 5 rows                           -- offset only

compileSelect() also injects the existing (SELECT 0) fallback ordering into unionOrders when a union has a limit or offset but no explicit order, mirroring what is already done for non-union queries.

Non-union queries are unaffected. compileLimit() and compileOffset() keep their current behaviour.

Tests

Added testSqlServerUnionLimitsAndOffsets covering limit with offset, limit only, offset only, forPage() without an explicit order, and per-subquery top limits combined with a union limit. The test fails on 13.x without the change and passes with it. The full tests/Database suite passes.
```