### PR TITLE
[13.x] Make Str::excerpt() find phrases in multi-line text

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -462,7 +462,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/isu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -325,6 +325,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('This is a...', Str::excerpt('This is a beautiful morning', 'this', ['radius' => 5]));
         $this->assertSame('...iful morning', Str::excerpt('This is a beautiful morning', 'morning', ['radius' => 5]));
         $this->assertNull(Str::excerpt('This is a beautiful morning', 'day'));
+        $this->assertSame("First line\nsecond line", Str::excerpt("First line\nsecond line", 'second'));
+        $this->assertSame("First line\nsecond line", Str::excerpt("First line\nsecond line", 'First'));
+        $this->assertSame('...fine morning', Str::excerpt("This is a beautiful\nfine morning", 'morning', ['radius' => 5]));
+        $this->assertNull(Str::excerpt("First line\nsecond line", 'third'));
         $this->assertSame('...is a beautiful! mor...', Str::excerpt('This is a beautiful! morning', 'Beautiful', ['radius' => 5]));
         $this->assertSame('...is a beautiful? mor...', Str::excerpt('This is a beautiful? morning', 'beautiful', ['radius' => 5]));
         $this->assertSame('', Str::excerpt('', '', ['radius' => 0]));


### PR DESCRIPTION
### Problem

`Str::excerpt()` locates the phrase with a regular expression anchored at both ends and without the `s` modifier:

```php
preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);

Because . does not match a newline, the pattern only succeeds when the phrase sits on the one and only line of the text. Any multi-line input returns null even though the phrase is present:

Str::excerpt("First line\nsecond line", 'second');
// actual:   null
// expected: "First line\nsecond line"

Str::excerpt("This is a beautiful\nfine morning", 'morning', ['radius' => 5]);
// actual:   null
// expected: "...fine morning"

Post bodies, markdown, text columns and strip_tags() output almost always contain newlines, and search result snippets are exactly the use case this helper exists for.

Fix

Add the s modifier so . matches newlines. The existing ltrim() / rtrim() handling of the surrounding text is unchanged, so single-line behaviour and all current expectations stay the same.

Tests

Added cases to testStrExcerpt with the phrase on the first line, on the second line, with a small radius crossing a newline, and a phrase that is absent from multi-line text. They fail on 13.x without the change and pass with it.
```