### PR TITLE
[13.x] Fix query string question mark encoding

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -378,7 +378,7 @@ class RouteUrlGenerator
     protected function encodeParameter($value)
     {
         return is_string($value) || $value instanceof Stringable
-            ? strtr((string) $value, ['%' => '%25', '?' => '%3F', '#' => '%23'])
+            ? str_replace('%', '%25', (string) $value)
             : $value;
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -776,6 +776,28 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->route('not_exists_route');
     }
 
+    public function testQuestionMarkInRouteParameterIsNotDoubleEncoded()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $routes->add(new Route(['GET'], 'page/{id}', ['as' => 'page', function () {
+            //
+        }]));
+
+        $this->assertSame(
+            'http://www.foo.com/page/99?q=foo&pageSize=all',
+            $url->route('page', ['id' => 99, 'q' => 'foo', 'pageSize' => 'all'])
+        );
+
+        $this->assertSame(
+            'http://www.foo.com/page/99?q=*0*&pageSize=all',
+            $url->route('page', ['id' => '99?q=*0*&pageSize=all'])
+        );
+    }
+
     public function testRouteParametersContainingPercentSignsAreEncoded()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes #61499.

`encodeParameter()` (added in #61475) pre-encoded `?` and `#` in route parameters. Those characters are already restored by `$dontEncode` after `rawurlencode()`, so pre-encoding `?` double-encoded it and left `%3F` in the URL (`/page/99%3Fq=...` instead of `/page/99?q=...`).

Only `%` needs to be pre-encoded, so the router does not treat `%66` as `f`. `?` and `#` are left to `$dontEncode`, which was the behavior before 12.69.2.

Existing percent-sign tests still pass. Added a regression test for the query-string delimiter.