### PR TITLE
[13.x] Fix findOr not calling the callback when an array of ids contains missing models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -688,7 +688,7 @@ class Builder implements BuilderContract
      * @param  (\Closure(): TValue)|null  $callback
      * @return (
      *     $id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>)
-     *     ? \Illuminate\Database\Eloquent\Collection<int, TModel>
+     *     ? \Illuminate\Database\Eloquent\Collection<int, TModel>|TValue
      *     : TModel|TValue
      * )
      */
@@ -700,8 +700,16 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->find($id, $columns))) {
-            return $model;
+        $result = $this->find($id, $columns);
+
+        $id = $id instanceof Arrayable ? $id->toArray() : $id;
+
+        if (is_array($id)) {
+            if (count($result) === count(array_unique($id))) {
+                return $result;
+            }
+        } elseif (! is_null($result)) {
+            return $result;
         }
 
         return $callback();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -208,12 +208,13 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model2 = $this->getMockModel();
         $model1->expects('getKeyType')->times(3)->andReturn('int');
         $model2->shouldReceive('getKeyType')->andReturn('int');
+        $model1->expects('newCollection')->andReturn(new Collection);
         $builder->setModel($model1);
         $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->times(2);
         $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
-        $builder->expects('get')->andReturn(null);
+        $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
 
         $result = $builder->findOr([1, 2], fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
@@ -227,6 +228,10 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->findOr([1, 2, 3], fn () => 'callback result');
         $this->assertSame('callback result', $result);
+
+        $result = $builder->findOr([], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertCount(0, $result);
     }
 
     public function testFindOrMethodWithManyUsingCollection()
@@ -241,7 +246,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->expects('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3]);
         $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
         $builder->expects('get')->with(['column'])->andReturn(new Collection([$model1, $model2]));
-        $builder->expects('get')->andReturn(null);
+        $builder->expects('get')->andReturn(new Collection([$model1, $model2]));
 
         $result = $builder->findOr(new Collection([1, 2]), fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -44,7 +44,7 @@ function test(
     assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOrFail([1]));
     assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOrNew([1]));
     assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->find([1]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOr([1], callback: fn () => 42));
+    assertType('42|Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOr([1], callback: fn () => 42));
     assertType('Illuminate\Types\Builder\User', $query->findOrFail(1));
     assertType('Illuminate\Types\Builder\User|null', $query->find(1));
     assertType('42|Illuminate\Types\Builder\User', $query->findOr(1, fn () => 42));


### PR DESCRIPTION
## Description

`Eloquent\Builder::findOr` never invokes the callback when given an array (or `Arrayable`) of ids, even if none of the models exist:

```php
User::findOrFail([1, 99]); // throws ModelNotFoundException for id 99
User::findOr([1, 99], fn () => 'fallback'); // returns a partial Collection — callback never called
```

This is inconsistent with `findOrFail` on the same class and with `BelongsToMany::findOr` / `HasOneOrManyThrough::findOr`, which call the callback when `count($result) !== count(array_unique($id))`. All three were introduced by the same commit (PR #42092); the builder version relies on `is_null(find(...))`, which can never be `true` for arrays since `find()` delegates to `findMany()` and always returns a `Collection`. The existing unit tests masked this by mocking `get()` to return `null`.

## Fix

`findOr` now mirrors the array-aware logic used by the relations: when any id in the array is missing, the callback is invoked. Scalar ids behave exactly as before, and the `@return` docblock now includes `TValue` in the array case, matching the relations.

Note: `Query\Builder::findOr` is left unchanged, as its `find()` has never supported arrays.

## Breaking change

Behavior change: code that relied on getting a partial collection back will now get the callback's return value instead:

```php
User::findOr([1, 99], fn () => 'fallback');
// before: Collection with only the model for id 1 (callback ignored)
// after: 'fallback'
```

We consider the old behavior a bug, consistent with `findOrFail` and the relations.

## Tests

`testFindOrMethodWithMany` and `testFindOrMethodWithManyUsingCollection` rewritten with realistic mocks, now asserting the callback is invoked when an id is missing added coverage for an empty ids array (empty collection, callback not invoked).