### PR TITLE
[13.x] Hash the token in TokenGuard::validate() when the guard hashes…

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -114,7 +114,11 @@ class TokenGuard implements Guard
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
+        $credentials = [
+            $this->storageKey => $this->hash
+                ? hash('sha256', $credentials[$this->inputKey])
+                : $credentials[$this->inputKey],
+        ];
 
         return (bool) $this->provider->retrieveByCredentials($credentials);
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -96,6 +96,19 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
 
+    public function testValidateHashesTheTokenWhenTheGuardUsesHashedTokens()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->expects('retrieveByCredentials')->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
+        $request = Request::create('/', 'GET', ['api_token' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', true);
+
+        $this->assertTrue($guard->validate(['api_token' => 'foo']));
+    }
+
     public function testValidateCanDetermineIfCredentialsAreInvalid()
     {
         $provider = Mockery::mock(UserProvider::class);


### PR DESCRIPTION
### Problem
`TokenGuard` can be configured with `hash = true`, in which case `user()` hashes the incoming token before looking it up:

```php
$user = $this->provider->retrieveByCredentials([
    $this->storageKey => $this->hash ? hash('sha256', $token) : $token,
]);

validate() does not apply the same hashing and passes the raw credential straight to the provider:

$credentials = [$this->storageKey => $credentials[$this->inputKey]];

return (bool) $this->provider->retrieveByCredentials($credentials);

On a hashed-token guard, validate() therefore rejects exactly the tokens that user() accepts:

// 'api' guard configured with 'hash' => true, token stored as sha256

Auth::guard('api')->user();                               // returns the user
Auth::guard('api')->validate(['api_token' => $plain]);    // false

Fix

Hash the credential in validate() when $this->hash is set, so both paths look up the same value. Guards without hashing are unaffected.

Tests

Added testValidateHashesTheTokenWhenTheGuardUsesHashedTokens, which constructs a hashed guard and asserts the provider receives the sha256 of the token. All existing TokenGuard tests use hash = false and continue to pass. The new test fails on 13.x without the change.
```