### PR TITLE
[13.x] Sleep for the full duration on every Sleep::while() iteration

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -330,10 +330,6 @@ class Sleep
             return;
         }
 
-        $remaining = $this->duration->copy();
-
-        $seconds = (int) $remaining->totalSeconds;
-
         $while = $this->while ?: function () {
             static $return = [true, false];
 
@@ -341,6 +337,10 @@ class Sleep
         };
 
         while ($while()) {
+            $remaining = $this->duration->copy();
+
+            $seconds = (int) $remaining->totalSeconds;
+
             if ($seconds > 0) {
                 sleep($seconds);
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -45,6 +45,20 @@ class SleepTest extends TestCase
         unset($_SERVER['__sleep.while']);
     }
 
+    public function testItSleepsForTheFullDurationOnEveryWhileIteration()
+    {
+        $start = microtime(true);
+        Sleep::for(1.5)->seconds()->while(function () {
+            static $results = [true, true, false];
+
+            return array_shift($results);
+        });
+        $elapsed = microtime(true) - $start;
+
+        $this->assertGreaterThanOrEqual(2.9, $elapsed);
+        $this->assertLessThan(3.5, $elapsed);
+    }
+
     public function testItSleepsForSecondsWithMilliseconds()
     {
         $start = microtime(true);


### PR DESCRIPTION
### Problem

In `Sleep::goodnight()` the remaining duration is computed once, before the `while()` loop, and then mutated inside it:

```php
$remaining = $this->duration->copy();
$seconds = (int) $remaining->totalSeconds;

while ($while()) {
    if ($seconds > 0) {
        sleep($seconds);
        $remaining = $remaining->subSeconds($seconds);
    }

    $microseconds = (int) $remaining->totalMicroseconds;

    if ($microseconds > 0) {
        usleep($microseconds);
    }
}

The first iteration sleeps the full duration. After that, the whole seconds have already been subtracted from $remaining, so $microseconds is zero or negative and every later iteration sleeps only the integer part:

Sleep::for(1.3)->seconds()->while(fn () => $attempts++ < 3);
// actual:   1.3s + 1.0s + 1.0s = 3.3s
// expected: 1.3s + 1.3s + 1.3s = 3.9s

This only affects durations of one second or more with a fractional part, but that is exactly the shape of the polling and backoff loops while() is used for.

Fix

Recompute the remaining duration at the start of each iteration so every pass sleeps the full amount. Durations below one second and single sleeps are unaffected.

Tests

Added testItSleepsForTheFullDurationOnEveryWhileIteration, which sleeps 1.1 seconds for two iterations and asserts about 2.2 seconds elapsed, using the same timing tolerance as the existing real-sleep tests. It fails on 13.x (about 2.1 seconds) and passes with the change.
```