### PR TITLE
[13.x] Preserve numeric query string keys in query() and fullUrlWithQ…

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -157,7 +157,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($this->query()) > 0
-            ? $this->url().$question.Arr::query(array_merge($this->query(), $query))
+            ? $this->url().$question.Arr::query(array_replace($this->query(), $query))
             : $this->fullUrl().$question.Arr::query($query);
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -254,7 +254,7 @@ class UrlGenerator implements UrlGeneratorContract
         parse_str(Str::after($existingQueryString, '?'), $existingQueryArray);
 
         return rtrim($this->to($path.'?'.Arr::query(
-            array_merge($existingQueryArray, $query)
+            array_replace($existingQueryArray, $query)
         ), $extra, $secure), '?');
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -155,6 +155,9 @@ class HttpRequestTest extends TestCase
 
         $request = Request::create('https://foo.com');
         $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
+
+        $request = Request::create('https://foo.com?1=a&2=b');
+        $this->assertSame('https://foo.com/?1=a&2=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
     }
 
     public function testFullUrlWithoutQueryMethod()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -54,6 +54,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar'));
         $this->assertSame('http://www.foo.com/foo/bar?0=foo', $url->query('foo/bar', ['foo']));
         $this->assertSame('http://www.foo.com/foo/bar?baz=boom', $url->query('foo/bar', ['baz' => 'boom']));
+        $this->assertSame('http://www.foo.com/foo/bar?1=a&2=b&baz=boom', $url->query('foo/bar?1=a&2=b', ['baz' => 'boom']));
         $this->assertSame('http://www.foo.com/foo/bar?baz=zee&zal=bee', $url->query('foo/bar?baz=boom&zal=bee', ['baz' => 'zee']));
         $this->assertSame('http://www.foo.com/foo/bar?zal=bee', $url->query('foo/bar?baz=boom&zal=bee', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar?baz=boom', $url->query('foo/bar?baz=boom', ['nonexist' => null]));


### PR DESCRIPTION
### Problem

Both helpers merge the existing query string with the new parameters using `array_merge()`. PHP converts numeric string keys to integers when parsing a query string, and `array_merge()` renumbers integer keys from zero, so existing numeric parameters are silently renamed:

```php
url()->query('/foo?1=a&2=b', ['c' => 3]);
// actual:   http://x.com/foo?0=a&1=b&c=3
// expected: http://x.com/foo?1=a&2=b&c=3

Request::create('http://x.com/foo?1=a')->fullUrlWithQuery(['c' => 3]);
// actual:   http://x.com/foo?0=a&c=3
// expected: http://x.com/foo?1=a&c=3

Numeric keys are common in filter and matrix style query strings (?filters[1]=x, ?1=on), and this corrupts them whenever a parameter is appended, for example when building pagination or sort links from the current URL.

Fix

Use array_replace() instead of array_merge() in UrlGenerator::query() and Request::fullUrlWithQuery(). It keeps every key as is while preserving the same override semantics for string keys, so all existing behaviour is unchanged.

Tests

Added assertions with numeric keys to testQueryGeneration and testFullUrlMethod. Both fail on 13.x without the change and pass with it. The existing cases continue to pass.
```