### PR TITLE
[13.x] Fix relative signed URL validation for the root route

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -467,7 +467,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $absolute
             ? rtrim($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo(), '/')
-            : '/'.$request->path();
+            : '/'.ltrim($request->path(), '/');
 
         $queryString = (new Stringable((string) ($request->server->get('VAPOR_RAW_QUERY_STRING') ?? $request->server->get('QUERY_STRING'))))->explode('&')
             ->reject(function ($parameter) use ($ignoreQuery) {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -908,6 +908,30 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertFalse($url->hasValidSignature($request, false));
     }
 
+    public function testSignedRelativeUrlForRootRoute()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $routes->add(new Route(['GET'], '/', ['as' => 'home', function () {
+            //
+        }]));
+
+        $request = Request::create($url->signedRoute('home', [], null, false));
+
+        $this->assertTrue($url->hasValidSignature($request, false));
+        $this->assertTrue($url->hasValidRelativeSignature($request));
+
+        $request = Request::create($url->signedRoute('home', [], null, false).'&tampered=true');
+
+        $this->assertFalse($url->hasValidSignature($request, false));
+    }
+
     public function testSignedUrlParameterCannotBeNamedSignature()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
### Problem

When validating a relative signature, `UrlGenerator::hasValidSignature()` rebuilds the URL that was signed as `'/'` followed by the request path:

```php
$url = $absolute
    ? rtrim($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo(), '/')
    : '/'.$request->path();

Request::path() returns '/' rather than '' for the root, so the verifier hashes '//' while signedRoute(..., absolute: false) generated and signed '/'. Any relative signed URL for a route whose URI is / is therefore always rejected, including through the signed:relative middleware and hasValidRelativeSignature():

Route::get('/', ...)->name('home');

$url = URL::signedRoute('home', [], null, false);   // "/?signature=..."
URL::hasValidRelativeSignature(Request::create($url)); // false, expected true

Absolute signed URLs for the same route validate correctly, and relative signed URLs for every other route work, which confirms the mismatch is limited to the root path.

Fix

Trim the leading slash before prefixing it, so the root becomes '/' and every other path is unchanged:

: '/'.ltrim($request->path(), '/');

Tests

Added testSignedRelativeUrlForRootRoute, which signs the / route relatively, asserts both hasValidSignature($request, false) and hasValidRelativeSignature() accept it, and asserts a tampered URL is still rejected. It fails on 13.x without the change and passes with it. Existing signed URL tests only use non-root routes and continue to pass.
```