### PR TITLE
Strengthen mocked tests with the real thing

### DIFF
--- a/tests/Console/ConfiguresPromptsTest.php
+++ b/tests/Console/ConfiguresPromptsTest.php
@@ -2,16 +2,13 @@
 
 namespace Illuminate\Tests\Console;
 
-use Illuminate\Console\Application;
 use Illuminate\Console\Command;
-use Illuminate\Console\OutputStyle;
-use Illuminate\Console\View\Components\Factory;
+use Illuminate\Foundation\Application;
 use Laravel\Prompts\Prompt;
-use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
@@ -19,48 +16,52 @@ use function Laravel\Prompts\select;
 class ConfiguresPromptsTest extends TestCase
 {
     #[DataProvider('selectDataProvider')]
-    public function testSelectFallback($prompt, $expectedOptions, $expectedDefault, $return, $expectedReturn)
+    public function testSelectFallback($prompt, $answer, $expectedReturn)
     {
-        Prompt::fallbackWhen(true);
-
-        $command = new class($prompt) extends Command
-        {
-            public $answer;
-
-            public function __construct(protected $prompt)
-            {
-                parent::__construct();
-            }
-
-            public function handle()
-            {
-                $this->answer = ($this->prompt)();
-            }
-        };
-
-        $this->runCommand($command, fn ($components) => $components
-            ->expects('choice')
-            ->with('Test', $expectedOptions, $expectedDefault)
-            ->andReturn($return)
-        );
-
-        $this->assertSame($expectedReturn, $command->answer);
+        $this->assertSame($expectedReturn, $this->answer($prompt, $answer));
     }
 
     public static function selectDataProvider()
     {
         return [
-            'list with no default' => [fn () => select('Test', ['a', 'b', 'c']), ['a', 'b', 'c'], null, 'b', 'b'],
-            'numeric keys with no default' => [fn () => select('Test', [1 => 'a', 2 => 'b', 3 => 'c']), [1 => 'a', 2 => 'b', 3 => 'c'], null, '2', 2],
-            'assoc with no default' => [fn () => select('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C']), ['a' => 'A', 'b' => 'B', 'c' => 'C'], null, 'b', 'b'],
-            'list with default' => [fn () => select('Test', ['a', 'b', 'c'], 'b'), ['a', 'b', 'c'], 'b', 'b', 'b'],
-            'numeric keys with default' => [fn () => select('Test', [1 => 'a', 2 => 'b', 3 => 'c'], 2), [1 => 'a', 2 => 'b', 3 => 'c'], 2, '2', 2],
-            'assoc with default' => [fn () => select('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], 'b'), ['a' => 'A', 'b' => 'B', 'c' => 'C'], 'b', 'b', 'b'],
+            'list with no default' => [fn () => select('Test', ['a', 'b', 'c']), 'b', 'b'],
+            'numeric keys with no default' => [fn () => select('Test', [1 => 'a', 2 => 'b', 3 => 'c']), '2', 2],
+            'assoc with no default' => [fn () => select('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C']), 'b', 'b'],
+            'list with default' => [fn () => select('Test', ['a', 'b', 'c'], 'b'), 'b', 'b'],
+            'numeric keys with default' => [fn () => select('Test', [1 => 'a', 2 => 'b', 3 => 'c'], 2), '2', 2],
+            'assoc with default' => [fn () => select('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], 'b'), 'b', 'b'],
         ];
     }
 
     #[DataProvider('multiselectDataProvider')]
-    public function testMultiselectFallback($prompt, $expectedOptions, $expectedDefault, $return, $expectedReturn)
+    public function testMultiselectFallback($prompt, $answer, $expectedReturn)
+    {
+        $this->assertSame($expectedReturn, $this->answer($prompt, $answer));
+    }
+
+    public static function multiselectDataProvider()
+    {
+        return [
+            'list with no default' => [fn () => multiselect('Test', ['a', 'b', 'c']), '', []],
+            'numeric keys with no default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c']), '', []],
+            'assoc with no default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C']), '', []],
+            'list with default' => [fn () => multiselect('Test', ['a', 'b', 'c'], ['b', 'c']), 'b,c', ['b', 'c']],
+            'numeric keys with default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3]), '2,3', [2, 3]],
+            'assoc with default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c']), 'b,c', ['b', 'c']],
+            'required list with no default' => [fn () => multiselect('Test', ['a', 'b', 'c'], required: true), 'b,c', ['b', 'c']],
+            'required numeric keys with no default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], required: true), '2,3', [2, 3]],
+            'required assoc with no default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], required: true), 'b,c', ['b', 'c']],
+            'required list with default' => [fn () => multiselect('Test', ['a', 'b', 'c'], ['b', 'c'], required: true), 'b,c', ['b', 'c']],
+            'required numeric keys with default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3], required: true), '2,3', [2, 3]],
+            'required assoc with default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c'], required: true), 'b,c', ['b', 'c']],
+        ];
+    }
+
+    /**
+     * Run the given prompt behind a real command, feeding it the given typed answer
+     * through a real input stream, and return what the prompt resolved to.
+     */
+    protected function answer($prompt, $answer)
     {
         Prompt::fallbackWhen(true);
 
@@ -79,48 +80,18 @@ class ConfiguresPromptsTest extends TestCase
             }
         };
 
-        $this->runCommand($command, fn ($components) => $components
-            ->expects('choice')
-            ->with('Test', $expectedOptions, $expectedDefault, null, true)
-            ->andReturn($return)
-        );
+        $app = new Application(__DIR__);
+        $command->setLaravel($app);
 
-        $this->assertSame($expectedReturn, $command->answer);
-    }
+        $input = new ArrayInput([]);
 
-    public static function multiselectDataProvider()
-    {
-        return [
-            'list with no default' => [fn () => multiselect('Test', ['a', 'b', 'c']), ['None', 'a', 'b', 'c'], 'None', ['None'], []],
-            'numeric keys with no default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c']), ['' => 'None', 1 => 'a', 2 => 'b', 3 => 'c'], 'None', [''], []],
-            'assoc with no default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C']), ['' => 'None', 'a' => 'A', 'b' => 'B', 'c' => 'C'], 'None', [''], []],
-            'list with default' => [fn () => multiselect('Test', ['a', 'b', 'c'], ['b', 'c']), ['None', 'a', 'b', 'c'], 'b,c', ['b', 'c'], ['b', 'c']],
-            'numeric keys with default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3]), ['' => 'None', 1 => 'a', 2 => 'b', 3 => 'c'], '2,3', ['2', '3'], [2, 3]],
-            'assoc with default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c']), ['' => 'None', 'a' => 'A', 'b' => 'B', 'c' => 'C'], 'b,c', ['b', 'c'], ['b', 'c']],
-            'required list with no default' => [fn () => multiselect('Test', ['a', 'b', 'c'], required: true), ['a', 'b', 'c'], null, ['b', 'c'], ['b', 'c']],
-            'required numeric keys with no default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], required: true), [1 => 'a', 2 => 'b', 3 => 'c'], null, ['2', '3'], [2, 3]],
-            'required assoc with no default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], required: true), ['a' => 'A', 'b' => 'B', 'c' => 'C'], null, ['b', 'c'], ['b', 'c']],
-            'required list with default' => [fn () => multiselect('Test', ['a', 'b', 'c'], ['b', 'c'], required: true), ['a', 'b', 'c'], 'b,c', ['b', 'c'], ['b', 'c']],
-            'required numeric keys with default' => [fn () => multiselect('Test', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3], required: true), [1 => 'a', 2 => 'b', 3 => 'c'], '2,3', ['2', '3'], [2, 3]],
-            'required assoc with default' => [fn () => multiselect('Test', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c'], required: true), ['a' => 'A', 'b' => 'B', 'c' => 'C'], 'b,c', ['b', 'c'], ['b', 'c']],
-        ];
-    }
+        $stream = fopen('php://memory', 'w+');
+        fwrite($stream, $answer."\n");
+        rewind($stream);
+        $input->setStream($stream);
 
-    protected function runCommand($command, $expectations)
-    {
-        $application = Mockery::mock(Application::class);
-        $command->setLaravel($application);
+        $command->run($input, new BufferedOutput);
 
-        $outputStyle = Mockery::mock(OutputStyle::class);
-        $application->expects('make')->withArgs(fn ($abstract) => $abstract === OutputStyle::class)->andReturn($outputStyle);
-        $factory = Mockery::mock(Factory::class);
-        $application->expects('make')->withArgs(fn ($abstract) => $abstract === Factory::class)->andReturn($factory);
-        $application->shouldReceive('runningUnitTests')->andReturn(false);
-        $application->expects('call')->with([$command, 'handle'])->andReturnUsing(fn ($callback) => call_user_func($callback));
-        $outputStyle->expects('newLinesWritten')->andReturn(1);
-
-        $expectations($factory);
-
-        $command->run(new ArrayInput([]), new NullOutput);
+        return $command->answer;
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -3,14 +3,16 @@
 namespace Illuminate\Tests\Mail;
 
 use Aws\Command;
+use Aws\Credentials\Credentials;
 use Aws\Exception\AwsException;
+use Aws\MockHandler;
+use Aws\Result;
 use Aws\Ses\SesClient;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\View\Factory;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
@@ -57,22 +59,25 @@ class MailSesTransportTest extends TestCase
         $message->getHeaders()->add(new MetadataHeader('FooTag', 'TagValue'));
         $message->getHeaders()->addTextHeader('X-Ses-List-Management-Options', 'contactListName=TestList;topicName=TestTopic');
 
-        $client = Mockery::mock(SesClient::class);
-        $sesResult = Mockery::mock();
-        $sesResult->expects('get')
-            ->with('MessageId')
-            ->andReturn('ses-message-id');
-        $client->expects('sendRawEmail')
-            ->with(Mockery::on(function ($arg) {
-                return $arg['Source'] === 'myself@example.com' &&
-                    $arg['Destinations'] === ['me@example.com', 'you@example.com'] &&
-                    $arg['ListManagementOptions'] === ['ContactListName' => 'TestList', 'TopicName' => 'TestTopic'] &&
-                    $arg['Tags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
-                    str_contains($arg['RawMessage']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>');
-            }))
-            ->andReturn($sesResult);
+        $mock = new MockHandler;
+        $mock->append(new Result(['MessageId' => 'ses-message-id']));
+
+        $client = new SesClient([
+            'credentials' => new Credentials('foo', 'bar'),
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'handler' => $mock,
+        ]);
 
         (new SesTransport($client))->send($message);
+
+        $arg = $mock->getLastCommand()->toArray();
+
+        $this->assertSame('myself@example.com', $arg['Source']);
+        $this->assertSame(['me@example.com', 'you@example.com'], $arg['Destinations']);
+        $this->assertSame(['ContactListName' => 'TestList', 'TopicName' => 'TestTopic'], $arg['ListManagementOptions']);
+        $this->assertSame([['Name' => 'FooTag', 'Value' => 'TagValue']], $arg['Tags']);
+        $this->assertStringContainsString('Reply-To: Taylor Otwell <taylor@example.com>', $arg['RawMessage']['Data']);
     }
 
     public function testSendError(): void
@@ -83,9 +88,15 @@ class MailSesTransportTest extends TestCase
         $message->sender('myself@example.com');
         $message->to('me@example.com');
 
-        $client = Mockery::mock(SesClient::class);
-        $client->expects('sendRawEmail')
-            ->andThrow(new AwsException('Email address is not verified.', new Command('sendRawEmail')));
+        $mock = new MockHandler;
+        $mock->append(new AwsException('Email address is not verified.', new Command('sendRawEmail')));
+
+        $client = new SesClient([
+            'credentials' => new Credentials('foo', 'bar'),
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'handler' => $mock,
+        ]);
 
         $this->expectException(TransportException::class);
 


### PR DESCRIPTION
While trying another pass to migrate the test suite from Mockery to [Double](https://github.com/jasonmccreary/double), I found a couple of tests mocking in a "weak" way. This PR drops Mockery to strengthen those tests by using the "real thing".

`MailSesTransportTest` mocked `SesClient` directly, so it never actually ran. It now builds a real `SesClient` wired to AWS's own `Aws\MockHandler`. This way the SDK's real command building and validation execute, and assertions read the real outgoing command instead of a mocked guess.

`ConfiguresPromptsTest` mocked the whole `Application`/`OutputStyle`/`Factory` chain to intercept a `choice()`. It now runs a real command through a real container, feeding a real input stream the way a user would type.