### PR TITLE
[13.x] Allow an Expression in the PostgreSQL using() column modifier

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -287,7 +287,7 @@ class PostgresGrammar extends Grammar
     {
         $column = $command->column;
 
-        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column).($column->using ? ' using '.$column->using : '')];
+        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column).($column->using ? ' using '.$this->getValue($column->using) : '')];
 
         foreach ($this->modifiers as $modifier) {
             if ($modifier === 'Collate') {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1375,6 +1375,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertStringNotContainsString('a.attgenerated', $statement);
     }
 
+    public function testAddUsingExpressionToColumnOnChange()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'currency_rates');
+        $blueprint->date('name')->using(new Expression('name::date'))->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertSame(
+            'alter table "currency_rates" alter column "name" type date using name::date, alter column "name" set not null, alter column "name" drop default, alter column "name" drop identity if exists',
+            $statements[0]
+        );
+    }
+
     public function testAddUsingKeywordToColumnOnChange()
     {
         $blueprint = new Blueprint($this->getConnection(), 'currency_rates');


### PR DESCRIPTION
### Problem

`ColumnDefinition::using()` is documented as accepting `string|Expression`, but `PostgresGrammar::compileChange()` concatenates the value directly:

```php
($column->using ? ' using '.$column->using : '')

Passing an Expression therefore fatals:

$table->integer('amount')->using(new Expression('amount::integer'))->change();
// Error: Object of class Illuminate\Database\Query\Expression could not be converted to string

Fix

Resolve the value through getValue(), as every other column modifier already does:

($column->using ? ' using '.$this->getValue($column->using) : '')

Plain strings are unaffected.

Tests

Added testAddUsingExpressionToColumnOnChange, which mirrors the existing string test with an Expression and expects the same SQL. It errors on 13.x without the change and passes with it.
```