### PR TITLE
[13.x] Fix appendToPriorityList() when the referenced middleware is the first item

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -485,23 +485,21 @@ class Kernel implements KernelContract
     protected function addToMiddlewarePriorityRelative($existing, $middleware, $after = true)
     {
         if (! in_array($middleware, $this->middlewarePriority)) {
-            $index = $after ? 0 : count($this->middlewarePriority);
+            $index = null;
 
             foreach ((array) $existing as $existingMiddleware) {
                 if (in_array($existingMiddleware, $this->middlewarePriority)) {
                     $middlewareIndex = array_search($existingMiddleware, $this->middlewarePriority);
 
-                    if ($after && $middlewareIndex > $index) {
+                    if ($after && (is_null($index) || $middlewareIndex >= $index)) {
                         $index = $middlewareIndex + 1;
-                    } elseif ($after === false && $middlewareIndex < $index) {
+                    } elseif ($after === false && (is_null($index) || $middlewareIndex < $index)) {
                         $index = $middlewareIndex;
                     }
                 }
             }
 
-            if ($index === 0 && $after === false) {
-                array_unshift($this->middlewarePriority, $middleware);
-            } elseif (($after && $index === 0) || $index === count($this->middlewarePriority)) {
+            if (is_null($index) || $index === count($this->middlewarePriority)) {
                 $this->middlewarePriority[] = $middleware;
             } else {
                 array_splice($this->middlewarePriority, $index, 0, $middleware);

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -74,6 +74,59 @@ class KernelTest extends TestCase
         ], $kernel->getMiddlewarePriority());
     }
 
+    public function testAddToMiddlewarePriorityAfterFirstMiddleware()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $kernel->addToMiddlewarePriorityAfter(
+            \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+            \Illuminate\Routing\Middleware\ValidateSignature::class,
+        );
+
+        $this->assertEquals([
+            \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+            \Illuminate\Routing\Middleware\ValidateSignature::class,
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
+            \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Illuminate\Auth\Middleware\Authorize::class,
+        ], $kernel->getMiddlewarePriority());
+    }
+
+    public function testAddToMiddlewarePriorityAfterAdjacentMiddleware()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $kernel->addToMiddlewarePriorityAfter(
+            [
+                \Illuminate\Cookie\Middleware\EncryptCookies::class,
+                \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            ],
+            \Illuminate\Routing\Middleware\ValidateSignature::class,
+        );
+
+        $this->assertEquals([
+            \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Routing\Middleware\ValidateSignature::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
+            \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Illuminate\Auth\Middleware\Authorize::class,
+        ], $kernel->getMiddlewarePriority());
+    }
+
     public function testAddToMiddlewarePriorityBefore()
     {
         $kernel = new Kernel($this->getApplication(), $this->getRouter());


### PR DESCRIPTION
Related: #61536

`appendToPriorityList()` doesn't work when the reference middleware is the first item of the priority list. The new middleware ends up at the end instead of second, so it runs after session, auth, throttling etc. and nothing warns you.

```php
$middleware->appendToPriorityList(
    HandlePrecognitiveRequests::class,
    EnsureTenantIsSet::class,
);
```

Same root cause hits the array form when the references are adjacent: on `[A, B, C, D]`, `addToMiddlewarePriorityAfter(['B', 'C'], 'X')` gives `[A, B, X, C, D]`, but `['C', 'B']` gives `[A, B, C, X, D]`.

The insertion index in `addToMiddlewarePriorityRelative()` starts at 0, and 0 is also a real position, so a match at index 0 never moves it and the code below assumes nothing matched. The `>` also skips a match sitting exactly at the current insertion point.

Now the index starts as `null` and is only set once something matches. No match still appends, `addToMiddlewarePriorityBefore()` is untouched. Added two tests to `KernelTest` (after first item, after adjacent items), both fail on 13.x today.