### PR TITLE
[13.x] Add pool-level request defaults to HTTP client Pool

### DIFF
--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
+use Closure;
 use GuzzleHttp\Utils;
 
 /**
@@ -31,6 +32,13 @@ class Pool
     protected $pool = [];
 
     /**
+     * The callback to configure default settings for all requests in the pool.
+     *
+     * @var (Closure(\Illuminate\Http\Client\PendingRequest): \Illuminate\Http\Client\PendingRequest)|null
+     */
+    protected $defaultsCallback = null;
+
+    /**
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -39,6 +47,22 @@ class Pool
     {
         $this->factory = $factory ?: new Factory();
         $this->handler = Utils::chooseHandler();
+    }
+
+    /**
+     * Set default request configuration for all requests in the pool.
+     *
+     * The callback receives a PendingRequest instance and should return it
+     * after applying any desired configuration
+     *
+     * @param  Closure(\Illuminate\Http\Client\PendingRequest): \Illuminate\Http\Client\PendingRequest  $callback
+     * @return $this
+     */
+    public function defaults(Closure $callback)
+    {
+        $this->defaultsCallback = $callback;
+
+        return $this;
     }
 
     /**
@@ -69,7 +93,13 @@ class Pool
      */
     protected function asyncRequest()
     {
-        return $this->factory->setHandler($this->handler)->async();
+        $request = $this->factory->createPendingRequest();
+
+        if ($this->defaultsCallback) {
+            $request = ($this->defaultsCallback)($request);
+        }
+
+        return $request->setHandler($this->handler)->async();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -5144,6 +5144,180 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(ConnectionException::class, $responses[0]);
         $this->assertSame($networkException, $responses[0]->getPrevious());
     }
+    
+    public function testPoolDefaultsAreAppliedToAllRequests()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->withHeader('X-Pool-Default', 'true')
+            );
+
+            return [
+                $pool->as('first')->get('http://foo.com/first'),
+                $pool->as('second')->get('http://foo.com/second'),
+            ];
+        });
+
+        $this->assertTrue($responses['first']->ok());
+        $this->assertTrue($responses['second']->ok());
+
+        $this->factory->assertSentCount(2);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->header('X-Pool-Default') === ['true'];
+        });
+    }
+
+    public function testPoolDefaultsBaseUrlAppliesToAllRequests()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->baseUrl('http://foo.com/api/v1')
+            );
+
+            return [
+                $pool->as('users')->get('/users'),
+                $pool->as('posts')->get('/posts'),
+            ];
+        });
+
+        $this->assertTrue($responses['users']->ok());
+        $this->assertTrue($responses['posts']->ok());
+
+        $this->factory->assertSent(
+            fn (Request $request) => $request->url() === 'http://foo.com/api/v1/users'
+        );
+
+        $this->factory->assertSent(
+            fn (Request $request) => $request->url() === 'http://foo.com/api/v1/posts'
+        );
+    }
+
+    public function testPoolDefaultsWithHeadersAndTokenAppliesToAllRequests()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->withToken('test-token')
+                ->withHeader('X-Api-Version', '2024-01-01')
+            );
+
+            return [
+                $pool->as('first')->get('http://foo.com/first'),
+                $pool->as('second')->get('http://foo.com/second'),
+            ];
+        });
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->header('Authorization') === ['Bearer test-token']
+                && $request->header('X-Api-Version') === ['2024-01-01'];
+        });
+
+        $this->factory->assertSentCount(2);
+    }
+
+    public function testPoolDefaultsWithRetryAppliesToAllRequests()
+    {
+        $this->factory->fake([
+            'http://foo.com/first' => $this->factory->sequence()
+                ->push('Server Error', 500)
+                ->push('ok', 200),
+
+            'http://foo.com/second' => $this->factory->sequence()
+                ->push('Server Error', 500)
+                ->push('ok', 200),
+        ]);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->retry(3, 0)
+            );
+
+            return [
+                $pool->as('first')->get('http://foo.com/first'),
+                $pool->as('second')->get('http://foo.com/second'),
+            ];
+        });
+
+        $this->assertTrue($responses['first']->ok());
+        $this->assertTrue($responses['second']->ok());
+
+        $this->factory->assertSentCount(4);
+    }
+
+    public function testPoolDefaultsCombinesMultipleSettings()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->baseUrl('http://foo.com/api')
+                ->withToken('my-token')
+                ->withHeader('X-Custom', 'value')
+            );
+
+            return [
+                $pool->as('first')->get('/endpoint'),
+            ];
+        });
+
+        $this->assertTrue($responses['first']->ok());
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/api/endpoint'
+                && $request->header('Authorization') === ['Bearer my-token']
+                && $request->header('X-Custom') === ['value'];
+        });
+    }
+    
+    public function testPoolDefaultsCanBeOverriddenPerRequest()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $responses = $this->factory->pool(function (Pool $pool) {
+            $pool->defaults(fn (PendingRequest $request) => $request
+                ->withToken('default-token')
+                ->withHeader('X-Source', 'pool')
+            );
+
+            return [
+                $pool->as('default')->get('http://foo.com/default'),
+                $pool->as('custom')
+                    ->withToken('custom-token')
+                    ->get('http://foo.com/custom'),
+            ];
+        });
+
+        $this->assertTrue($responses['default']->ok());
+        $this->assertTrue($responses['custom']->ok());
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/default'
+                && $request->header('Authorization') === ['Bearer default-token']
+                && $request->header('X-Source') === ['pool'];
+        });
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/custom'
+                && $request->header('Authorization') === ['Bearer custom-token']
+                && $request->header('X-Source') === ['pool'];
+        });
+    }
 
     public function testUrlsWithoutTemplateExpressionsAreNotExpanded()
     {


### PR DESCRIPTION
This PR adds support for configuring default settings for all requests created through an HTTP pool.

A new `defaults()` callback allows a `PendingRequest` to be configured before it is added to the pool.

### Example

```php
$responses = Http::pool(function (Pool $pool) {
    $pool->defaults(fn (PendingRequest $request) => $request
        ->baseUrl('https://api.example.com')
        ->withToken('token')
        ->timeout(10)
    );

    return [
        $pool->get('/users'),
        $pool->get('/posts'),
    ];
});
```

The configured defaults are applied to every request created through the pool.

### Retry example

This also allows common retry configuration to be applied to all pooled requests:

```php
$responses = Http::pool(function (Pool $pool) {
    $pool->defaults(fn (PendingRequest $request) => $request
        ->retry(3, 100)
    );

    return [
        $pool->get('/users'),
        $pool->get('/posts'),
    ];
});
```

Each request retains its own retry behavior, while the configuration is defined once at the pool level.

### Per-request overrides

Individual requests can still override the defaults when necessary:

```php
$responses = Http::pool(function (Pool $pool) {
    $pool->defaults(fn (PendingRequest $request) => $request
        ->timeout(10)
        ->withToken('default-token')
    );

    return [
        $pool->get('/users'),

        $pool->withToken('special-token')
            ->timeout(30)
            ->get('/special'),
    ];
});
```

### Why `defaults()` instead of a pool-level `retry()`

Rather than introducing separate pool-level methods for every `PendingRequest` option, `defaults()` provides a general mechanism for configuring pooled requests.

This keeps the API small while allowing existing `PendingRequest` functionality such as:

* `retry()`
* `timeout()`
* `connectTimeout()`
* `withToken()`
* `withHeaders()`
* `baseUrl()`
* authentication
* other request configuration

to be reused without duplicating APIs on `Pool`.

### Caution with retries

Retrying pooled requests should be used carefully, particularly for non-idempotent operations such as `POST`, `PUT`, or `PATCH`.

A retry can result in the remote server receiving the same operation more than once if the original request succeeded but the response was lost or an intermediate failure occurred.

For operations where duplicate execution is possible, applications should consider idempotency keys or appropriate server-side safeguards.

### Testing

Tests cover:

* defaults being applied to all pooled requests
* common request configuration
* combining multiple default settings
* retry configuration applied to pooled requests
* per-request configuration overriding pool defaults
* fluent `defaults()` behavior

This keeps the change focused on providing a general mechanism for configuring pooled requests without introducing separate pool-level APIs for individual request options.
