### PR TITLE
[13.x] Preserve keys in LazyCollection::select()

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -996,7 +996,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             if (is_null($keys)) {
                 yield from $this;
             } else {
-                foreach ($this as $item) {
+                foreach ($this as $itemKey => $item) {
                     $result = [];
 
                     foreach ($keys as $key) {
@@ -1007,7 +1007,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                         }
                     }
 
-                    yield $result;
+                    yield $itemKey => $result;
                 }
             }
         });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4854,6 +4854,30 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testSelectPreservesKeys($collection)
+    {
+        $data = new $collection([
+            'taylor' => ['first' => 'Taylor', 'last' => 'Otwell'],
+            'jess' => ['first' => 'Jess', 'last' => 'Archer'],
+        ]);
+
+        $this->assertSame([
+            'taylor' => ['first' => 'Taylor'],
+            'jess' => ['first' => 'Jess'],
+        ], $data->select('first')->all());
+
+        $data = new $collection([
+            7 => (object) ['first' => 'Taylor', 'last' => 'Otwell'],
+            9 => (object) ['first' => 'Jess', 'last' => 'Archer'],
+        ]);
+
+        $this->assertSame([
+            7 => ['first' => 'Taylor'],
+            9 => ['first' => 'Jess'],
+        ], $data->select(['first'])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testGettingAvgItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);


### PR DESCRIPTION
### Problem

`Collection::select()` delegates to `Arr::select()`, which uses `Arr::map()` and therefore keeps the original keys. `LazyCollection::select()` iterates with `foreach ($this as $item)` and yields the projected item without its key, so the result is re-indexed from zero:

```php
$users = [
    7 => ['id' => 7, 'name' => 'Taylor'],
    9 => ['id' => 9, 'name' => 'Jess'],
];

(new Collection($users))->select(['name'])->all();
// [7 => ['name' => 'Taylor'], 9 => ['name' => 'Jess']]

(new LazyCollection($users))->select(['name'])->all();
// [0 => ['name' => 'Taylor'], 1 => ['name' => 'Jess']]   <- keys lost

Both classes implement Enumerable and are meant to be interchangeable. Every other key-preserving LazyCollection method (map, filter, and the select(null) branch itself, which uses yield from $this) keeps keys, so the re-indexing here looks unintended. It silently breaks patterns such as $rows->keyBy('id')->select([...]) when the source is lazy.

Fix

Yield the original key alongside the projected item:

foreach ($this as $itemKey => $item) {
    // ...
    yield $itemKey => $result;
}

Tests

Added testSelectPreservesKeys, run against both Collection and LazyCollection through the existing collectionClassProvider, covering string keys with array items and integer keys with object items. It fails on 13.x for LazyCollection without the change and passes with it. The existing select tests continue to pass.
```