### PR TITLE
[13.x] Add `isManagedQueue` to CloudManager

### DIFF
--- a/src/Illuminate/Foundation/Cloud/CloudManager.php
+++ b/src/Illuminate/Foundation/Cloud/CloudManager.php
@@ -46,4 +46,12 @@ class CloudManager
 
         return $this->container->make('queue')->connection('cloud');
     }
+
+    /**
+     * Determine if the given queue is managed by Laravel Cloud.
+     */
+    public function isQueueManaged(string $queue): bool
+    {
+        return $this->usesManagedQueues() && in_array($queue, $this->queue()->managedQueues(), true);
+    }
 }

--- a/src/Illuminate/Foundation/Cloud/CloudManager.php
+++ b/src/Illuminate/Foundation/Cloud/CloudManager.php
@@ -50,7 +50,7 @@ class CloudManager
     /**
      * Determine if the given queue is managed by Laravel Cloud.
      */
-    public function isQueueManaged(string $queue): bool
+    public function isManagedQueue(string $queue): bool
     {
         return $this->usesManagedQueues() && in_array($queue, $this->queue()->managedQueues(), true);
     }

--- a/tests/Foundation/Cloud/CloudManagerTest.php
+++ b/tests/Foundation/Cloud/CloudManagerTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Foundation\Cloud;
 
 use Illuminate\Foundation\Cloud\CloudManager;
+use Illuminate\Foundation\Cloud\Queue as CloudQueue;
 use Illuminate\Support\Facades\Cloud;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
@@ -27,6 +29,19 @@ class CloudManagerTest extends TestCase
         ));
 
         Cloud::queue();
+    }
+
+    #[TestWith(['emails', true])]
+    #[TestWith(['exports', false])]
+    public function testIsQueueManagedChecksTheConfiguredManagedQueues(string $queue, bool $managed)
+    {
+        $cloud = Cloud::partialMock();
+        $cloud->shouldReceive('usesManagedQueues')->andReturn(true);
+        $cloud->shouldReceive('queue')->andReturn(
+            Mockery::mock(CloudQueue::class)->shouldReceive('managedQueues')->andReturn(['emails'])->getMock()
+        );
+
+        $this->assertSame($managed, Cloud::isQueueManaged($queue));
     }
 
     public function testFacadeResolvesTheCloudManager()

--- a/tests/Foundation/Cloud/CloudManagerTest.php
+++ b/tests/Foundation/Cloud/CloudManagerTest.php
@@ -33,7 +33,7 @@ class CloudManagerTest extends TestCase
 
     #[TestWith(['emails', true])]
     #[TestWith(['exports', false])]
-    public function testIsQueueManagedChecksTheConfiguredManagedQueues(string $queue, bool $managed)
+    public function testIsManagedQueueChecksTheConfiguredManagedQueues(string $queue, bool $managed)
     {
         $cloud = Cloud::partialMock();
         $cloud->shouldReceive('usesManagedQueues')->andReturn(true);
@@ -41,7 +41,7 @@ class CloudManagerTest extends TestCase
             Mockery::mock(CloudQueue::class)->shouldReceive('managedQueues')->andReturn(['emails'])->getMock()
         );
 
-        $this->assertSame($managed, Cloud::isQueueManaged($queue));
+        $this->assertSame($managed, Cloud::isManagedQueue($queue));
     }
 
     public function testFacadeResolvesTheCloudManager()

--- a/tests/Foundation/Cloud/CloudManagerTest.php
+++ b/tests/Foundation/Cloud/CloudManagerTest.php
@@ -35,11 +35,12 @@ class CloudManagerTest extends TestCase
     #[TestWith(['exports', false])]
     public function testIsManagedQueueChecksTheConfiguredManagedQueues(string $queue, bool $managed)
     {
+        $cloudQueue = Mockery::mock(CloudQueue::class);
+        $cloudQueue->shouldReceive('managedQueues')->andReturn(['emails']);
+
         $cloud = Cloud::partialMock();
         $cloud->shouldReceive('usesManagedQueues')->andReturn(true);
-        $cloud->shouldReceive('queue')->andReturn(
-            Mockery::mock(CloudQueue::class)->shouldReceive('managedQueues')->andReturn(['emails'])->getMock()
-        );
+        $cloud->shouldReceive('queue')->andReturn($cloudQueue);
 
         $this->assertSame($managed, Cloud::isManagedQueue($queue));
     }


### PR DESCRIPTION
I've macro'd this, but I think it's worth adding on the manager as it's easier than going through the queue connection (as in most people won't realise this is there)

This gives anyone an easy answer of "Is this queue managed", which is very useful if you're multiple drivers- useful locally, and useful if you're using fifo in cloud. 


This means we can do stuff like this:
```php
if (Cloud::isManagedQueue('notifications.fifo')) {
    Queue::forward('notifications', 'notifications.fifo', 'cloud');
}
``` 

Feels cool to me, and imagine I won't be the only person to reach for this, but, feel free to adjust to throw away- just something I macro'd 🫡 