### PR TITLE
[13.x] Apply nullsNotDistinct() to online and algorithm unique indexe…

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -334,17 +334,22 @@ class PostgresGrammar extends Grammar
     {
         $uniqueStatement = 'unique';
 
+        $nullsStatement = '';
+
         if (! is_null($command->nullsNotDistinct)) {
-            $uniqueStatement .= ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
+            $nullsStatement = ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
+
+            $uniqueStatement .= $nullsStatement;
         }
 
         if ($command->online || $command->algorithm) {
-            $createIndexSql = sprintf('create unique index %s%s on %s%s (%s)',
+            $createIndexSql = sprintf('create unique index %s%s on %s%s (%s)%s',
                 $command->online ? 'concurrently ' : '',
                 $this->wrap($command->index),
                 $this->wrapTable($blueprint),
                 $command->algorithm ? ' using '.$command->algorithm : '',
-                $this->columnize($command->columns)
+                $this->columnize($command->columns),
+                $nullsStatement
             );
 
             $sql = sprintf('alter table %s add constraint %s unique using index %s',

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -352,6 +352,28 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "users_foo_unique" unique using index "users_foo_unique"', $statements[1]);
     }
 
+    public function testAddingUniqueKeyOnlineWithNullsNotDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo')->nullsNotDistinct()->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('create unique index concurrently "users_foo_unique" on "users" ("foo") nulls not distinct', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_foo_unique" unique using index "users_foo_unique"', $statements[1]);
+    }
+
+    public function testAddingUniqueKeyWithAlgorithmAndNullsDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar', 'btree')->nullsNotDistinct(false);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('create unique index "bar" on "users" using btree ("foo") nulls distinct', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "bar" unique using index "bar"', $statements[1]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');


### PR DESCRIPTION
### Problem

`PostgresGrammar::compileUnique()` builds a `$uniqueStatement` that carries the `nulls [not] distinct` modifier requested via `nullsNotDistinct()`. That statement is only used in the plain `alter table ... add constraint` branch. When the unique key is created with `online()` or a custom algorithm, the grammar instead emits a `create unique index` statement and attaches it as a constraint, and that branch never includes the modifier:

```php
Schema::table('users', function (Blueprint $table) {
    $table->unique('email')->nullsNotDistinct();
});
// alter table "users" add constraint "users_email_unique" unique nulls not distinct ("email")

Schema::table('users', function (Blueprint $table) {
    $table->unique('email')->nullsNotDistinct()->online();
});
// create unique index concurrently "users_email_unique" on "users" ("email")   <- modifier dropped
// alter table "users" add constraint "users_email_unique" unique using index "users_email_unique"

The migration asks for NULLS NOT DISTINCT but the resulting constraint uses PostgreSQL's default NULLS DISTINCT semantics, so multiple rows with a NULL email are accepted. This is a silent data-integrity difference that appears only when online() or an algorithm is added.

Fix

Append the nulls [not] distinct clause to the create unique index statement as well. PostgreSQL 15+ accepts it after the column list:

create unique index concurrently "users_email_unique" on "users" ("email") nulls not distinct

The plain alter table branch is unchanged. When nullsNotDistinct() is not called, no clause is emitted, exactly as before.

Tests

Added testAddingUniqueKeyOnlineWithNullsNotDistinct and testAddingUniqueKeyWithAlgorithmAndNullsDistinct to DatabasePostgresSchemaGrammarTest, covering both online() and a custom algorithm with each value of the modifier. Both fail on 13.x without the change and pass with it. The full tests/Database suite passes.
```