### PR TITLE
[13.x] Recreate inline unique constraints when rebuilding a SQLite table

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -344,12 +344,18 @@ class SQLiteGrammar extends Grammar
                 );
             })->all();
 
+        [, $tableName] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
+
         $indexes = (new Collection($blueprint->getState()->getIndexes()))
-            ->reject(fn ($index) => str_starts_with('sqlite_', $index->index))
-            ->map(fn ($index) => $this->{'compile'.ucfirst($index->name)}($blueprint, $index))
+            ->map(function ($index) use ($blueprint, $tableName) {
+                if (str_starts_with($index->index, 'sqlite_autoindex_')) {
+                    $index->index = $this->createIndexName($tableName, $index->name, $index->columns);
+                }
+
+                return $this->{'compile'.ucfirst($index->name)}($blueprint, $index);
+            })
             ->all();
 
-        [, $tableName] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
         $tempTable = $this->wrapTable($blueprint, '__temp__'.$this->connection->getTablePrefix());
         $table = $this->wrapTable($blueprint);
         $columnNames = implode(', ', $columnNames);
@@ -368,6 +374,23 @@ class SQLiteGrammar extends Grammar
             sprintf('drop table %s', $table),
             sprintf('alter table %s rename to %s', $tempTable, $this->wrapTable($tableName)),
         ], $indexes, [$foreignKeyConstraintsEnabled ? $this->compileEnableForeignKeyConstraints() : null]));
+    }
+
+    /**
+     * Create a default index name for the given table, type and columns.
+     *
+     * @param  string  $table
+     * @param  string  $type
+     * @param  array  $columns
+     * @return string
+     */
+    protected function createIndexName($table, $type, array $columns)
+    {
+        if ($this->connection->getConfig('prefix_indexes')) {
+            $table = $this->connection->getTablePrefix().$table;
+        }
+
+        return str_replace(['-', '.'], '_', strtolower($table.'_'.implode('_', $columns).'_'.$type));
     }
 
     /** @inheritDoc */

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -61,6 +61,22 @@ class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
         Schema::drop('posts');
     }
 
+    public function testInlineUniqueConstraintsSurviveTableRebuild()
+    {
+        DB::statement('create table "accounts" ("id" integer primary key autoincrement, "email" varchar not null unique, "name" varchar)');
+
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->string('name', 100)->nullable()->change();
+        });
+
+        $indexes = collect(Schema::getIndexes('accounts'));
+
+        $this->assertTrue($indexes->contains(fn ($index) => $index['name'] === 'accounts_email_unique' && $index['unique'] && $index['columns'] === ['email']));
+        $this->assertFalse($indexes->contains(fn ($index) => str_starts_with($index['name'], 'sqlite_autoindex')));
+
+        Schema::drop('accounts');
+    }
+
     public function testGetViews()
     {
         DB::connection('conn1')->statement(<<<'SQL'


### PR DESCRIPTION
### Problem

When SQLite cannot alter a table in place (`change()`, `dropPrimary()`, `dropColumn()` on older SQLite versions, and so on), the schema grammar rebuilds it: create a temp table, copy the rows, drop the original, rename, then recreate the indexes. SQLite's internal `sqlite_autoindex_*` indexes, which back inline `UNIQUE` constraints, were meant to be skipped:

```php
->reject(fn ($index) => str_starts_with('sqlite_', $index->index))

The haystack and needle are reversed, so the guard never matches. The grammar then emits create unique index "sqlite_autoindex_users_1" ..., which SQLite rejects:

SQLSTATE[HY000]: General error: 1 object name reserved for internal use: sqlite_autoindex_users_1

Because this statement runs after the original table has already been dropped and the temp table renamed, the migration aborts half way and the table is left without its unique constraint.

Any table with an inline UNIQUE that was not created by Laravel's own grammar triggers this: raw CREATE TABLE statements, imported schema dumps, or tables created by third party packages.

DB::statement('create table accounts (id integer primary key autoincrement, email varchar unique, name varchar)');

Schema::table('accounts', fn (Blueprint $table) => $table->string('name', 100)->nullable()->change());
// QueryException, and "accounts" now has no unique constraint on "email"

Fix

Fixing only the argument order would make the rebuild succeed but silently drop the unique constraint. Instead, indexes named sqlite_autoindex_* are recreated under the conventional {table}_{columns}_{type} name (honouring prefix_indexes), so the constraint survives the rebuild:

create unique index "accounts_email_unique" on "accounts" ("email")

Tests

Added testInlineUniqueConstraintsSurviveTableRebuild to the SQLite integration suite. It creates a table with an inline UNIQUE via raw SQL, changes a column, and asserts a unique index named accounts_email_unique on email exists and no sqlite_autoindex name remains. Without the change the test errors with the "reserved for internal use" exception. The full tests/Database suite and the SQLite integration suite pass.
```