### PR TITLE
[13.x] Accept enums in Queue::isPaused() and Queue::getPausedQueues()

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -330,12 +330,15 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Determine if a queue is paused.
      *
-     * @param  string  $connection
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $connection
+     * @param  \UnitEnum|string  $queue
      * @return bool
      */
     public function isPaused($connection, $queue)
     {
+        $connection = enum_value($connection);
+        $queue = enum_value($queue);
+
         $cache = $this->app['cache']->store();
 
         return (bool) ($cache->get('illuminate:queues:paused')
@@ -345,12 +348,15 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Determine which of the given queues are currently paused.
      *
-     * @param  string  $connection
-     * @param  array  $queues
-     * @return array
+     * @param  \UnitEnum|string  $connection
+     * @param  array<int, \UnitEnum|string>  $queues
+     * @return array<int, string>
      */
     public function getPausedQueues($connection, $queues)
     {
+        $connection = enum_value($connection);
+        $queues = array_map(enum_value(...), $queues);
+
         $cache = $this->app['cache']->store();
 
         if ($cache->get('illuminate:queues:paused')) {

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -266,6 +266,8 @@ class QueuePauseResumeTest extends TestCase
 
         $this->manager->pauseFor(PauseQueueConnection::Redis, PauseQueueName::Emails, 30);
         $this->assertTrue($this->manager->isPaused('redis', 'emails'));
+        $this->assertTrue($this->manager->isPaused(PauseQueueConnection::Redis, PauseQueueName::Emails));
+        $this->assertSame(['emails'], $this->manager->getPausedQueues(PauseQueueConnection::Redis, [PauseQueueName::Emails, 'default']));
     }
 }
 


### PR DESCRIPTION
### Problem

#61464 allowed enums to be passed to `pause()`, `pauseFor()` and `resume()` by normalising the arguments with `enum_value()`. The two read methods were not updated and still interpolate the connection and queue straight into the cache key, so passing the same enum that was used to pause a queue throws:

```php
Queue::pause(QueueConnection::Redis, QueueName::Emails);   // works

Queue::isPaused(QueueConnection::Redis, QueueName::Emails);
// Error: Object of class QueueConnection could not be converted to string

Queue::getPausedQueues(QueueConnection::Redis, [QueueName::Emails]);
// same error

The test added with #61464 passes enums to the writers but plain strings to isPaused(), which is why it did not catch this.

Fix

Normalise the arguments in isPaused() and getPausedQueues() with enum_value() as well, and update the docblocks to \UnitEnum|string. Normalising $queues up front also keeps the return value of getPausedQueues() a list of strings, which is what Worker::raisePausedQueueEvents() expects when it diffs them against the cached names.

Tests

Extended testEnumsAreAccepted to call isPaused() with enums and getPausedQueues() with a mix of enum and string queue names. It errors on 13.x without the change and passes with it.
```