### PR TITLE
[13.x] Stop ArrayLock reporting expired locks as held

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -115,6 +115,12 @@ class ArrayLock extends Lock
             return null;
         }
 
+        $expiresAt = $this->store->locks[$this->name]['expiresAt'];
+
+        if ($expiresAt && ! $expiresAt->isFuture()) {
+            return null;
+        }
+
         return $this->store->locks[$this->name]['owner'];
     }
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -355,6 +355,23 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 
+    public function testExpiredLockIsNotReportedAsHeld()
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $store = new ArrayStore;
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertTrue($lock->isLocked());
+        $this->assertTrue($lock->isOwnedByCurrentProcess());
+
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
+
+        $this->assertFalse($lock->isLocked());
+        $this->assertFalse($lock->isOwnedByCurrentProcess());
+        $this->assertFalse($lock->isOwnedBy($lock->owner()));
+    }
+
     public function testExpiredLockCannotBeRefreshedByPreviousOwner()
     {
         Carbon::setTestNow($now = Carbon::now());


### PR DESCRIPTION
### Problem

`ArrayLock::getCurrentOwner()` returns the stored owner whenever the lock entry exists, without checking `expiresAt`:

```php
protected function getCurrentOwner()
{
    if (! $this->exists()) {
        return null;
    }

    return $this->store->locks[$this->name]['owner'];
}

acquire() and refresh() in the same class already honour expiry, and every other driver does too: DatabaseLock filters on expiration > now and CacheLock relies on the cache entry expiring. As a result isLocked(), isOwnedBy() and isOwnedByCurrentProcess() keep returning true for an array store lock long after it has expired:

$lock = Cache::store('array')->lock('foo', 10);
$lock->get();

// 11 seconds later
$lock->isLocked();               // true, expected false
$lock->isOwnedByCurrentProcess(); // true, expected false

// the same sequence on the file store returns false for both

Lock::isLocked() is documented as "determine if the lock is currently held by any process", so this is a driver inconsistency that shows up in tests and local development using the array store.

Fix

Return null from getCurrentOwner() once the lock has expired, using the same check refresh() already performs.

Tests

Added testExpiredLockIsNotReportedAsHeld, which acquires a lock, travels past its expiry, and asserts isLocked(), isOwnedByCurrentProcess() and isOwnedBy() all return false. It fails on 13.x without the change and passes with it.
```