### PR TITLE
[13.x] Add MemoizedStore::add() so memoized misses cannot clobber exi…

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -104,6 +104,21 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
     }
 
     /**
+     * Store an item in the cache if the key does not exist.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function add($key, $value, $seconds)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->add($key, $value, $seconds);
+    }
+
+    /**
      * Store multiple items in the cache for a given number of seconds.
      *
      * @param  int  $seconds

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -28,6 +28,24 @@ class CacheMemoizedStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
+    public function testAddDoesNotOverwriteValueWrittenAfterMissWasMemoized(): void
+    {
+        $repository = new Repository(new ArrayStore);
+        $memoized = new Repository(new MemoizedStore('test', $repository));
+
+        $this->assertNull($memoized->get('foo'));
+
+        $repository->put('foo', 'bar', 30);
+
+        $this->assertFalse($memoized->add('foo', 'baz', 30));
+        $this->assertSame('bar', $memoized->get('foo'));
+        $this->assertSame('bar', $repository->get('foo'));
+
+        $this->assertTrue($memoized->add('new', 'value', 30));
+        $this->assertSame('value', $memoized->get('new'));
+        $this->assertSame('value', $repository->get('new'));
+    }
+
     public function testLocksCanBeFlushedWhenUnderlyingStoreSupportsIt(): void
     {
         $store = new MemoizedStore('test', new Repository(new ArrayStore));


### PR DESCRIPTION
Description

### Problem

`Repository::add()` uses the store's own `add()` when one exists and otherwise falls back to "get, then put if null". `MemoizedStore` has no `add()`, so the fallback runs, and its `get()` is served from the memo cache. Once a miss has been memoized, `add()` believes the key is absent and overwrites whatever another request has written since, returning `true`:

```php
Cache::memo()->get('foo');            // memoizes the miss
Cache::put('foo', 'written-elsewhere', 60);

Cache::memo()->add('foo', 'mine', 60); // true, and 'foo' is now 'mine'

The plain repository returns false and leaves the existing value alone. This breaks the "store only if absent" contract of add() and anything layered on it through the memo driver, such as RateLimiter::increment() and CacheLock::acquire(), which use add() for their atomic guarantees.

Fix

Add an add() method to MemoizedStore that invalidates the memoized entry and delegates to the underlying repository's add(), mirroring what put(), forever() and touch() already do. Repository::add() then takes the atomic path and the underlying store decides whether the key exists.

Tests

Added testAddDoesNotOverwriteValueWrittenAfterMissWasMemoized. It memoizes a miss, writes the key through the underlying repository, and asserts that add() returns false and keeps the existing value, while add() on a genuinely new key still succeeds. The test fails on 13.x without the change and passes with it. There was no existing add() coverage for the memo store.
```