### PR TITLE
[13.x] Fix LazyCollection::take() with a negative limit larger than the collection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1574,8 +1574,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $position = ($position + 1) % $limit;
                 }
 
-                for ($i = 0, $end = min($limit, count($ringBuffer)); $i < $end; $i++) {
-                    $pointer = ($position + $i) % $limit;
+                $count = count($ringBuffer);
+
+                for ($i = 0, $end = min($limit, $count); $i < $end; $i++) {
+                    $pointer = $count < $limit ? $i : ($position + $i) % $limit;
                     yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
                 }
             });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2871,6 +2871,14 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testTakeLastWithLimitGreaterThanCollectionSize($collection)
+    {
+        $data = new $collection(['taylor', 'dayle', 'shawn']);
+        $data = $data->take(-5);
+        $this->assertEquals([0 => 'taylor', 1 => 'dayle', 2 => 'shawn'], $data->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testTakeUntilUsingValue($collection)
     {
         $data = new $collection([1, 2, 3, 4]);


### PR DESCRIPTION
### Problem

## Issue : https://github.com/laravel/framework/issues/61514
`Collection` and `LazyCollection` both implement `Enumerable`, so `take()`
is expected to behave identically on either. It does, except for one gap:
a negative limit whose absolute value is larger than the number of items
in the collection.

```php
use Illuminate\Support\Collection;
use Illuminate\Support\LazyCollection;

(new Collection(['a', 'b', 'c']))->take(-5)->all();
// ['a', 'b', 'c']

(new LazyCollection(['a', 'b', 'c']))->take(-5)->all();
// ['' => null, 0 => 'a']
```

The `LazyCollection` call also raises:

```
Warning: Undefined array key 3 in .../LazyCollection.php on line 1577
Warning: Trying to access array offset on null in .../LazyCollection.php on line 1577
```

Every combination where `abs($limit) <= count()` already agreed between
the two classes, which is why this went unnoticed: the existing
`testTakeLast` case (`take(-2)` on three items) never exercises a limit
larger than the collection.

Observed results across sizes, `Collection` (correct) vs. `LazyCollection` (buggy):

| items | limit | `Collection` | `LazyCollection` (before fix) |
| --- | --- | --- | --- |
| 1 | -2 | `['a']` | `['' => null]` |
| 3 | -5 | `['a', 'b', 'c']` | `['' => null, 0 => 'a']` |
| 4 | -5 | `['a', 'b', 'c', 'd']` | `['' => null, 0 => 'a', 1 => 'b', 2 => 'c']` |
| 5 | -7 | `['a', 'b', 'c', 'd', 'e']` | `['' => null, 0 => 'a', 1 => 'b', 2 => 'c']` |

### Root cause

`LazyCollection::take()` handles negative limits with a fixed-size ring
buffer, so it never has to materialize the whole (possibly infinite) source
just to keep the last N items:

```php
$ringBuffer = [];
$position = 0;

foreach ($this as $key => $value) {
    $ringBuffer[$position] = [$key, $value];
    $position = ($position + 1) % $limit;
}

for ($i = 0, $end = min($limit, count($ringBuffer)); $i < $end; $i++) {
    $pointer = ($position + $i) % $limit;
    yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
}
```

After the write loop, `$position` is the *next slot to write to*. That is
only the same thing as "the oldest item in the buffer" once the buffer has
wrapped around at least once — i.e. once `count() >= abs($limit)`. While
the buffer is still partially filled, the oldest item is at index `0`, but
`$position` has advanced to equal the number of items written, pointing
just past the last real slot.

With 3 items and `$limit = 5`: after the loop `$position = 3`, and the read
loop computes pointers `3, 4, 0` — two of which were never written. Reading
an unwritten `null` slot's `[0]`/`[1]` offsets triggers the two warnings per
missing slot, and yielding a `null` key collapses onto `''`, which is why
real items (`'b'`, `'c'`) silently disappear from the result instead of the
call simply erroring.

### Fix

Track how many slots were actually written (`$count`). When `$count <
$limit`, the buffer never wrapped, so the items are already in order
starting at index `0` — read from `$i` directly instead of offsetting by
`$position`. When `$count === $limit` (the buffer has wrapped), behavior is
byte-for-byte the same as before.

```php
$count = count($ringBuffer);

for ($i = 0, $end = min($limit, $count); $i < $end; $i++) {
    $pointer = $count < $limit ? $i : ($position + $i) % $limit;
    yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
}
```

The write loop is untouched, so memory characteristics don't change — the
buffer still holds at most `abs($limit)` items regardless of source size.

### Why this doesn't break existing behavior

- The wrapped case (`count() >= abs($limit)`) takes the exact same branch
  and computes the exact same pointer as before — this is what the
  existing `testTakeLast` (`take(-2)` on 3 items) already covers, and it
  still passes unchanged.
- `take(0)` and positive limits never enter this branch at all.
- No other method in the framework shares this ring-buffer pattern, and no
  internal call site (`grep -rn "->take(" src/`) passes a negative limit
  that could hit the buggy path, so nothing else in the framework depends
  on the previous (incorrect) output.

### Testing

- Added `testTakeLastWithLimitGreaterThanCollectionSize` next to the
  existing `testTakeLast` in `tests/Support/SupportCollectionTest.php`, on
  the same `collectionClassProvider` so it runs against both `Collection`
  and `LazyCollection`.
- Full `tests/Support/` suite: 2225 tests, 0 failures (identical warning/skip
  counts before and after — verified by diffing a run on unmodified `13.x`
  against a run with this change).
- Verified manually against a generator-backed `LazyCollection` (a true
  lazy source, not backed by an array) with string keys, confirming keys
  and values are preserved and the collection can be iterated more than
  once without leaking state between reads.
- `vendor/bin/pint --test` clean on the modified source file.
- `vendor/bin/phpstan analyse` (level 1, the config this repo uses) reports
  no errors on the modified file.
  
 Before : 
  <img width="1450" height="873" alt="Screenshot 2026-09-11 at 9 13 52 PM" src="https://github.com/user-attachments/assets/4881ad79-e69f-48e7-82f5-5da6b7944140" />

After : 
<img width="1477" height="489" alt="Screenshot 2026-09-11 at 9 12 33 PM" src="https://github.com/user-attachments/assets/fe58c196-84af-496a-b846-517cab61414b" />
