### PR TITLE
[13.x] Fix Str::camel() not lowercasing multibyte first characters

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -238,7 +238,7 @@ class Str
      */
     public static function camel($value)
     {
-        return static::$camelCache[$value] ?? static::$camelCache[$value] = lcfirst(static::studly($value));
+        return static::$camelCache[$value] ?? static::$camelCache[$value] = static::lcfirst(static::studly($value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1323,6 +1323,10 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('foo1Bar', Str::camel('foo1_bar'));
         $this->assertSame('1FooBar', Str::camel('1 foo bar'));
+
+        $this->assertSame('überUns', Str::camel('Über uns'));
+        $this->assertSame('émileZola', Str::camel('émile_zola'));
+        $this->assertSame('élanVital', Str::camel('Élan-vital'));
     }
 
     public function testCharAt()


### PR DESCRIPTION
`Str::camel()` lowercases the first character with PHP's native `lcfirst()`, which only handles ASCII letters, so strings that start with an accented or non-Latin letter keep their capital:

```php
Str::camel('Über uns');   // expected "überUns", but got "ÜberUns"
Str::camel('émile_zola'); // expected "émileZola", but got "ÉmileZola"
```

`Str::studly()` already capitalises each word with the multibyte-safe `Str::ucfirst()`, so this PR switches `camel()` to the matching `Str::lcfirst()`. ASCII strings are unaffected.