### PR TITLE
[13.x] Keep the debounce first-dispatch timestamp alive for the whole…

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -69,7 +69,7 @@ class DebounceLock
         $firstDispatchedAt = $cache->get($timestampKey);
 
         if (is_null($firstDispatchedAt)) {
-            $cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl);
+            $cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl + $maxWait);
 
             return false;
         }

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -228,6 +228,25 @@ class DebouncedJobTest extends QueueTestCase
         $this->assertFalse($second['maxWaitExceeded']);
     }
 
+    public function testMaxDebounceWaitIsHonoredWhenLongerThanDebounceTtl()
+    {
+        $cache = $this->app->get(Cache::class);
+        $lock = new DebounceLock($cache);
+        $job = new DebouncedWithLongMaxWaitJob('entity-1');
+
+        $this->assertFalse($lock->acquire($job)['maxWaitExceeded']);
+
+        for ($i = 1; $i < 60; $i++) {
+            $this->travelTo(Carbon::now()->addSeconds(60));
+
+            $this->assertFalse($lock->acquire($job)['maxWaitExceeded']);
+        }
+
+        $this->travelTo(Carbon::now()->addSeconds(60));
+
+        $this->assertTrue($lock->acquire($job)['maxWaitExceeded']);
+    }
+
     public function testSupersededDebouncedJobDoesNotDispatchChain()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
@@ -484,6 +503,25 @@ class DebouncedWithCustomCacheJob implements ShouldQueue
     public function handle()
     {
         static::$handled = true;
+    }
+}
+
+#[DebounceFor(60, maxWait: 3600)]
+class DebouncedWithLongMaxWaitJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public function __construct(public string $entityId)
+    {
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function handle()
+    {
     }
 }
 


### PR DESCRIPTION
### Problem

`DebounceLock` stores a `:first_dispatched_at` marker so that `maxWait` can force a debounced job to run even when new dispatches keep arriving. That marker is written with the same TTL as the debounce token:

```php
$ttl = max(($debounceFor ?? $this->getDebounceDelay($job)) * 10, 300);
// ...
$cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl);

When maxWait is larger than that TTL, the marker expires before the deadline is reached. The next acquire() sees no marker, writes a fresh "now", and the elapsed time starts over. A job that is dispatched more often than its debounce window is therefore deferred forever, which is exactly the starvation maxWait exists to prevent.

An ordinary configuration triggers it:

#[DebounceFor(60, maxWait: 3600)]
class SyncSearchIndex implements ShouldQueue { /* ... */ }

Here the TTL is 600 seconds, so with a dispatch every minute the marker resets every ten minutes and maxWaitExceeded is never true. Nothing is logged; the job simply never runs.

Fix

Store the marker for the debounce TTL plus the full maxWait window, so it is guaranteed to outlive the deadline:

$cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl + $maxWait);

The marker is still cleared by release() and releaseMaxWait() once the job runs, so nothing lingers longer than before in the normal path.

Tests

Added testMaxDebounceWaitIsHonoredWhenLongerThanDebounceTtl with a #[DebounceFor(60, maxWait: 3600)] job that is re-acquired every minute. Without the change maxWaitExceeded stays false past the one hour mark; with it, the dispatch at one hour is forced to run. The existing debounce tests only use maxWait: 60, which is below the minimum TTL of 300, so they never exercised this path and continue to pass.
```