### PR TITLE
[13.x] Fix whereJsonContains() with array values on SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -204,6 +204,31 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where JSON contains" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereJsonContains(Builder $query, $where)
+    {
+        if (! is_array($where['value'])) {
+            return parent::whereJsonContains($query, $where);
+        }
+
+        $not = $where['not'] ? 'not ' : '';
+
+        if (empty($where['value'])) {
+            return $not.'(1 = 1)';
+        }
+
+        return $not.'('.implode(' and ', array_map(
+            fn ($value) => $this->compileJsonContains($where['column'], $this->parameter($value)),
+            $where['value']
+        )).')';
+    }
+
+    /**
      * Compile a "JSON contains" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7350,6 +7350,16 @@ SQL;
         $builder->select('*')->from('users')->whereJsonContains('users.options->language', 'en')->toSql();
         $this->assertSame('select * from "users" where exists (select 1 from json_each("users"."options", \'$."language"\') where "json_each"."value" is ?)', $builder->toSql());
         $this->assertEquals(['en'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en', 'fr']);
+        $this->assertSame('select * from "users" where (exists (select 1 from json_each("options", \'$."languages"\') where "json_each"."value" is ?) and exists (select 1 from json_each("options", \'$."languages"\') where "json_each"."value" is ?))', $builder->toSql());
+        $this->assertEquals(['en', 'fr'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en', 'fr']);
+        $this->assertSame('select * from "users" where not (exists (select 1 from json_each("options", \'$."languages"\') where "json_each"."value" is ?) and exists (select 1 from json_each("options", \'$."languages"\') where "json_each"."value" is ?))', $builder->toSql());
+        $this->assertEquals(['en', 'fr'], $builder->getBindings());
     }
 
     public function testWhereJsonContainsSqlServer()


### PR DESCRIPTION
### Problem

  `whereJsonContains()` documents that an array value means "contains all of these values". MySQL, PostgreSQL and SQL Server implement this by JSON-encoding the array into a single binding in `prepareBindingForJsonContains()`. The SQLite grammar leaves the binding untouched, but still compiles a single placeholder:

```php
DB::table('users')->whereJsonContains('options->languages', ['en', 'fr'])->get();

select * from "users" where exists (select 1 from json_each("options", '$."languages"') where "json_each"."value" is ?)
bindings: ['en', 'fr']

PDOException: SQLSTATE[HY000]: General error: 25 column index out of range

The builder spreads the array into one binding per element, so the placeholder count no longer matches and the query fails at execution time. Applications that develop against SQLite and deploy on MySQL or PostgreSQL, or run their test suite on SQLite, hit this as soon as they pass an array.

Fix

Override whereJsonContains() in SQLiteGrammar so that an array value compiles to one json_each() existence check per element, joined with and. Each element keeps its own placeholder, matching the bindings one to one, and the result has the same "contains all" semantics as the other grammars:

select * from "users" where (
    exists (select 1 from json_each("options", '$."languages"') where "json_each"."value" is ?)
    and exists (select 1 from json_each("options", '$."languages"') where "json_each"."value" is ?)
)

whereJsonDoesntContain() negates the whole group. Scalar values are unchanged, and an empty array compiles to an always-true condition, matching MySQL's json_contains(col, '[]').

Tests

Extended testWhereJsonContainsSqlite with array cases for both whereJsonContains() and whereJsonDoesntContain(), asserting the generated SQL and bindings. The new assertions fail on 13.x and pass with the change. I also confirmed against an in-memory SQLite database that the query executes and returns only rows containing every value.
```